### PR TITLE
Feature/comm ptr in lambdas

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -14,12 +14,19 @@
 namespace ygm {
 
 class comm {
+ private:
+  class impl;
+
  public:
   comm(int *argc, char ***argv, int buffer_capacity);
 
   // TODO:  Add way to detect if this MPI_Comm is already open. E.g., static
   // map<MPI_Comm, impl*>
   comm(MPI_Comm comm, int buffer_capacity);
+
+  // Constructor to allow comm::impl to build temporary comm using itself as the
+  // impl
+  comm(std::shared_ptr<impl> impl_ptr);
 
   ~comm();
 
@@ -150,7 +157,6 @@ class comm {
  private:
   comm() = delete;
 
-  class impl;
   std::shared_ptr<impl>                      pimpl;
   std::shared_ptr<detail::mpi_init_finalize> pimpl_if;
 };

--- a/include/ygm/detail/comm_impl.hpp
+++ b/include/ygm/detail/comm_impl.hpp
@@ -502,9 +502,7 @@ inline comm::~comm() {
   if (pimpl.use_count() == 1) {
     barrier();
   }
-  ASSERT_RELEASE(MPI_Barrier(MPI_COMM_WORLD) == MPI_SUCCESS);
   pimpl.reset();
-  ASSERT_RELEASE(MPI_Barrier(MPI_COMM_WORLD) == MPI_SUCCESS);
   pimpl_if.reset();
 }
 


### PR DESCRIPTION
Makes changes to pass a true ygm::comm pointer to lambdas instead of a ygm::comm::impl. This includes allowing a ygm::comm::impl to construct a temporary ygm::comm using itself as the impl.