### PR TITLE
Lambda consistency in map_impl

### DIFF
--- a/include/ygm/container/counting_set.hpp
+++ b/include/ygm/container/counting_set.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <ygm/comm.hpp>
-#include <ygm/detail/ygm_ptr.hpp>
 #include <ygm/container/map.hpp>
+#include <ygm/detail/ygm_ptr.hpp>
 
 namespace ygm::container {
 
@@ -15,22 +15,21 @@ template <typename Key, typename Partitioner = detail::hash_partitioner<Key>,
           typename Compare = std::less<Key>,
           class Alloc = std::allocator<std::pair<const Key, size_t>>>
 class counting_set {
- public:
+public:
   using self_type = counting_set<Key, Partitioner, Compare, Alloc>;
   using key_type = Key;
   using value_type = size_t;
   const size_t count_cache_size = 1024 * 1024;
 
-  counting_set(ygm::comm& comm) : m_map(comm, value_type(0)), pthis(this) {
+  counting_set(ygm::comm &comm) : m_map(comm, value_type(0)), pthis(this) {
     m_count_cache.resize(count_cache_size, {key_type(), -1});
   }
 
-  void async_insert(const key_type& key) { cache_insert(key); }
+  void async_insert(const key_type &key) { cache_insert(key); }
 
   // void async_erase(const key_type& key) { cache_erase(key); }
 
-  template <typename Function>
-  void for_all(Function fn) {
+  template <typename Function> void for_all(Function fn) {
     count_cache_flush_all();
     m_map.for_all(fn);
   }
@@ -45,46 +44,48 @@ class counting_set {
     return m_map.size();
   }
 
-  size_t count(const key_type& key) {
+  size_t count(const key_type &key) {
     count_cache_flush_all();
     m_map.comm().barrier();
     auto vals = m_map.local_get(key);
     size_t local_count{0};
-    for (auto v : vals) { local_count += v; }
+    for (auto v : vals) {
+      local_count += v;
+    }
     return m_map.comm().all_reduce_sum(local_count);
   }
 
   size_t count_all() {
     count_cache_flush_all();
     size_t local_count{0};
-    for_all([&local_count](const auto& kv) { local_count += kv.second; });
+    for_all([&local_count](const auto &kv) { local_count += kv.second; });
     return m_map.comm().all_reduce_sum(local_count);
   }
 
-  bool is_mine(const key_type& key) const { return m_map.is_mine(key); }
+  bool is_mine(const key_type &key) const { return m_map.is_mine(key); }
 
   template <typename STLKeyContainer>
-  std::map<key_type, value_type> all_gather(const STLKeyContainer& keys) {
+  std::map<key_type, value_type> all_gather(const STLKeyContainer &keys) {
     count_cache_flush_all();
     return m_map.all_gather(keys);
   }
 
-  std::map<key_type, value_type> all_gather(const std::vector<key_type>& keys) {
+  std::map<key_type, value_type> all_gather(const std::vector<key_type> &keys) {
     count_cache_flush_all();
     return m_map.all_gather(keys);
   }
 
-  void serialize(const std::string& fname) {
+  void serialize(const std::string &fname) {
     count_cache_flush_all();
     m_map.serialize(fname);
   }
-  void deserialize(const std::string& fname) {
+  void deserialize(const std::string &fname) {
     count_cache_flush_all();
     m_map.deserialize(fname);
   }
 
- private:
-  void cache_erase(const key_type& key) {
+private:
+  void cache_erase(const key_type &key) {
     size_t slot = std::hash<key_type>{}(key) % count_cache_size;
     if (m_count_cache[slot].second != -1 && m_count_cache[slot].first == key) {
       // Key was cached, clear cache
@@ -93,7 +94,7 @@ class counting_set {
     }
     m_map.async_erase(key);
   }
-  void cache_insert(const key_type& key) {
+  void cache_insert(const key_type &key) {
     size_t slot = std::hash<key_type>{}(key) % count_cache_size;
     if (m_count_cache[slot].second == -1) {
       m_count_cache[slot].first = key;
@@ -119,19 +120,19 @@ class counting_set {
     auto key = m_count_cache[slot].first;
     auto cached_count = m_count_cache[slot].second;
     ASSERT_DEBUG(cached_count > 0);
-    m_map.async_visit(
-        key,
-        [](const key_type& k, size_t& count, int32_t to_add) {
-          count += to_add;
-        },
-        cached_count);
+    m_map.async_visit(key,
+                      [](std::pair<const key_type, size_t> &key_count,
+                         int32_t to_add) { key_count.second += to_add; },
+                      cached_count);
     m_count_cache[slot].first = key_type();
     m_count_cache[slot].second = -1;
   }
 
   void count_cache_flush_all() {
     for (size_t i = 0; i < m_count_cache.size(); ++i) {
-      if (m_count_cache[i].second > 0) { count_cache_flush(i); }
+      if (m_count_cache[i].second > 0) {
+        count_cache_flush(i);
+      }
     }
   }
   counting_set() = delete;
@@ -141,4 +142,4 @@ class counting_set {
   typename ygm::ygm_ptr<self_type> pthis;
 };
 
-}  // namespace ygm::container
+} // namespace ygm::container

--- a/include/ygm/container/detail/map_impl.hpp
+++ b/include/ygm/container/detail/map_impl.hpp
@@ -4,12 +4,12 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <cereal/archives/portable_binary.hpp>
+#include <fstream>
 #include <map>
 #include <ygm/comm.hpp>
-#include <ygm/detail/ygm_ptr.hpp>
 #include <ygm/container/detail/hash_partitioner.hpp>
-#include <fstream>
-#include <cereal/archives/portable_binary.hpp>
+#include <ygm/detail/ygm_ptr.hpp>
 
 namespace ygm::container::detail {
 
@@ -18,27 +18,27 @@ template <typename Key, typename Value,
           typename Compare = std::less<Key>,
           class Alloc = std::allocator<std::pair<const Key, Value>>>
 class map_impl {
- public:
+public:
   using self_type = map_impl<Key, Value, Partitioner, Compare, Alloc>;
   using value_type = Value;
   using key_type = Key;
 
   Partitioner partitioner;
 
-  map_impl(ygm::comm& comm) : m_comm(comm), pthis(this), m_default_value{} {
+  map_impl(ygm::comm &comm) : m_comm(comm), pthis(this), m_default_value{} {
     m_comm.barrier();
   }
 
-  map_impl(ygm::comm& comm, const value_type& dv)
+  map_impl(ygm::comm &comm, const value_type &dv)
       : m_comm(comm), pthis(this), m_default_value(dv) {
     m_comm.barrier();
   }
 
   ~map_impl() { m_comm.barrier(); }
 
-  void async_insert_unique(const key_type& key, const value_type& value) {
-    auto inserter = [](auto mailbox, int from, auto map, const key_type& key,
-                       const value_type& value) {
+  void async_insert_unique(const key_type &key, const value_type &value) {
+    auto inserter = [](auto mailbox, int from, auto map, const key_type &key,
+                       const value_type &value) {
       auto itr = map->m_local_map.find(key);
       if (itr != map->m_local_map.end()) {
         itr->second = value;
@@ -50,9 +50,9 @@ class map_impl {
     m_comm.async(dest, inserter, pthis, key, value);
   }
 
-  void async_insert_multi(const key_type& key, const value_type& value) {
-    auto inserter = [](auto mailbox, int from, auto map, const key_type& key,
-                       const value_type& value) {
+  void async_insert_multi(const key_type &key, const value_type &value) {
+    auto inserter = [](auto mailbox, int from, auto map, const key_type &key,
+                       const value_type &value) {
       map->m_local_map.insert(std::make_pair(key, value));
     };
     int dest = owner(key);
@@ -60,20 +60,20 @@ class map_impl {
   }
 
   template <typename Visitor, typename... VisitorArgs>
-  void async_visit(const key_type& key, Visitor visitor,
-                   const VisitorArgs&... args) {
+  void async_visit(const key_type &key, Visitor visitor,
+                   const VisitorArgs &... args) {
     int dest = owner(key);
     auto visit_wrapper = [](auto pcomm, int from, auto pmap,
-                            const key_type& key, const VisitorArgs&... args) {
+                            const key_type &key, const VisitorArgs &... args) {
       auto range = pmap->m_local_map.equal_range(key);
-      if (range.first == range.second) {  // check if not in range
+      if (range.first == range.second) { // check if not in range
         pmap->m_local_map.insert(std::make_pair(key, pmap->m_default_value));
         range = pmap->m_local_map.equal_range(key);
         ASSERT_DEBUG(range.first != range.second);
       }
       for (auto itr = range.first; itr != range.second; ++itr) {
-        Visitor* v;
-        (*v)(itr->first, itr->second, std::forward<const VisitorArgs>(args)...);
+        Visitor *v;
+        (*v)(*itr, std::forward<const VisitorArgs>(args)...);
       }
     };
 
@@ -82,12 +82,12 @@ class map_impl {
   }
 
   template <typename Visitor, typename... VisitorArgs>
-  void async_visit_if_exists(const key_type& key, Visitor visitor,
-                             const VisitorArgs&... args) {
+  void async_visit_if_exists(const key_type &key, Visitor visitor,
+                             const VisitorArgs &... args) {
     int dest = owner(key);
     auto visit_wrapper = [](auto pcomm, int from, auto pmap,
-                            const key_type& key, const VisitorArgs&... args) {
-      Visitor* vis;
+                            const key_type &key, const VisitorArgs &... args) {
+      Visitor *vis;
       pmap->local_visit(key, *vis);
     };
 
@@ -95,18 +95,17 @@ class map_impl {
                  std::forward<const VisitorArgs>(args)...);
   }
 
-  void async_erase(const key_type& key) {
+  void async_erase(const key_type &key) {
     int dest = owner(key);
     auto erase_wrapper = [](auto pcomm, int from, auto pmap,
-                            const key_type& key) { pmap->local_erase(key); };
+                            const key_type &key) { pmap->local_erase(key); };
 
     m_comm.async(dest, erase_wrapper, pthis, key);
   }
 
-  size_t local_count(const key_type& key) { return m_local_map.count(key); }
+  size_t local_count(const key_type &key) { return m_local_map.count(key); }
 
-  template <typename Function>
-  void for_all(Function fn) {
+  template <typename Function> void for_all(Function fn) {
     m_comm.barrier();
     local_for_all(fn);
   }
@@ -121,35 +120,37 @@ class map_impl {
     return m_comm.all_reduce_sum(m_local_map.size());
   }
 
-  size_t count(const key_type& key) {
+  size_t count(const key_type &key) {
     m_comm.barrier();
     return m_comm.all_reduce_sum(m_local_map.count(key));
   }
 
   // Doesn't swap pthis.
   // should we check comm is equal? -- probably
-  void swap(self_type& s) {
+  void swap(self_type &s) {
     m_comm.barrier();
     std::swap(m_default_value, s.m_default_value);
     m_local_map.swap(s.m_local_map);
   }
 
   template <typename STLKeyContainer, typename MapKeyValue>
-  void all_gather(const STLKeyContainer& keys, MapKeyValue& output) {
+  void all_gather(const STLKeyContainer &keys, MapKeyValue &output) {
     ygm::ygm_ptr<MapKeyValue> preturn(&output);
 
-    auto fetcher = [](auto pcomm, int from, const key_type& key, auto pmap,
+    auto fetcher = [](auto pcomm, int from, const key_type &key, auto pmap,
                       auto pcont) {
-      auto returner = [](auto pcomm, int from, const key_type& key,
-                         const std::vector<value_type>& values, auto pcont) {
-        for (const auto& v : values) { pcont->insert(std::make_pair(key, v)); }
+      auto returner = [](auto pcomm, int from, const key_type &key,
+                         const std::vector<value_type> &values, auto pcont) {
+        for (const auto &v : values) {
+          pcont->insert(std::make_pair(key, v));
+        }
       };
       auto values = pmap->local_get(key);
       pcomm->async(from, returner, key, values, pcont);
     };
 
     m_comm.barrier();
-    for (const auto& key : keys) {
+    for (const auto &key : keys) {
       int o = owner(key);
       m_comm.async(o, fetcher, key, pthis, preturn);
     }
@@ -158,7 +159,7 @@ class map_impl {
 
   typename ygm::ygm_ptr<self_type> get_ygm_ptr() const { return pthis; }
 
-  void serialize(const std::string& fname) {
+  void serialize(const std::string &fname) {
     m_comm.barrier();
     std::string rank_fname = fname + std::to_string(m_comm.rank());
     std::ofstream os(rank_fname, std::ios::binary);
@@ -166,7 +167,7 @@ class map_impl {
     oarchive(m_local_map, m_default_value, m_comm.size());
   }
 
-  void deserialize(const std::string& fname) {
+  void deserialize(const std::string &fname) {
     m_comm.barrier();
 
     std::string rank_fname = fname + std::to_string(m_comm.rank());
@@ -177,22 +178,21 @@ class map_impl {
     iarchive(m_local_map, m_default_value, comm_size);
 
     if (comm_size != m_comm.size()) {
-      m_comm.cerr0(
-          "Attempting to deserialize map_impl using communicator of "
-          "different size than serialized with");
+      m_comm.cerr0("Attempting to deserialize map_impl using communicator of "
+                   "different size than serialized with");
     }
   }
 
-  int owner(const key_type& key) const {
+  int owner(const key_type &key) const {
     auto [owner, rank] = partitioner(key, m_comm.size(), 1024);
     return owner;
   }
 
-  bool is_mine(const key_type& key) const {
+  bool is_mine(const key_type &key) const {
     return owner(key) == m_comm.rank();
   }
 
-  std::vector<value_type> local_get(const key_type& key) {
+  std::vector<value_type> local_get(const key_type &key) {
     std::vector<value_type> to_return;
 
     auto range = m_local_map.equal_range(key);
@@ -204,23 +204,22 @@ class map_impl {
   }
 
   template <typename Function>
-  void local_visit(const key_type& key, Function& fn) {
+  void local_visit(const key_type &key, Function &fn) {
     auto range = m_local_map.equal_range(key);
     std::for_each(range.first, range.second, fn);
   }
 
-  void local_erase(const key_type& key) { m_local_map.erase(key); }
+  void local_erase(const key_type &key) { m_local_map.erase(key); }
 
   void local_clear() { m_local_map.clear(); }
 
   size_t local_size() const { return m_local_map.size(); }
 
-  size_t local_const(const key_type& k) const { return m_local_map.count(k); }
+  size_t local_const(const key_type &k) const { return m_local_map.count(k); }
 
-  ygm::comm& comm() { return m_comm; }
+  ygm::comm &comm() { return m_comm; }
 
-  template <typename Function>
-  void local_for_all(Function fn) {
+  template <typename Function> void local_for_all(Function fn) {
     std::for_each(m_local_map.begin(), m_local_map.end(), fn);
   }
 
@@ -229,23 +228,27 @@ class map_impl {
                                                     CompareFunction cfn) {
     using vec_type = std::vector<std::pair<key_type, value_type>>;
     vec_type local_topk;
-    for (const auto& kv : m_local_map) {
+    for (const auto &kv : m_local_map) {
       local_topk.push_back(kv);
       std::sort(local_topk.begin(), local_topk.end(), cfn);
-      if (local_topk.size() > k) { local_topk.pop_back(); }
+      if (local_topk.size() > k) {
+        local_topk.pop_back();
+      }
     }
 
     auto to_return = m_comm.all_reduce(
-        local_topk, [cfn, k](const vec_type& va, const vec_type& vb) {
+        local_topk, [cfn, k](const vec_type &va, const vec_type &vb) {
           vec_type out(va.begin(), va.end());
           out.push_back(vb.begin(), vb.end());
           std::sort(out.begin(), out.end(), cfn);
-          while (out.size() > k) { out.pop_back(); }
+          while (out.size() > k) {
+            out.pop_back();
+          }
         });
     return to_return;
   }
 
- protected:
+protected:
   map_impl() = delete;
 
   value_type m_default_value;
@@ -253,4 +256,4 @@ class map_impl {
   ygm::comm m_comm;
   typename ygm::ygm_ptr<self_type> pthis;
 };
-}  // namespace ygm::container::detail
+} // namespace ygm::container::detail

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -8,7 +8,7 @@
 #include <ygm/comm.hpp>
 #include <ygm/container/map.hpp>
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   ygm::comm world(&argc, &argv);
 
   //
@@ -43,16 +43,16 @@ int main(int argc, char** argv) {
   // Test all ranks default & async_visit_if_exists
   {
     ygm::container::map<std::string, std::string> smap(world, "default_string");
-    smap.async_visit("dog", [](const std::string& s1, const std::string& s2) {
-      ASSERT_RELEASE(s1 == "dog");
-      ASSERT_RELEASE(s2 == "default_string");
+    smap.async_visit("dog", [](std::pair<const std::string, std::string> &s) {
+      ASSERT_RELEASE(s.first == "dog");
+      ASSERT_RELEASE(s.second == "default_string");
     });
-    smap.async_visit("cat", [](const std::string& s1, const std::string& s2) {
-      ASSERT_RELEASE(s1 == "cat");
-      ASSERT_RELEASE(s2 == "default_string");
+    smap.async_visit("cat", [](std::pair<const std::string, std::string> &s) {
+      ASSERT_RELEASE(s.first == "cat");
+      ASSERT_RELEASE(s.second == "default_string");
     });
     smap.async_visit_if_exists("red",
-                               [](const auto& p) { ASSERT_RELEASE(false); });
+                               [](const auto &p) { ASSERT_RELEASE(false); });
 
     ASSERT_RELEASE(smap.count("dog") == 1);
     ASSERT_RELEASE(smap.count("cat") == 1);
@@ -60,7 +60,9 @@ int main(int argc, char** argv) {
 
     ASSERT_RELEASE(smap.size() == 2);
 
-    if (world.rank() == 0) { smap.async_erase("dog"); }
+    if (world.rank() == 0) {
+      smap.async_erase("dog");
+    }
     ASSERT_RELEASE(smap.count("dog") == 0);
     ASSERT_RELEASE(smap.size() == 1);
     smap.async_erase("cat");
@@ -93,9 +95,12 @@ int main(int argc, char** argv) {
   //
   // Test map<vector>
   {
-    ygm::container::map<std::string, std::vector<std::string> > smap(world);
-    auto str_push_back = [](const auto& key, auto& value,
-                            const std::string& str) { value.push_back(str); };
+    ygm::container::map<std::string, std::vector<std::string>> smap(world);
+    auto str_push_back = [](std::pair<const auto, auto> &key_value,
+                            const std::string &str) {
+      // auto str_push_back = [](auto key_value, const std::string &str) {
+      key_value.second.push_back(str);
+    };
     if (world.rank0()) {
       smap.async_visit("foo", str_push_back, std::string("bar"));
       smap.async_visit("foo", str_push_back, std::string("baz"));
@@ -103,7 +108,9 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> gather_list = {"foo"};
 
-    if (!world.rank0()) { gather_list.clear(); }
+    if (!world.rank0()) {
+      gather_list.clear();
+    }
 
     auto gmap = smap.all_gather(gather_list);
 

--- a/test/test_multimap.cpp
+++ b/test/test_multimap.cpp
@@ -8,7 +8,7 @@
 #include <ygm/comm.hpp>
 #include <ygm/container/map.hpp>
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   ygm::comm world(&argc, &argv);
 
   //
@@ -44,16 +44,16 @@ int main(int argc, char** argv) {
   {
     ygm::container::multimap<std::string, std::string> smap(world,
                                                             "default_string");
-    smap.async_visit("dog", [](const std::string& s1, const std::string& s2) {
-      ASSERT_RELEASE(s1 == "dog");
-      ASSERT_RELEASE(s2 == "default_string");
+    smap.async_visit("dog", [](std::pair<const std::string, std::string> s) {
+      ASSERT_RELEASE(s.first == "dog");
+      ASSERT_RELEASE(s.second == "default_string");
     });
-    smap.async_visit("cat", [](const std::string& s1, const std::string& s2) {
-      ASSERT_RELEASE(s1 == "cat");
-      ASSERT_RELEASE(s2 == "default_string");
+    smap.async_visit("cat", [](std::pair<const std::string, std::string> &s) {
+      ASSERT_RELEASE(s.first == "cat");
+      ASSERT_RELEASE(s.second == "default_string");
     });
     smap.async_visit_if_exists("red",
-                               [](const auto& p) { ASSERT_RELEASE(false); });
+                               [](const auto &p) { ASSERT_RELEASE(false); });
 
     ASSERT_RELEASE(smap.count("dog") == 1);
     ASSERT_RELEASE(smap.count("cat") == 1);
@@ -61,7 +61,9 @@ int main(int argc, char** argv) {
 
     ASSERT_RELEASE(smap.size() == 2);
 
-    if (world.rank() == 0) { smap.async_erase("dog"); }
+    if (world.rank() == 0) {
+      smap.async_erase("dog");
+    }
     ASSERT_RELEASE(smap.count("dog") == 0);
     ASSERT_RELEASE(smap.size() == 1);
     smap.async_erase("cat");


### PR DESCRIPTION
Makes syntax for lambdas given to map_impl::for_all and map_impl::async_visit consistent by requiring an
std::pair<const key_type, mapped_type> (i.e. std::map::value_type) as the first argument to each.