### PR TITLE
Removes public async_flush functionality

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -45,10 +45,6 @@ class comm {
   void async_mcast_preempt(const std::vector<int> &dests, AsyncFunction fn,
                            const SendArgs &... args);
 
-  void async_flush(int rank);
-  void async_flush_bcast();
-  void async_flush_all();
-
   //
   // Collective operations across all ranks.  Cannot be called inside OpenMP
   // region.

--- a/include/ygm/detail/comm_impl.hpp
+++ b/include/ygm/detail/comm_impl.hpp
@@ -667,10 +667,6 @@ inline void comm::reset_rpc_call_counter() { pimpl->reset_rpc_call_counter(); }
 
 inline void comm::barrier() { pimpl->barrier(); }
 
-inline void comm::async_flush(int rank) { pimpl->async_flush(rank); }
-
-inline void comm::async_flush_all() { pimpl->async_flush_all(); }
-
 template <typename T>
 inline T comm::all_reduce_sum(const T &t) const {
   return pimpl->all_reduce_sum(t);


### PR DESCRIPTION
@rogerpearce, do you want to remove the public async_flush functions now? There are _preempt versions of all async/bcast/mcast functionality, but they call the non-preempt versions for now.