### PR TITLE
Iss/39

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,38 @@
+# -----------------------------
+# Options effecting formatting.
+#
+# Requires cmake-format (pip install cmake_format). See
+# https://cmake-format.readthedocs.io/en/latest/configuration.html for more
+# examples.
+# -----------------------------
+with section("format"):
+
+    # How wide to allow formatted cmake files
+    line_width = 80
+
+    # How many spaces to tab for indent
+    tab_size = 4
+
+    use_tabchars = False
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = True
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = True
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it
+    # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+    # the start of the statement, plus one indentation  level, `child`: align to
+    # the column of the arguments
+    dangle_align = "prefix"
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = "canonical"
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = "unchanged"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ include(FetchContent)
 # Cereal
 #
 set(ygm_cereal_VERSION 1.3.0)
+# Would like to version this find, but the spack config file is versionless so
+# will always throw an error.
 find_package(cereal CONFIG QUIET)
 if (NOT cereal_FOUND)
     # Currently cereal version 1.3.0 has an outdated CMakeLists.txt, so we need

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ include(FetchContent)
 set(ygm_cereal_VERSION 1.3.0)
 find_package(cereal CONFIG QUIET)
 if (NOT cereal_FOUND)
-    # Currently cereal version 1.3.0 has an outdate CMakeLists.txt, so we need to use this commit
+    # Currently cereal version 1.3.0 has an outdated CMakeLists.txt, so we need 
+    # to use this specific commit for now.
     FetchContent_Declare(
         cereal
         GIT_REPOSITORY https://github.com/USCiLab/cereal
@@ -85,12 +86,15 @@ if (NOT cereal_FOUND)
         set(JUST_INSTALL_CEREAL ON)
         # Install cereal at ${CMAKE_INSTALL_PREFIX}
         set(CEREAL_INSTALL ${YGM_INSTALL})
-        FetchContent_MakeAvailable(cereal)
+        # Populate cereal
+        FetchContent_POPULATE(cereal)
+        # Include cereal root cmake boilerplate
+        add_subdirectory(${cereal_SOURCE_DIR})
         message(STATUS "YGM cloned cereal dependency: " ${cereal_SOURCE_DIR})
     endif()
     target_link_libraries(ygm INTERFACE cereal::cereal)
 else()
-    message(STATUS "YGM found cereal dependency: " ${cereal_DIR})
+    message(STATUS "YGM found installed cereal dependency: " ${cereal_DIR})
     # cereal installed with spack creates library target "cereal", whereas 
     # installing from source creates target "cereal::cereal". This is the only
     # simple way I could figure out how to differentiate the two, but this will 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,53 +5,59 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-project(ygm
+project(
+    ygm
     VERSION 0.2
     DESCRIPTION "HPC Communication Library"
-    LANGUAGES CXX)
+    LANGUAGES CXX
+)
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(YGM_MAIN_PROJECT ON)
-endif()
+endif ()
 
-# Controls whether to set up install boilerplate for project and depencencies
+# Controls whether to set up install boilerplate for project and depencencies.
+# Expects CMAKE_INSTALL_PREFIX to be set to a suitable directory.
 option(YGM_INSTALL "Generate the install target" ${YGM_MAIN_PROJECT})
 
-# Only do these if this is the main project, and not if it is included through add_subdirectory
-if(YGM_MAIN_PROJECT)
+# Only do these if this is the main project, and not if it is included through
+# add_subdirectory
+if (YGM_MAIN_PROJECT)
 
     # Let's nicely support folders in IDE's
     set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-    # Testing only available if this is the main app
-    # Note this needs to be done in the main CMakeLists
-    # since it calls enable_testing, which must be in the
+    # Testing only available if this is the main app Note this needs to be done
+    # in the main CMakeLists since it calls enable_testing, which must be in the
     # main CMakeLists.
     include(CTest)
 
     # Docs only available if this is the main app
     find_package(Doxygen)
-    if(Doxygen_FOUND)
-    #add_subdirectory(docs)
-    else()
-    message(STATUS "Doxygen not found, not building docs")
-    endif()
-endif()
+    if (Doxygen_FOUND)
+        # add_subdirectory(docs)
+    else ()
+        message(STATUS "Doxygen not found, not building docs")
+    endif ()
+endif ()
 
-### Require out-of-source builds
+# Require out-of-source builds
 file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
