### PR TITLE
Hotfix/config_find_order

### DIFF
--- a/cmake/ygmConfig.cmake.in
+++ b/cmake/ygmConfig.cmake.in
@@ -1,8 +1,8 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-check_required_components("@PROJECT_NAME@")
-
 find_package(Threads REQUIRED)
 find_package(MPI REQUIRED)
 find_package(cereal QUIET) # If cereal not found, hopefully included via FetchContent
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Fixed a bug introduced in the ordering of called in the config maker file. Now we can correctly include a ygm instance with a daisy-chained cereal install in a downstream source. 