### PR TITLE
ygm::comm::Layout class

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <ygm/detail/layout.hpp>
 #include <ygm/detail/mpi.hpp>
 #include <ygm/detail/ygm_ptr.hpp>
 
@@ -35,14 +36,14 @@ class comm {
   //
 
   template <typename AsyncFunction, typename... SendArgs>
-  void async(int dest, AsyncFunction fn, const SendArgs &... args);
+  void async(int dest, AsyncFunction fn, const SendArgs &...args);
 
   template <typename AsyncFunction, typename... SendArgs>
-  void async_bcast(AsyncFunction fn, const SendArgs &... args);
+  void async_bcast(AsyncFunction fn, const SendArgs &...args);
 
   template <typename AsyncFunction, typename... SendArgs>
   void async_mcast(const std::vector<int> &dests, AsyncFunction fn,
-                   const SendArgs &... args);
+                   const SendArgs &...args);
 
   //
   // Collective operations across all ranks.  Cannot be called inside OpenMP
@@ -90,6 +91,8 @@ class comm {
   int size() const;
   int rank() const;
 
+  const Layout &layout() const;
+
   //
   //	Counters
   //
@@ -131,24 +134,24 @@ class comm {
   bool rank0() const { return rank() == 0; }
 
   template <typename... Args>
-  void cout(Args &&... args) const {
+  void cout(Args &&...args) const {
     (cout() << ... << args) << std::endl;
   }
 
   template <typename... Args>
-  void cerr(Args &&... args) const {
+  void cerr(Args &&...args) const {
     (cerr() << ... << args) << std::endl;
   }
 
   template <typename... Args>
-  void cout0(Args &&... args) const {
+  void cout0(Args &&...args) const {
     if (rank0()) {
       (std::cout << ... << args) << std::endl;
     }
   }
 
   template <typename... Args>
-  void cerr0(Args &&... args) const {
+  void cerr0(Args &&...args) const {
     if (rank0()) {
       (std::cerr << ... << args) << std::endl;
     }

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -91,7 +91,7 @@ class comm {
   int size() const;
   int rank() const;
 
-  const Layout &layout() const;
+  const detail::layout &layout() const;
 
   //
   //	Counters

--- a/include/ygm/detail/comm_impl.hpp
+++ b/include/ygm/detail/comm_impl.hpp
@@ -261,7 +261,7 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
     return to_return;
   }
 
-  const Layout &layout() const { return m_layout; }
+  const detail::layout &layout() const { return m_layout; }
 
  private:
   std::pair<uint64_t, uint64_t> barrier_reduce_counts() {
@@ -459,7 +459,7 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
   int      m_comm_rank;
   size_t   m_buffer_capacity_bytes;
 
-  Layout m_layout;
+  detail::layout m_layout;
 
   std::vector<std::vector<std::byte>> m_vec_send_buffers;
   size_t                              m_send_buffer_bytes = 0;
@@ -533,7 +533,7 @@ inline void comm::async_mcast(const std::vector<int> &dests, AsyncFunction fn,
   pimpl->async_mcast(dests, fn, std::forward<const SendArgs>(args)...);
 }
 
-inline const Layout &comm::layout() const { return pimpl->layout(); }
+inline const detail::layout &comm::layout() const { return pimpl->layout(); }
 
 inline int comm::size() const { return pimpl->size(); }
 inline int comm::rank() const { return pimpl->rank(); }

--- a/include/ygm/detail/layout.hpp
+++ b/include/ygm/detail/layout.hpp
@@ -1,0 +1,191 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <exception>
+#include <iostream>
+#include <sstream>
+
+#include <ygm/detail/mpi.hpp>
+
+namespace ygm {
+
+class Layout {
+ private:
+  // MPI_Comm m_comm_local;
+  // MPI_Comm m_comm_node;
+  int m_world_size;
+  int m_world_rank;
+  int m_local_size;
+  int m_local_rank;
+  int m_node_size;
+  int m_node_rank;
+
+  std::vector<int> m_local_ranks;
+  std::vector<int> m_node_ranks;
+  std::vector<int> m_rank_to_local;
+  std::vector<int> m_rank_to_node;
+
+  template <typename T>
+  void mpi_allgather(T _t, std::vector<T> &out_vec, int size, MPI_Comm comm) {
+    out_vec.resize(size);
+    ASSERT_MPI(MPI_Allgather(&_t, sizeof(_t), MPI_BYTE, &(out_vec[0]),
+                             sizeof(_t), MPI_BYTE, comm));
+  }
+
+ public:
+  Layout(MPI_Comm comm) {
+    // global ranks
+    ASSERT_MPI(MPI_Comm_size(comm, &m_world_size));
+    ASSERT_MPI(MPI_Comm_rank(comm, &m_world_rank));
+
+    // local ranks
+    MPI_Comm comm_local;
+    ASSERT_MPI(MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, m_world_rank,
+                                   MPI_INFO_NULL, &comm_local));
+    ASSERT_MPI(MPI_Comm_size(comm_local, &m_local_size));
+    ASSERT_MPI(MPI_Comm_rank(comm_local, &m_local_rank));
+
+    mpi_allgather(m_local_rank, m_local_ranks, m_local_size, comm_local);
+
+    // m_local_ranks.resize(m_local_size);
+    // ASSERT_MPI(MPI_Allgather(&m_local_rank, 1, MPI_INT, &(m_local_ranks[0]),
+    // 1,
+    //                          MPI_INT, comm_local));
+
+    // remote ranks
+    MPI_Comm comm_node;
+    ASSERT_MPI(MPI_Comm_split(comm, m_local_rank, m_world_rank, &comm_node));
+    ASSERT_MPI(MPI_Comm_size(comm_node, &m_node_size));
+    ASSERT_MPI(MPI_Comm_rank(comm_node, &m_node_rank));
+
+    mpi_allgather(m_node_rank, m_node_ranks, m_node_size, comm_node);
+
+    mpi_allgather(m_local_rank, m_rank_to_local, m_world_size, comm);
+    mpi_allgather(m_node_rank, m_rank_to_node, m_world_size, comm);
+
+    // m_node_ranks.resize(m_node_size);
+    // ASSERT_MPI(MPI_Allgather(&m_node_ranks, 1, MPI_INT, &(m_node_ranks[0]),
+    // 1,
+    //                          MPI_INT, comm_local));
+    // delete communicators
+    ASSERT_RELEASE(MPI_Comm_free(&comm_local) == MPI_SUCCESS);
+    ASSERT_RELEASE(MPI_Comm_free(&comm_node) == MPI_SUCCESS);
+  }
+
+  Layout(const Layout &rhs)
+      : m_world_size(rhs.m_world_size),
+        m_world_rank(rhs.m_world_rank),
+        m_local_size(rhs.m_local_size),
+        m_local_rank(rhs.m_local_rank),
+        m_node_size(rhs.m_node_size),
+        m_node_rank(rhs.m_node_rank) {
+    // ASSERT_MPI(MPI_Comm_dup(rhs.m_comm_local, &m_comm_local));
+    // ASSERT_MPI(MPI_Comm_dup(rhs.m_comm_node, &m_comm_node));
+  }
+
+  Layout() {}
+
+  friend void swap(Layout &lhs, Layout &rhs) {
+    std::swap(lhs.m_world_size, rhs.m_world_size);
+    std::swap(lhs.m_world_rank, rhs.m_world_rank);
+    std::swap(lhs.m_local_size, rhs.m_local_size);
+    std::swap(lhs.m_local_rank, rhs.m_local_rank);
+    std::swap(lhs.m_node_size, rhs.m_node_size);
+    std::swap(lhs.m_node_rank, rhs.m_node_rank);
+    std::swap(lhs.m_local_ranks, rhs.m_local_ranks);
+    std::swap(lhs.m_node_ranks, rhs.m_node_ranks);
+    std::swap(lhs.m_rank_to_node, rhs.m_rank_to_node);
+    std::swap(lhs.m_rank_to_local, rhs.m_rank_to_local);
+  }
+
+  ~Layout() {
+    // ASSERT_RELEASE(MPI_Comm_free(&m_local));
+    // ASSERT_RELEASE(MPI_Comm_free(&m_node));
+  }
+
+  constexpr int count() const { return m_world_size; }
+  constexpr int rank() const { return m_world_rank; }
+
+  constexpr int node_count() const { return m_node_size; }
+  constexpr int local_count() const { return m_local_size; }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // ID conversion
+  //////////////////////////////////////////////////////////////////////////////
+
+  constexpr int node_id() const { return m_node_rank; }
+  inline int    node_id(const int rank) const {
+    _check_world_rank(rank);
+    return m_rank_to_node.at(rank);
+    // return rank / m_local_size;
+  }
+
+  constexpr int local_id() const { return m_local_rank; }
+  inline int    local_id(const int rank) const {
+    _check_world_rank(rank);
+    return m_rank_to_local.at(rank);
+    // return rank % m_local_size;
+  }
+
+  constexpr std::pair<int, int> rank_to_nl() const {
+    return {m_node_rank, m_local_rank};
+  }
+  inline std::pair<int, int> rank_to_nl(const int rank) const {
+    return {node_id(rank), local_id(rank)};
+  }
+
+  inline int nl_to_rank(const int nid, const int lid) const {
+    _check_node_rank(nid);
+    _check_local_rank(lid);
+    return nid * m_local_size + lid;
+  }
+  inline int nl_to_rank(const std::pair<int, int> pid) const {
+    return nl_to_rank(pid.first, pid.second);
+  }
+
+  inline bool is_local(const int rank) const {
+    _check_local_rank(rank);
+    return m_node_rank == node_id(rank);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Cached data
+  //////////////////////////////////////////////////////////////////////////////
+
+  // constexpr const std::vector<int> &local_ranks() const {
+  //   return m_local_ranks;
+  // }
+  // constexpr const std::vector<int> &node_ranks() const { return m_node_ranks;
+  // } constexpr const std::vector<int> &rank_to_local() const {
+  //   return m_rank_to_local;
+  // }
+  // constexpr const std::vector<int> &rank_to_node() const {
+  //   return m_rank_to_node;
+  // }
+
+ private:
+  inline void _check_world_rank(const int rank) const {
+    _check_rank(rank, m_world_size, "world");
+  }
+  inline void _check_local_rank(const int local_rank) const {
+    _check_rank(local_rank, m_local_size, "local");
+  }
+  inline void _check_node_rank(const int node_rank) const {
+    _check_rank(node_rank, m_node_size, "node");
+  }
+  inline void _check_rank(const int rank, const int size,
+                          const char *scope) const {
+    if (rank < 0 || rank > m_world_size) {
+      std::stringstream ss;
+      ss << scope << " rank " << rank << " is not in the range [0, "
+         << m_world_size << "]";
+      throw std::logic_error(ss.str());
+    }
+  }
+};
+
+}  // namespace ygm

--- a/include/ygm/detail/layout.hpp
+++ b/include/ygm/detail/layout.hpp
@@ -18,11 +18,11 @@ class Layout {
   int m_world_size;
   int m_world_rank;
   int m_node_size;
-  int m_node_rank;
+  int m_node_id;
   int m_local_size;
-  int m_local_rank;
+  int m_local_id;
 
-  std::vector<int> m_node_ranks;
+  std::vector<int> m_strided_ranks;
   std::vector<int> m_local_ranks;
 
   std::vector<int> m_rank_to_node;
@@ -39,20 +39,20 @@ class Layout {
     ASSERT_MPI(MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, m_world_rank,
                                    MPI_INFO_NULL, &comm_local));
     ASSERT_MPI(MPI_Comm_size(comm_local, &m_local_size));
-    ASSERT_MPI(MPI_Comm_rank(comm_local, &m_local_rank));
+    ASSERT_MPI(MPI_Comm_rank(comm_local, &m_local_id));
 
     _mpi_allgather(m_world_rank, m_local_ranks, m_local_size, comm_local);
 
     // node ranks
     MPI_Comm comm_node;
-    ASSERT_MPI(MPI_Comm_split(comm, m_local_rank, m_world_rank, &comm_node));
+    ASSERT_MPI(MPI_Comm_split(comm, m_local_id, m_world_rank, &comm_node));
     ASSERT_MPI(MPI_Comm_size(comm_node, &m_node_size));
-    ASSERT_MPI(MPI_Comm_rank(comm_node, &m_node_rank));
+    ASSERT_MPI(MPI_Comm_rank(comm_node, &m_node_id));
 
-    _mpi_allgather(m_world_rank, m_node_ranks, m_node_size, comm_node);
+    _mpi_allgather(m_world_rank, m_strided_ranks, m_node_size, comm_node);
 
-    _mpi_allgather(m_local_rank, m_rank_to_local, m_world_size, comm);
-    _mpi_allgather(m_node_rank, m_rank_to_node, m_world_size, comm);
+    _mpi_allgather(m_local_id, m_rank_to_local, m_world_size, comm);
+    _mpi_allgather(m_node_id, m_rank_to_node, m_world_size, comm);
 
     ASSERT_RELEASE(MPI_Comm_free(&comm_local) == MPI_SUCCESS);
     ASSERT_RELEASE(MPI_Comm_free(&comm_node) == MPI_SUCCESS);
@@ -62,10 +62,10 @@ class Layout {
       : m_world_size(rhs.m_world_size),
         m_world_rank(rhs.m_world_rank),
         m_node_size(rhs.m_node_size),
-        m_node_rank(rhs.m_node_rank),
+        m_node_id(rhs.m_node_id),
         m_local_size(rhs.m_local_size),
-        m_local_rank(rhs.m_local_rank),
-        m_node_ranks(rhs.m_node_ranks),
+        m_local_id(rhs.m_local_id),
+        m_strided_ranks(rhs.m_strided_ranks),
         m_local_ranks(rhs.m_local_ranks),
         m_rank_to_node(rhs.m_rank_to_node),
         m_rank_to_local(rhs.m_rank_to_local) {}
@@ -76,10 +76,10 @@ class Layout {
     std::swap(lhs.m_world_size, rhs.m_world_size);
     std::swap(lhs.m_world_rank, rhs.m_world_rank);
     std::swap(lhs.m_node_size, rhs.m_node_size);
-    std::swap(lhs.m_node_rank, rhs.m_node_rank);
+    std::swap(lhs.m_node_id, rhs.m_node_id);
     std::swap(lhs.m_local_size, rhs.m_local_size);
-    std::swap(lhs.m_local_rank, rhs.m_local_rank);
-    std::swap(lhs.m_node_ranks, rhs.m_node_ranks);
+    std::swap(lhs.m_local_id, rhs.m_local_id);
+    std::swap(lhs.m_strided_ranks, rhs.m_strided_ranks);
     std::swap(lhs.m_local_ranks, rhs.m_local_ranks);
     std::swap(lhs.m_rank_to_node, rhs.m_rank_to_node);
     std::swap(lhs.m_rank_to_local, rhs.m_rank_to_local);
@@ -87,26 +87,34 @@ class Layout {
 
   ~Layout() {}
 
+  //////////////////////////////////////////////////////////////////////////////
+  // global layout info
+  //////////////////////////////////////////////////////////////////////////////
+
   constexpr int size() const { return m_world_size; }
   constexpr int rank() const { return m_world_rank; }
 
   constexpr int node_size() const { return m_node_size; }
   constexpr int local_size() const { return m_local_size; }
 
-  constexpr int node_id() const { return m_node_rank; }
+  //////////////////////////////////////////////////////////////////////////////
+  // global perspective rank layout lookups
+  //////////////////////////////////////////////////////////////////////////////
+
+  constexpr int node_id() const { return m_node_id; }
   inline int    node_id(const int rank) const {
     _check_world_rank(rank);
     return m_rank_to_node.at(rank);
   }
 
-  constexpr int local_id() const { return m_local_rank; }
+  constexpr int local_id() const { return m_local_id; }
   inline int    local_id(const int rank) const {
     _check_world_rank(rank);
     return m_rank_to_local.at(rank);
   }
 
   constexpr std::pair<int, int> rank_to_nl() const {
-    return {m_node_rank, m_local_rank};
+    return {m_node_id, m_local_id};
   }
   inline std::pair<int, int> rank_to_nl(const int rank) const {
     return {node_id(rank), local_id(rank)};
@@ -121,9 +129,28 @@ class Layout {
     return nl_to_rank(pid.first, pid.second);
   }
 
+  //////////////////////////////////////////////////////////////////////////////
+  // local perspective rank layout lookups
+  //////////////////////////////////////////////////////////////////////////////
+
+  inline bool is_strided(const int rank) const {
+    _check_world_rank(rank);
+    return m_local_id == local_id(rank);
+  }
   inline bool is_local(const int rank) const {
-    _check_local_rank(rank);
-    return m_node_rank == node_id(rank);
+    _check_world_rank(rank);
+    return m_node_id == node_id(rank);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // cached local and strided ranks
+  //////////////////////////////////////////////////////////////////////////////
+
+  constexpr const std::vector<int> &strided_ranks() const {
+    return m_strided_ranks;
+  }
+  constexpr const std::vector<int> &local_ranks() const {
+    return m_local_ranks;
   }
 
  private:

--- a/include/ygm/detail/layout.hpp
+++ b/include/ygm/detail/layout.hpp
@@ -17,15 +17,16 @@ class Layout {
  private:
   int m_world_size;
   int m_world_rank;
-  int m_local_size;
-  int m_local_rank;
   int m_node_size;
   int m_node_rank;
+  int m_local_size;
+  int m_local_rank;
 
-  std::vector<int> m_local_ranks;
   std::vector<int> m_node_ranks;
-  std::vector<int> m_rank_to_local;
+  std::vector<int> m_local_ranks;
+
   std::vector<int> m_rank_to_node;
+  std::vector<int> m_rank_to_local;
 
  public:
   Layout(MPI_Comm comm) {
@@ -60,10 +61,10 @@ class Layout {
   Layout(const Layout &rhs)
       : m_world_size(rhs.m_world_size),
         m_world_rank(rhs.m_world_rank),
-        m_local_size(rhs.m_local_size),
-        m_local_rank(rhs.m_local_rank),
         m_node_size(rhs.m_node_size),
         m_node_rank(rhs.m_node_rank),
+        m_local_size(rhs.m_local_size),
+        m_local_rank(rhs.m_local_rank),
         m_node_ranks(rhs.m_node_ranks),
         m_local_ranks(rhs.m_local_ranks),
         m_rank_to_node(rhs.m_rank_to_node),
@@ -74,12 +75,12 @@ class Layout {
   friend void swap(Layout &lhs, Layout &rhs) {
     std::swap(lhs.m_world_size, rhs.m_world_size);
     std::swap(lhs.m_world_rank, rhs.m_world_rank);
-    std::swap(lhs.m_local_size, rhs.m_local_size);
-    std::swap(lhs.m_local_rank, rhs.m_local_rank);
     std::swap(lhs.m_node_size, rhs.m_node_size);
     std::swap(lhs.m_node_rank, rhs.m_node_rank);
-    std::swap(lhs.m_local_ranks, rhs.m_local_ranks);
+    std::swap(lhs.m_local_size, rhs.m_local_size);
+    std::swap(lhs.m_local_rank, rhs.m_local_rank);
     std::swap(lhs.m_node_ranks, rhs.m_node_ranks);
+    std::swap(lhs.m_local_ranks, rhs.m_local_ranks);
     std::swap(lhs.m_rank_to_node, rhs.m_rank_to_node);
     std::swap(lhs.m_rank_to_local, rhs.m_rank_to_local);
   }

--- a/include/ygm/detail/layout.hpp
+++ b/include/ygm/detail/layout.hpp
@@ -12,8 +12,9 @@
 #include <ygm/detail/mpi.hpp>
 
 namespace ygm {
+namespace detail {
 
-class Layout {
+class layout {
  private:
   int m_world_size;
   int m_world_rank;
@@ -29,7 +30,7 @@ class Layout {
   std::vector<int> m_rank_to_local;
 
  public:
-  Layout(MPI_Comm comm) {
+  layout(MPI_Comm comm) {
     // global ranks
     ASSERT_MPI(MPI_Comm_size(comm, &m_world_size));
     ASSERT_MPI(MPI_Comm_rank(comm, &m_world_rank));
@@ -58,7 +59,7 @@ class Layout {
     ASSERT_RELEASE(MPI_Comm_free(&comm_node) == MPI_SUCCESS);
   }
 
-  Layout(const Layout &rhs)
+  layout(const layout &rhs)
       : m_world_size(rhs.m_world_size),
         m_world_rank(rhs.m_world_rank),
         m_node_size(rhs.m_node_size),
@@ -70,9 +71,9 @@ class Layout {
         m_rank_to_node(rhs.m_rank_to_node),
         m_rank_to_local(rhs.m_rank_to_local) {}
 
-  Layout() {}
+  layout() {}
 
-  friend void swap(Layout &lhs, Layout &rhs) {
+  friend void swap(layout &lhs, layout &rhs) {
     std::swap(lhs.m_world_size, rhs.m_world_size);
     std::swap(lhs.m_world_rank, rhs.m_world_rank);
     std::swap(lhs.m_node_size, rhs.m_node_size);
@@ -85,7 +86,7 @@ class Layout {
     std::swap(lhs.m_rank_to_local, rhs.m_rank_to_local);
   }
 
-  ~Layout() {}
+  ~layout() {}
 
   //////////////////////////////////////////////////////////////////////////////
   // global layout info
@@ -181,4 +182,5 @@ class Layout {
   }
 };
 
+}  // namespace detail
 }  // namespace ygm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_ygm_seq_test(test_cereal_archive)
 
 add_ygm_test(test_comm)
 add_ygm_test(test_comm_2)
+add_ygm_test(test_layout)
 add_ygm_test(test_large_messages)
 add_ygm_test(test_map)
 add_ygm_test(test_multimap)

--- a/test/test_layout.cpp
+++ b/test/test_layout.cpp
@@ -1,0 +1,82 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+#include <ygm/comm.hpp>
+#include <ygm/detail/layout.hpp>
+
+int main(int argc, char** argv) {
+  ygm::comm world(&argc, &argv);
+
+  //
+  // node counts agree
+  {
+    int node_count(world.layout().node_count());
+    int min_node_count = world.all_reduce_min(node_count);
+    world.barrier();
+    // world.cout0("node count: ", min_node_count);
+    ASSERT_RELEASE(min_node_count == node_count);
+  }
+
+  //
+  // local counts agree
+  {
+    int local_count(world.layout().local_count());
+    int min_local_count = world.all_reduce_min(local_count);
+    world.barrier();
+    // world.cout0("local count: ", min_local_count);
+    ASSERT_RELEASE(min_local_count == local_count);
+  }
+
+  //
+  // local and node id computations agree locally
+  {
+    for (int dst(0); dst < world.size(); ++dst) {
+      auto p = world.layout().rank_to_nl(dst);
+      ASSERT_RELEASE(p.first == world.layout().node_id(dst));
+      ASSERT_RELEASE(p.second == world.layout().local_id(dst));
+    }
+    world.barrier();
+  }
+
+  //
+  // local and node id computations agree globally
+  {
+    if (world.rank0()) {
+      for (int dst(0); dst < world.size(); ++dst) {
+        auto check_fn = [](auto pcomm, int node_guess, int local_guess) {
+          // std::cout << "I am: " << pcomm->rank()
+          //           << ", local: " << pcomm->layout().local_id()
+          //           << ", local guess is: " << guess << std::endl;
+          ASSERT_RELEASE(pcomm->layout().node_id() == node_guess);
+          ASSERT_RELEASE(pcomm->layout().local_id() == local_guess);
+        };
+        auto p = world.layout().rank_to_nl(dst);
+        world.async(dst, check_fn, p.first, p.second);
+      }
+    }
+    world.barrier();
+  }
+
+  //
+  // is_local() is correct
+  {
+    auto check_fn = [](auto pcomm, int rank, bool tru) {
+      // std::cout << "I am: " << pcomm->layout().rank() << ", my node id is "
+      //           << pcomm->layout().node_id() << " and I am "
+      //           << ((pcomm->layout().is_local(rank)) ? "" : "not ")
+      //           << "local to rank " << rank << std::endl;
+      ASSERT_RELEASE(pcomm->layout().is_local(rank) == tru);
+    };
+
+    bool target = (world.layout().node_id() == 0) ? true : false;
+    // world.cout("node id:", world.layout().node_id(), "target: ", target);
+    // world.cout(world.layout().node_id(), ", ", world.layout().local_id());
+    world.async(0, check_fn, world.layout().rank(), target);
+    world.barrier();
+  }
+
+  return 0;
+}

--- a/test/test_layout.cpp
+++ b/test/test_layout.cpp
@@ -11,23 +11,21 @@ int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
 
   //
-  // node counts agree
+  // node sizes agree
   {
-    int node_count(world.layout().node_count());
-    int min_node_count = world.all_reduce_min(node_count);
+    int node_size(world.layout().node_size());
+    int min_node_size = world.all_reduce_min(node_size);
     world.barrier();
-    // world.cout0("node count: ", min_node_count);
-    ASSERT_RELEASE(min_node_count == node_count);
+    ASSERT_RELEASE(min_node_size == node_size);
   }
 
   //
-  // local counts agree
+  // local sizes agree
   {
-    int local_count(world.layout().local_count());
-    int min_local_count = world.all_reduce_min(local_count);
+    int local_size(world.layout().local_size());
+    int min_local_size = world.all_reduce_min(local_size);
     world.barrier();
-    // world.cout0("local count: ", min_local_count);
-    ASSERT_RELEASE(min_local_count == local_count);
+    ASSERT_RELEASE(min_local_size == local_size);
   }
 
   //
@@ -47,9 +45,6 @@ int main(int argc, char** argv) {
     if (world.rank0()) {
       for (int dst(0); dst < world.size(); ++dst) {
         auto check_fn = [](auto pcomm, int node_guess, int local_guess) {
-          // std::cout << "I am: " << pcomm->rank()
-          //           << ", local: " << pcomm->layout().local_id()
-          //           << ", local guess is: " << guess << std::endl;
           ASSERT_RELEASE(pcomm->layout().node_id() == node_guess);
           ASSERT_RELEASE(pcomm->layout().local_id() == local_guess);
         };
@@ -64,16 +59,10 @@ int main(int argc, char** argv) {
   // is_local() is correct
   {
     auto check_fn = [](auto pcomm, int rank, bool tru) {
-      // std::cout << "I am: " << pcomm->layout().rank() << ", my node id is "
-      //           << pcomm->layout().node_id() << " and I am "
-      //           << ((pcomm->layout().is_local(rank)) ? "" : "not ")
-      //           << "local to rank " << rank << std::endl;
       ASSERT_RELEASE(pcomm->layout().is_local(rank) == tru);
     };
 
     bool target = (world.layout().node_id() == 0) ? true : false;
-    // world.cout("node id:", world.layout().node_id(), "target: ", target);
-    // world.cout(world.layout().node_id(), ", ", world.layout().local_id());
     world.async(0, check_fn, world.layout().rank(), target);
     world.barrier();
   }


### PR DESCRIPTION
Right now, ygm::comm::layout() turns a const reference to an instance of the ygm::Layout class. I tried to instead keep a const public ygm::Layout member in ygm::comm, but the comm/comm_impl pattern made that difficult.