### PR TITLE
More granular CI triggers

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,6 +1,10 @@
 name: CI Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ main, develop ]
+  push:
+    branches: [ 'feature/**', 'hotfix/**']
 
 env:
   BUILD_TYPE: Release


### PR DESCRIPTION
Changing triggers so that CI runs on PRs to main/develop and pushes to feature/** and hotfix/** branches. Addresses issue #87.