-if(EXISTS "${LOC_PATH}")
-    message(FATAL_ERROR "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
-endif()
+if (EXISTS "${LOC_PATH}")
+    message(
+        FATAL_ERROR
+            "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles."
+    )
+endif ()
 
 #
 # Create the YGM target library
 #
 add_library(ygm INTERFACE)
 add_library(ygm::ygm ALIAS ygm)
-target_include_directories(ygm INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(
+    ygm INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                  $<INSTALL_INTERFACE:include>
 )
 target_compile_features(ygm INTERFACE cxx_std_17)
 
@@ -71,110 +77,118 @@ include(FetchContent)
 set(ygm_cereal_VERSION 1.3.0)
 find_package(cereal CONFIG QUIET)
 if (NOT cereal_FOUND)
-    # Currently cereal version 1.3.0 has an outdated CMakeLists.txt, so we need 
+    # Currently cereal version 1.3.0 has an outdated CMakeLists.txt, so we need
     # to use this specific commit for now.
     FetchContent_Declare(
         cereal
         GIT_REPOSITORY https://github.com/USCiLab/cereal
-        GIT_TAG        af0700efb25e7dc7af637b9e6f970dbb94813bff
+        GIT_TAG af0700efb25e7dc7af637b9e6f970dbb94813bff
     )
     FetchContent_GetProperties(cereal)
     if (cereal_POPULATED)
-        message(STATUS "YGM found already populated cereal dependency: " ${cereal_SOURCE_DIR})
-    else()
+        message(STATUS "YGM found already populated cereal dependency: "
+                       ${cereal_SOURCE_DIR}
+        )
+    else ()
         # Do not compile any cereal tests
         set(JUST_INSTALL_CEREAL ON)
         # Install cereal at ${CMAKE_INSTALL_PREFIX}
         set(CEREAL_INSTALL ${YGM_INSTALL})
         # Populate cereal
-        FetchContent_POPULATE(cereal)
+        FetchContent_Populate(cereal)
         # Include cereal root cmake boilerplate
         add_subdirectory(${cereal_SOURCE_DIR})
         message(STATUS "YGM cloned cereal dependency: " ${cereal_SOURCE_DIR})
-    endif()
+    endif ()
     target_link_libraries(ygm INTERFACE cereal::cereal)
-else()
+else ()
     message(STATUS "YGM found installed cereal dependency: " ${cereal_DIR})
-    # cereal installed with spack creates library target "cereal", whereas 
+    # cereal installed with spack creates library target "cereal", whereas
     # installing from source creates target "cereal::cereal". This is the only
-    # simple way I could figure out how to differentiate the two, but this will 
+    # simple way I could figure out how to differentiate the two, but this will
     # cause problems if a spack instance installs headers to a path that does
-    # not include the substring "spack". 
+    # not include the substring "spack".
     if (${cereal_DIR} MATCHES ".*spack.*")
         target_link_libraries(ygm INTERFACE cereal)
-    else()
+    else ()
         target_link_libraries(ygm INTERFACE cereal::cereal)
-    endif()
-endif()
+    endif ()
+endif ()
 
 #
 # Boost
 #
-# only required by ygm/detail/cereal_boost_json.hpp. YGM will build if Boost is not found.
-# The user must manually link to executable.
+# only required by ygm/detail/cereal_boost_json.hpp. YGM will build if Boost is
+# not found. The user must manually link to executable.
 #
-#find_package(Boost 1.75 COMPONENTS json)  # this would be better, but is not working on LC
+# find_package(Boost 1.75 COMPONENTS json)  # this would be better, but is not
+# working on LC
 find_package(Boost 1.75)
 if (Boost_FOUND)
     message(STATUS "YGM found boost include dirs: " ${Boost_INCLUDE_DIRS})
-else()
+else ()
     message(WARNING "YGM did not find Boost >=1.75. Building without Boost.")
-endif()
+endif ()
 
 option(TEST_WITH_SLURM "Run tests with Slurm" OFF)
 
-
 # Install ygm. Expects CMAKE_INSTALL_PREFIX to be set to a suitable directory.
-if(${YGM_INSTALL})
+if (${YGM_INSTALL})
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 
     # List libraries to be installed
     set(YGM_EXPORT_TARGETS ygm)
 
-    install(TARGETS ${PROJECT_NAME}
-            EXPORT ${PROJECT_NAME}Targets
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-    install(EXPORT ${PROJECT_NAME}Targets
-            FILE ${PROJECT_NAME}Targets.cmake
-            NAMESPACE ${PROJECT_NAME}::
-            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+    install(
+        EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    )
 
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ygm
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 
     # create version file
     write_basic_package_version_file(
         "${PROJECT_NAME}ConfigVersion.cmake"
-          VERSION ${PROJECT_VERSION}
-          COMPATIBILITY ExactVersion)
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY ExactVersion
+    )
 
     # create config file
     configure_package_config_file(
         "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
         "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-        INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+        INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    )
 
-    install(FILES
-        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+    )
 
-
-endif()
+endif ()
 
 option(JUST_INSTALL_YGM "Skip executable compilation" OFF)
-if(JUST_INSTALL_YGM)
+if (JUST_INSTALL_YGM)
     return()
-endif()
+endif ()
 
 # Testing & examples are only available if this is the main app
-if(YGM_MAIN_PROJECT)
+if (YGM_MAIN_PROJECT)
     add_subdirectory(test)
     add_subdirectory(performance)
     # Example codes are here.
     add_subdirectory(examples)
-endif()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(YGM_MAIN_PROJECT ON)
 endif()
 
+# Controls whether to set up install boilerplate for project and depencencies
+option(YGM_INSTALL "Generate the install target" ${YGM_MAIN_PROJECT})
+
 # Only do these if this is the main project, and not if it is included through add_subdirectory
 if(YGM_MAIN_PROJECT)
 
@@ -74,12 +77,17 @@ if (NOT cereal_FOUND)
         GIT_REPOSITORY https://github.com/USCiLab/cereal
         GIT_TAG        af0700efb25e7dc7af637b9e6f970dbb94813bff
     )
-    # Do not compile any cereal tests
-    set(JUST_INSTALL_CEREAL ON)
-    # Install cereal at ${CMAKE_INSTALL_PREFIX}
-    set(CEREAL_INSTALL ON)
-    FetchContent_MakeAvailable(cereal)
-    message(STATUS "YGM cloned cereal dependency: " ${cereal_SOURCE_DIR})
+    FetchContent_GetProperties(cereal)
+    if (cereal_POPULATED)
+        message(STATUS "YGM found already populated cereal dependency: " ${cereal_SOURCE_DIR})
+    else()
+        # Do not compile any cereal tests
+        set(JUST_INSTALL_CEREAL ON)
+        # Install cereal at ${CMAKE_INSTALL_PREFIX}
+        set(CEREAL_INSTALL ${YGM_INSTALL})
+        FetchContent_MakeAvailable(cereal)
+        message(STATUS "YGM cloned cereal dependency: " ${cereal_SOURCE_DIR})
+    endif()
     target_link_libraries(ygm INTERFACE cereal::cereal)
 else()
     message(STATUS "YGM found cereal dependency: " ${cereal_DIR})
@@ -113,7 +121,6 @@ option(TEST_WITH_SLURM "Run tests with Slurm" OFF)
 
 
 # Install ygm. Expects CMAKE_INSTALL_PREFIX to be set to a suitable directory.
-option(YGM_INSTALL "Generate the install target" ${YGM_MAIN_PROJECT})
 if(${YGM_INSTALL})
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)

--- a/cmake/ygmConfig.cmake.in
+++ b/cmake/ygmConfig.cmake.in
@@ -2,7 +2,8 @@
 
 find_package(Threads REQUIRED)
 find_package(MPI REQUIRED)
-find_package(cereal QUIET) # If cereal not found, hopefully included via FetchContent
+# If cereal not found, hopefully included via FetchContent
+find_package(cereal CONFIG QUIET) 
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,12 +6,12 @@
 #
 # This function adds an mpi example.
 #
-function ( add_ygm_example example_name )
-  set(example_source "${example_name}.cpp")
-  set(example_exe    "${example_name}")
-  add_executable(${example_exe} ${example_source})
-  target_link_libraries(${example_exe} ygm)
-endfunction()
+function (add_ygm_example example_name)
+    set(example_source "${example_name}.cpp")
+    set(example_exe "${example_name}")
+    add_executable(${example_exe} ${example_source})
+    target_link_libraries(${example_exe} PUBLIC ygm::ygm)
+endfunction ()
 
 add_ygm_example(hello_world)
 add_ygm_example(howdy_world)

--- a/performance/CMakeLists.txt
+++ b/performance/CMakeLists.txt
@@ -6,12 +6,12 @@
 #
 # This function adds an mpi example.
 #
-function ( add_ygm_example example_name )
-  set(example_source "${example_name}.cpp")
-  set(example_exe    "${example_name}")
-  add_executable(${example_exe} ${example_source})
-  target_link_libraries(${example_exe} ygm)
-endfunction()
+function (add_ygm_example example_name)
+    set(example_source "${example_name}.cpp")
+    set(example_exe "${example_name}")
+    add_executable(${example_exe} ${example_source})
+    target_link_libraries(${example_exe} PUBLIC ygm::ygm)
+endfunction ()
 
 add_ygm_example(counter_scaling_test)
 add_ygm_example(disjoint_set_union_chain)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,34 +3,33 @@
 #
 # SPDX-License-Identifier: MIT
 
-
 #
 # This function adds a Sequential test.
 #
-function ( add_ygm_seq_test test_name )
-  set(test_source "${test_name}.cpp")
-  set(test_exe    "SEQ_${test_name}")
-  add_executable(${test_exe} ${test_source})
-  target_link_libraries(${test_exe} ygm)
-  add_test( ${test_exe} "${CMAKE_CURRENT_BINARY_DIR}/${test_exe}")
-endfunction()
+function (add_ygm_seq_test test_name)
+    set(test_source "${test_name}.cpp")
+    set(test_exe "SEQ_${test_name}")
+    add_executable(${test_exe} ${test_source})
+    target_link_libraries(${test_exe} PUBLIC ygm::ygm)
+    add_test(${test_exe} "${CMAKE_CURRENT_BINARY_DIR}/${test_exe}")
+endfunction ()
 
 #
 # This function adds an MPI test.
 #
-function ( add_ygm_test test_name )
-  set(test_source "${test_name}.cpp")
-  set(test_exe    "MPI_${test_name}")
-  add_executable(${test_exe} ${test_source})
-  target_link_libraries(${test_exe} ygm)
-  if(${TEST_WITH_SLURM}) 
-    add_test( ${test_exe} "srun" "${CMAKE_CURRENT_BINARY_DIR}/${test_exe}")
-  else()
-    add_test( ${test_exe} ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
-    "4" ${MPIEXEC_PREFLAGS} "${CMAKE_CURRENT_BINARY_DIR}/${test_exe}")
-  endif()
-endfunction()
-
+function (add_ygm_test test_name)
+    set(test_source "${test_name}.cpp")
+    set(test_exe "MPI_${test_name}")
+    add_executable(${test_exe} ${test_source})
+    target_link_libraries(${test_exe} PUBLIC ygm::ygm)
+    if (${TEST_WITH_SLURM})
+        add_test(${test_exe} "srun" "${CMAKE_CURRENT_BINARY_DIR}/${test_exe}")
+    else ()
+        add_test(${test_exe} ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} "4"
+                 ${MPIEXEC_PREFLAGS} "${CMAKE_CURRENT_BINARY_DIR}/${test_exe}"
+        )
+    endif ()
+endfunction ()
 
 add_ygm_seq_test(test_cereal_archive)
 
@@ -48,12 +47,15 @@ add_ygm_test(test_container_serialization)
 add_ygm_test(test_line_parser)
 add_ygm_test(test_csv_parser)
 
-
 if (Boost_FOUND)
-  add_ygm_seq_test(test_cereal_boost_json)
-  add_ygm_test(test_ndjson_parser)
-  target_include_directories(SEQ_test_cereal_boost_json PUBLIC ${Boost_INCLUDE_DIRS})
-  target_include_directories(MPI_test_ndjson_parser PUBLIC ${Boost_INCLUDE_DIRS})
+    add_ygm_seq_test(test_cereal_boost_json)
+    add_ygm_test(test_ndjson_parser)
+    target_include_directories(
+        SEQ_test_cereal_boost_json PUBLIC ${Boost_INCLUDE_DIRS}
+    )
+    target_include_directories(
+        MPI_test_ndjson_parser PUBLIC ${Boost_INCLUDE_DIRS}
+    )
 endif ()
 
 #


### PR DESCRIPTION
Addressed Keita's comments in issue #39. Dependent projects can now separately find-else-fetch cereal before or after find-else-fetching ygm. Also added formatting to cmake files via cmake-format (similar to clang-format). See .cmake-format.py for details. 