### PR TITLE
(lambda calls) support optional argument passing

### DIFF
--- a/include/ygm/detail/comm_impl.hpp
+++ b/include/ygm/detail/comm_impl.hpp
@@ -14,6 +14,7 @@
 
 #include <ygm/detail/mpi.hpp>
 #include <ygm/detail/ygm_cereal_archive.hpp>
+#include <ygm/meta/functional.hpp>
 
 namespace ygm {
 
@@ -429,7 +430,8 @@ class comm::impl {
   int32_t local_receive(Lambda l, const Args &... args) {
     ASSERT_DEBUG(sizeof(Lambda) == 1);
     // Question: should this be std::forward(...)
-    (l)(this, m_comm_rank, args...);
+    // \pp was: (l)(this, m_comm_rank, args...);
+    ygm::meta::apply_optional(l, std::make_tuple(this, m_comm_rank), std::make_tuple(args...));
     return 1;
   }
 
@@ -446,7 +448,9 @@ class comm::impl {
           bia(ta);
           Lambda *pl;
           auto t1 = std::make_tuple((impl *)t, from);
-          std::apply(*pl, std::tuple_cat(t1, ta));
+          
+          // \pp was: std::apply(*pl, std::tuple_cat(t1, ta));
+          ygm::meta::apply_optional(*pl, std::move(t1), std::move(ta));
         };
 
     cereal::YGMOutputArchive oarchive(to_return);  // Create an output archive

--- a/include/ygm/meta/functional.hpp
+++ b/include/ygm/meta/functional.hpp
@@ -1,0 +1,65 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+// 
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <tuple>
+#include <type_traits>
+
+namespace ygm
+{
+
+namespace meta
+{
+  namespace details
+  {
+    template <class Fn, class... Opts, class... Args>
+    auto apply(const std::true_type&, Fn fn, std::tuple<Opts...>&& optional, std::tuple<Args...>&& args)
+    {
+      using OptType = std::tuple<Opts...>;
+      using ArgType = std::tuple<Args...>;
+
+      return std::apply(fn, std::tuple_cat(std::forward<OptType>(optional), std::forward<ArgType>(args)));
+    }
+
+    template <class Fn, class... Opts, class... Args>
+    auto apply(const std::false_type&, Fn fn, std::tuple<Opts...>&& optional, std::tuple<Args...>&& args)
+    {
+      using ArgType = std::tuple<Args...>;
+      
+      return std::apply(fn, std::forward<ArgType>(args));
+    }
+  }
+
+  /// calls fn(optional..., args...) if \ref fn expects optional... as the first arguments
+  ///       fn(args...)              otherwise
+  /// \tparam Fn     functor type
+  /// \tparam Opts   argument pack describing the tuple element types 
+  /// \tparam Args   argument pack passed to the functor
+  /// \param  fn       the functor
+  /// \param  optional the optional arguments packed into a tuple
+  /// \param  args     the regular arguments packed into a tuple
+  /// \returns the result of calling \ref fn
+  template <class Fn, class... Opts, class... Args>
+  auto apply_optional(Fn&& fn, std::tuple<Opts...>&& optional, std::tuple<Args...>&& args)
+  {
+    using tag = typename std::is_invocable<Fn, Opts..., Args...>::type;
+    using OptType = std::tuple<Opts...>;
+    using ArgType = std::tuple<Args...>;
+
+    return details::apply(tag{}, fn, std::forward<OptType>(optional), std::forward<ArgType>(args));
+  }
+} // meta
+
+} // ygm
+
+
+
+
+
+
+
+


### PR DESCRIPTION
- added header include/ygm/meta/functional.hpp
- provide custom ygm::meta::apply that takes three arguments
  (1) function fn
	(2) optional tuple (opt...)
	(3) required tuple (arg...)

  ygm::meta::apply calls function with expanded tuples.
  calls fn(opt..., args...) if supported by fn
	      fn(args...) otherwise