### PR TITLE
Feature/interrupt mask

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -14,9 +14,15 @@
 
 namespace ygm {
 
+namespace detail {
+class interrupt_mask;
+}
+
 class comm {
  private:
   class impl;
+  // class detail::interrupt_mask;
+  friend class detail::interrupt_mask;
 
  public:
   comm(int *argc, char ***argv, int buffer_capacity);

--- a/include/ygm/container/detail/map_impl.hpp
+++ b/include/ygm/container/detail/map_impl.hpp
@@ -107,7 +107,7 @@ class map_impl {
         ASSERT_DEBUG(range.first != range.second);
       }
 
-      detail::interrupt_mask mask(m_comm);
+      ygm::detail::interrupt_mask mask(m_comm);
 
       Visitor *vis = nullptr;
       ygm::meta::apply_optional(
@@ -269,7 +269,7 @@ class map_impl {
   template <typename Function, typename... VisitorArgs>
   void local_visit(const key_type &key, Function &fn,
                    const VisitorArgs &...args) {
-    detail::interrupt_mask mask(m_comm);
+    ygm::detail::interrupt_mask mask(m_comm);
 
     auto range = m_local_map.equal_range(key);
     for (auto itr = range.first; itr != range.second; ++itr) {

--- a/include/ygm/container/detail/map_impl.hpp
+++ b/include/ygm/container/detail/map_impl.hpp
@@ -107,7 +107,7 @@ class map_impl {
         ASSERT_DEBUG(range.first != range.second);
       }
 
-      ygm::detail::interrupt_mask mask(m_comm);
+      ygm::detail::interrupt_mask mask(pmap->m_comm);
 
       Visitor *vis = nullptr;
       ygm::meta::apply_optional(

--- a/include/ygm/container/detail/map_impl.hpp
+++ b/include/ygm/container/detail/map_impl.hpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <ygm/comm.hpp>
 #include <ygm/container/detail/hash_partitioner.hpp>
+#include <ygm/detail/interrupt_mask.hpp>
 #include <ygm/detail/ygm_ptr.hpp>
 
 namespace ygm::container::detail {

--- a/include/ygm/detail/interrupt_mask.hpp
+++ b/include/ygm/detail/interrupt_mask.hpp
@@ -1,0 +1,30 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <ygm/comm.hpp>
+
+namespace ygm {
+
+namespace detail {
+
+class interrupt_mask {
+ public:
+  interrupt_mask(ygm::comm &c) : m_comm(c) {
+    m_comm.pimpl->m_enable_interrupts = false;
+  }
+
+  ~interrupt_mask() {
+    m_comm.pimpl->m_enable_interrupts = true;
+    m_comm.pimpl->process_receive_queue();
+  }
+
+ private:
+  ygm::comm &m_comm;
+};
+
+}  // namespace detail
+}  // namespace ygm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_ygm_test(test_line_parser)
 add_ygm_test(test_csv_parser)
 add_ygm_test(test_multi_output)
 add_ygm_test(test_daily_output)
+add_ygm_test(test_interrupt_mask)
 
 if (Boost_FOUND)
     add_ygm_seq_test(test_cereal_boost_json)

--- a/test/test_interrupt_mask.cpp
+++ b/test/test_interrupt_mask.cpp
@@ -1,0 +1,36 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+#include <ygm/comm.hpp>
+#include <ygm/detail/interrupt_mask.hpp>
+
+int main(int argc, char** argv) {
+  ygm::comm world(&argc, &argv, 8);
+
+  int  count{0};
+  auto count_ptr = world.make_ygm_ptr(count);
+  int  num_sends{100};
+  {
+    ygm::detail::interrupt_mask mask(world);
+
+    for (int i = 0; i < num_sends; ++i) {
+      world.async(
+          0, [](auto count_ptr) { ++(*count_ptr); }, count_ptr);
+    }
+
+    world.cf_barrier();
+
+    ASSERT_RELEASE(count == 0);
+  }
+
+  world.barrier();
+
+  if (world.rank0()) {
+    ASSERT_RELEASE(count == num_sends * world.size());
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Adds an RAII-style interrupt mask to temporarily prevent messages being received from being processed. Uses this interrupt mask to prevent incoming messages from invalidating iterators used internally in ygm::container::detail::map_impl during async_visit types of operations.