### PR TITLE
Feature/comm_ptr_in_lambdas

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -14,12 +14,19 @@
 namespace ygm {
 
 class comm {
+ private:
+  class impl;
+
  public:
   comm(int *argc, char ***argv, int buffer_capacity);
 
   // TODO:  Add way to detect if this MPI_Comm is already open. E.g., static
   // map<MPI_Comm, impl*>
   comm(MPI_Comm comm, int buffer_capacity);
+
+  // Constructor to allow comm::impl to build temporary comm using itself as the
+  // impl
+  comm(std::shared_ptr<impl> impl_ptr);
 
   ~comm();
 
@@ -150,7 +157,6 @@ class comm {
  private:
   comm() = delete;
 
-  class impl;
   std::shared_ptr<impl>                      pimpl;
   std::shared_ptr<detail::mpi_init_finalize> pimpl_if;
 };


### PR DESCRIPTION
- makes optional comm argument given to lambdas a true ygm::comm instead of a ygm::comm::impl
- includes changes to comm and comm::impl to allow comm::impl to construct a comm using itself as the impl for use in lambdas