### PR TITLE
Feature/single threaded overhaul

### DIFF
--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -9,7 +9,7 @@
 int main(int argc, char** argv) {
   // Construct a communicator that sends messages when it has 32MB of used send
   // buffer space
-  ygm::comm world(&argc, &argv, 32 * 1024 * 1024);
+  ygm::comm world(&argc, &argv);
 
   // Define a "hello world" lambda to execute on a remote rank
   auto hello_world_lambda = [](const std::string& name) {

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -16,13 +16,14 @@ namespace ygm {
 
 namespace detail {
 class interrupt_mask;
-}
+class comm_stats;
+}  // namespace detail
 
 class comm {
  private:
   class impl;
-  // class detail::interrupt_mask;
   friend class detail::interrupt_mask;
+  friend class detail::comm_stats;
 
  public:
   comm(int *argc, char ***argv);
@@ -42,6 +43,9 @@ class comm {
    *
    */
   void welcome(std::ostream &os = std::cout);
+
+  void stats_reset();
+  void stats_print(const std::string &name = "", std::ostream &os = std::cout);
 
   //
   //  Asynchronous rpc interfaces.   Can be called inside OpenMP loop
@@ -104,16 +108,6 @@ class comm {
   int rank() const;
 
   const detail::layout &layout() const;
-
-  //
-  //	Counters
-  //
-  int64_t local_bytes_sent() const;
-  int64_t global_bytes_sent() const;
-  void    reset_bytes_sent_counter();
-  int64_t local_rpc_calls() const;
-  int64_t global_rpc_calls() const;
-  void    reset_rpc_call_counter();
 
   std::ostream &cout0() const {
     static std::ostringstream dummy;

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -25,11 +25,11 @@ class comm {
   friend class detail::interrupt_mask;
 
  public:
-  comm(int *argc, char ***argv, int buffer_capacity);
+  comm(int *argc, char ***argv);
 
   // TODO:  Add way to detect if this MPI_Comm is already open. E.g., static
   // map<MPI_Comm, impl*>
-  comm(MPI_Comm comm, int buffer_capacity);
+  comm(MPI_Comm comm);
 
   // Constructor to allow comm::impl to build temporary comm using itself as the
   // impl

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -37,6 +37,12 @@ class comm {
 
   ~comm();
 
+  /**
+   * @brief Prints a welcome message with configuration details.
+   *
+   */
+  void welcome(std::ostream &os = std::cout);
+
   //
   //  Asynchronous rpc interfaces.   Can be called inside OpenMP loop
   //

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -1,0 +1,100 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdlib>
+#include <sstream>
+#include <string>
+
+namespace ygm {
+
+namespace detail {
+
+/**
+ * @brief Configuration enviornment for ygm::comm.
+ *
+ * @todo Add support for a ".ygm" file and YGM_CONFIG_FILE.
+ */
+class comm_environment {
+  /**
+   * @brief Converts char* to type T
+   */
+  template <typename T>
+  T convert(const char* str) {
+    std::stringstream sstr;
+    sstr << str;
+    T to_return;
+    sstr >> to_return;
+    return to_return;
+  }
+
+ public:
+  comm_environment() {
+    if (const char* cc = std::getenv("YGM_COMM_BUFFER_SIZE_KB")) {
+      buffer_size = convert<size_t>(cc) * 1024;
+    }
+    if (const char* cc = std::getenv("YGM_COMM_NUM_IRECVS")) {
+      num_irecvs = convert<size_t>(cc);
+    }
+    if (const char* cc = std::getenv("YGM_COMM_IRECV_SIZE_KB")) {
+      irecv_size = convert<size_t>(cc) * 1024;
+    }
+    if (const char* cc = std::getenv("YGM_COMM_PRINT_CONFIG")) {
+      print_config = convert<bool>(cc) * 1024;
+    }
+    if (const char* cc = std::getenv("YGM_COMM_ENABLE_ROUTING")) {
+      if (std::string(cc) == "NONE") {
+        enable_routing = NONE;
+      } else if (std::string(cc) == "NR") {
+        enable_routing = NR;
+      } else if (std::string(cc) == "NLNR") {
+        enable_routing = NLNR;
+      } else {
+        throw std::runtime_error("comm_enviornment -- unknown routing type");
+      }
+    }
+  }
+
+  void print() const {
+    using std::cout;
+    cout << "========= YGM COMM ENVIORNMENT =========\n"
+         << "YGM_COMM_BUFFER_SIZE_KB  = " << buffer_size / 1024 << "\n"
+         << "YGM_COMM_NUM_IRECVS      = " << num_irecvs << "\n"
+         << "YGM_COMM_IRECVS_SIZE_KB  = " << irecv_size / 1024 << "\n"
+         << "YGM_COMM_NUM_ISENDS_WAIT = " << num_isends_wait << "\n"
+         << "YGM_COMM_ENABLE_ROUTING  = ";
+    switch (enable_routing) {
+      case NONE:
+        std::cout << "NONE\n";
+        break;
+      case NR:
+        std::cout << "NR\n";
+        break;
+      case NLNR:
+        std::cout << "NLNR\n";
+        break;
+    }
+    cout << "========================================"
+         << "\n";
+  }
+
+  //
+  // variables with their default values
+  size_t buffer_size = 16 * 1024 * 1024;
+
+  size_t irecv_size = 1024 * 1024 * 1024;
+  size_t num_irecvs = 8;
+
+  size_t num_isends_wait = 4;
+
+  bool print_config = false;
+
+  enum routing_type { NONE = 0, NR = 1, NLNR = 2 };
+  routing_type enable_routing = NONE;
+};
+
+}  // namespace detail
+}  // namespace ygm

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -42,43 +42,42 @@ class comm_environment {
     if (const char* cc = std::getenv("YGM_COMM_IRECV_SIZE_KB")) {
       irecv_size = convert<size_t>(cc) * 1024;
     }
-    if (const char* cc = std::getenv("YGM_COMM_PRINT_CONFIG")) {
-      print_config = convert<bool>(cc) * 1024;
+    if (const char* cc = std::getenv("YGM_COMM_WELCOME")) {
+      welcome = convert<bool>(cc);
     }
-    if (const char* cc = std::getenv("YGM_COMM_ENABLE_ROUTING")) {
+    if (const char* cc = std::getenv("YGM_COMM_ROUTING")) {
       if (std::string(cc) == "NONE") {
-        enable_routing = NONE;
+        routing = NONE;
       } else if (std::string(cc) == "NR") {
-        enable_routing = NR;
+        routing = NR;
       } else if (std::string(cc) == "NLNR") {
-        enable_routing = NLNR;
+        routing = NLNR;
       } else {
         throw std::runtime_error("comm_enviornment -- unknown routing type");
       }
     }
   }
 
-  void print() const {
-    using std::cout;
-    cout << "========= YGM COMM ENVIORNMENT =========\n"
-         << "YGM_COMM_BUFFER_SIZE_KB  = " << buffer_size / 1024 << "\n"
-         << "YGM_COMM_NUM_IRECVS      = " << num_irecvs << "\n"
-         << "YGM_COMM_IRECVS_SIZE_KB  = " << irecv_size / 1024 << "\n"
-         << "YGM_COMM_NUM_ISENDS_WAIT = " << num_isends_wait << "\n"
-         << "YGM_COMM_ENABLE_ROUTING  = ";
-    switch (enable_routing) {
+  void print(std::ostream& os = std::cout) const {
+    os << "======== ENVIRONMENT SETTINGS ========\n"
+       << "YGM_COMM_BUFFER_SIZE_KB  = " << buffer_size / 1024 << "\n"
+       << "YGM_COMM_NUM_IRECVS      = " << num_irecvs << "\n"
+       << "YGM_COMM_IRECVS_SIZE_KB  = " << irecv_size / 1024 << "\n"
+       << "YGM_COMM_NUM_ISENDS_WAIT = " << num_isends_wait << "\n"
+       << "YGM_COMM_ROUTING         = ";
+    switch (routing) {
       case NONE:
-        std::cout << "NONE\n";
+        os << "NONE\n";
         break;
       case NR:
-        std::cout << "NR\n";
+        os << "NR\n";
         break;
       case NLNR:
-        std::cout << "NLNR\n";
+        os << "NLNR\n";
         break;
     }
-    cout << "========================================"
-         << "\n";
+    os << "YGM_COMM_WELCOME         = " << std::boolalpha << welcome << "\n"
+       << "======================================\n";
   }
 
   //
@@ -90,10 +89,10 @@ class comm_environment {
 
   size_t num_isends_wait = 4;
 
-  bool print_config = false;
-
   enum routing_type { NONE = 0, NR = 1, NLNR = 2 };
-  routing_type enable_routing = NONE;
+  routing_type routing = NONE;
+
+  bool welcome = false;
 };
 
 }  // namespace detail

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -76,8 +76,7 @@ class comm_environment {
         os << "NLNR\n";
         break;
     }
-    os << "YGM_COMM_WELCOME         = " << std::boolalpha << welcome << "\n"
-       << "======================================\n";
+    os << "======================================\n";
   }
 
   //

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -45,6 +45,12 @@ class comm_environment {
     if (const char* cc = std::getenv("YGM_COMM_WELCOME")) {
       welcome = convert<bool>(cc);
     }
+    if (const char* cc = std::getenv("YGM_COMM_NUM_ISENDS_WAIT")) {
+      num_isends_wait = convert<size_t>(cc);
+    }
+    if (const char* cc = std::getenv("YGM_COMM_ISSEND_FREQ")) {
+      freq_issend = convert<size_t>(cc);
+    }
     if (const char* cc = std::getenv("YGM_COMM_ROUTING")) {
       if (std::string(cc) == "NONE") {
         routing = NONE;
@@ -64,6 +70,7 @@ class comm_environment {
        << "YGM_COMM_NUM_IRECVS      = " << num_irecvs << "\n"
        << "YGM_COMM_IRECVS_SIZE_KB  = " << irecv_size / 1024 << "\n"
        << "YGM_COMM_NUM_ISENDS_WAIT = " << num_isends_wait << "\n"
+       << "YGM_COMM_ISSEND_FREQ     = " << freq_issend << "\n"
        << "YGM_COMM_ROUTING         = ";
     switch (routing) {
       case NONE:
@@ -87,6 +94,7 @@ class comm_environment {
   size_t num_irecvs = 8;
 
   size_t num_isends_wait = 4;
+  size_t freq_issend     = 8;
 
   enum routing_type { NONE = 0, NR = 1, NLNR = 2 };
   routing_type routing = NONE;

--- a/include/ygm/detail/comm_impl.hpp
+++ b/include/ygm/detail/comm_impl.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <x86intrin.h>
 #include <atomic>
 #include <deque>
 #include <memory>
@@ -22,10 +23,83 @@ namespace ygm {
 
 class comm::impl : public std::enable_shared_from_this<comm::impl> {
  private:
-  enum class ygm_tag : int { message, kill };
-  constexpr int to_mpi_tag(ygm_tag t) { return static_cast<int>(t); }
-
   friend class ygm::detail::interrupt_mask;
+
+  struct mpi_irecv_request {
+    std::shared_ptr<std::byte[]> buffer;
+    MPI_Request                  request;
+  };
+
+  struct mpi_isend_request {
+    std::shared_ptr<std::vector<std::byte>> buffer;
+    MPI_Request                             request;
+  };
+
+  struct header_t {
+    uint16_t message_size;
+    uint16_t dest;
+
+    template <typename Archive>
+    void serialize(Archive &ar) {
+      ar(message_size, dest);
+    }
+  };
+
+  struct env_configuration {
+    env_configuration() {}
+    size_t num_irecvs = 64;
+  };
+
+  // NR Routing
+  int next_hop(const int dest) {
+    // if (m_layout.is_local(dest)) {
+    //   return dest;
+    // } else {
+    //   // return m_layout.strided_ranks()[m_layout.node_id(dest)];
+    //   const auto [dest_node, dest_local] = m_layout.rank_to_nl(dest);
+    //   auto dest_layer_offset             = dest_node % m_layout.local_size();
+    //   if (m_layout.local_id() == dest_layer_offset) {
+    //     auto my_layer_offset = m_layout.node_id() % m_layout.local_size();
+    //     return m_layout.nl_to_rank(dest_node, my_layer_offset);
+    //   } else {
+    //     return m_layout.nl_to_rank(m_layout.node_id(), dest_layer_offset);
+    //   }
+    // }
+    //
+    //  Roger's hack
+    //
+    // static int tpn       = m_layout.local_size();
+    static int my_node   = m_comm_rank / m_layout.local_size();
+    static int my_offset = m_comm_rank % m_layout.local_size();
+    int        dest_node = dest / m_layout.local_size();
+    if (my_node == dest_node) {
+      return dest;
+    } else {
+      //      return dest_node * m_layout.local_size() + my_offset;
+      int responsible_core = (dest_node % m_layout.local_size()) +
+                             (my_node * m_layout.local_size());
+      if (m_comm_rank == responsible_core) {
+        return (dest_node * m_layout.local_size()) +
+               (my_node % m_layout.local_size());
+      } else {
+        return responsible_core;
+      }
+    }
+  }
+
+  size_t pack_header(std::vector<std::byte> &packed, const int dest,
+                     size_t size) {
+    size_t size_before = packed.size();
+
+    header_t h;
+    h.dest         = dest;
+    h.message_size = size;
+
+    cereal::YGMOutputArchive oarchive(packed);
+    oarchive(h);
+
+    return packed.size() - size_before;
+  }
 
  public:
   impl(MPI_Comm c, int buffer_capacity) : m_layout(c) {
@@ -37,22 +111,53 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
     m_buffer_capacity_bytes = buffer_capacity;
 
     m_vec_send_buffers.resize(m_comm_size);
-    // launch listener thread
-    m_listener = std::thread(&impl::listener_thread, this);
+
+    if (m_comm_rank == 0) {
+      std::cout << "config.num_irecvs = " << config.num_irecvs << std::endl;
+    }
+    for (size_t i = 0; i < config.num_irecvs; ++i) {
+      std::shared_ptr<std::byte[]> recv_buffer{
+          new std::byte[m_buffer_capacity_bytes / m_layout.local_size()]};
+      post_new_irecv(recv_buffer);
+    }
+
+    m_packing_buffer.reserve(1024);
   }
 
   ~impl() {
-    // send kill signal to self (listener thread)
-    ASSERT_RELEASE(MPI_Send(NULL, 0, MPI_BYTE, m_comm_rank,
-                            to_mpi_tag(ygm_tag::kill),
-                            m_comm_async) == MPI_SUCCESS);
-    // Join listener thread.
-    m_listener.join();
-    // Free cloned communicator.
     ASSERT_RELEASE(MPI_Barrier(m_comm_async) == MPI_SUCCESS);
+    if (m_comm_rank == 0) {
+      std::cout << "m_local_isend = " << m_local_isend << std::endl;
+      std::cout << "m_local_isend_test = " << m_local_isend_test << std::endl;
+      std::cout << "m_local_irecv = " << m_local_irecv << std::endl;
+      std::cout << "m_local_irecv_test = " << m_local_irecv_test << std::endl;
+      std::cout << "m_local_iallreduce_test = " << m_local_iallreduce_test
+                << std::endl;
+      std::cout << "m_local_iallreduce = " << m_local_iallreduce << std::endl;
+      std::cout << "m_mpi_wait_time = " << m_mpi_wait_time << std::endl;
+      std::cout << "m_enable_routing = " << m_enable_routing << std::endl;
+      std::cout << "m_buffer_capacity_bytes = " << m_buffer_capacity_bytes
+                << std::endl;
+    }
+
+    ASSERT_RELEASE(m_send_queue.empty());
+    ASSERT_RELEASE(m_send_dest_queue.empty());
+    ASSERT_RELEASE(m_send_buffer_bytes == 0);
+    ASSERT_RELEASE(m_isend_bytes == 0);
+
+    for (size_t i = 0; i < m_recv_queue.size(); ++i) {
+      ASSERT_RELEASE(MPI_Cancel(&(m_recv_queue[i].request)) == MPI_SUCCESS);
+    }
+    ASSERT_RELEASE(MPI_Barrier(m_comm_async) == MPI_SUCCESS);
+    if (m_comm_rank == 0) {
+      std::cout << "Last barrier" << std::endl;
+    }
     ASSERT_RELEASE(MPI_Comm_free(&m_comm_async) == MPI_SUCCESS);
     ASSERT_RELEASE(MPI_Comm_free(&m_comm_barrier) == MPI_SUCCESS);
     ASSERT_RELEASE(MPI_Comm_free(&m_comm_other) == MPI_SUCCESS);
+    if (m_comm_rank == 0) {
+      std::cout << "Last MPI_Comm_free" << std::endl;
+    }
   }
 
   int size() const { return m_comm_size; }
@@ -60,31 +165,52 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
 
   template <typename... SendArgs>
   void async(int dest, const SendArgs &...args) {
-    ASSERT_DEBUG(dest < m_comm_size);
-    static size_t recursion_detector = 0;
-    ++recursion_detector;
+    ASSERT_RELEASE(dest < m_comm_size);
+
+    // check_if_production_halt_required();
+
     m_send_count++;
 
     //
-    // add data to the to dest buffer
-    if (m_vec_send_buffers[dest].empty()) {
-      m_send_dest_queue.push_back(dest);
+    //
+    int next_dest = dest;
+    if (m_enable_routing) {
+      next_hop(dest);
     }
-    size_t bytes = pack_lambda(m_vec_send_buffers[dest],
+
+    //
+    // add data to the to dest buffer
+    if (m_vec_send_buffers[next_dest].empty()) {
+      m_send_dest_queue.push_back(next_dest);
+      m_vec_send_buffers[next_dest].reserve(m_buffer_capacity_bytes /
+                                            m_layout.local_size());
+    }
+
+    // // Add header without message size
+    size_t header_bytes = 0;
+    if (m_enable_routing) {
+      header_bytes = pack_header(m_vec_send_buffers[next_dest], dest, 0);
+      m_local_bytes_sent += header_bytes;
+      m_send_buffer_bytes += header_bytes;
+    }
+
+    size_t bytes = pack_lambda(m_vec_send_buffers[next_dest],
                                std::forward<const SendArgs>(args)...);
     m_local_bytes_sent += bytes;
     m_send_buffer_bytes += bytes;
 
+    // // Add message size to header
+    if (m_enable_routing) {
+      auto iter = m_vec_send_buffers[next_dest].end();
+      iter -= (header_bytes + bytes);
+      std::memcpy(&*iter, &bytes, sizeof(header_t::dest));
+    }
+
     //
     // Check if send buffer capacity has been exceeded
-    flush_to_capacity();
-
-    // If not experiencing recursion, check if listener has queued receives to
-    // process
-    if (recursion_detector == 1 && receive_queue_peek_size() > 0) {
-      process_receive_queue();
+    if (!in_process_receive_queue) {
+      flush_to_capacity();
     }
-    --recursion_detector;
   }
 
   template <typename... SendArgs>
@@ -120,6 +246,9 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
              previous_counts == current_counts)) {
       previous_counts = current_counts;
       current_counts  = barrier_reduce_counts();
+      if (current_counts.first != current_counts.second) {
+        flush_all_local_and_process_incoming();
+      }
     }
     ASSERT_RELEASE(m_pre_barrier_callbacks.empty());
     ASSERT_RELEASE(m_send_dest_queue.empty());
@@ -267,13 +396,36 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
     uint64_t local_counts[2]  = {m_recv_count, m_send_count};
     uint64_t global_counts[2] = {0, 0};
 
+    ASSERT_RELEASE(m_isend_bytes == 0);
+    ASSERT_RELEASE(m_send_buffer_bytes == 0);
+
     MPI_Request req = MPI_REQUEST_NULL;
     ASSERT_MPI(MPI_Iallreduce(local_counts, global_counts, 2, MPI_UINT64_T,
                               MPI_SUM, m_comm_barrier, &req));
-    int mpi_test_flag{0};
-    while (!mpi_test_flag) {
-      flush_all_local_and_process_incoming();
-      ASSERT_MPI(MPI_Test(&req, &mpi_test_flag, MPI_STATUS_IGNORE));
+    m_local_iallreduce++;
+    bool iallreduce_complete(false);
+    while (!iallreduce_complete) {
+      MPI_Request twin_req[2];
+      twin_req[0] = req;
+      twin_req[1] = m_recv_queue.front().request;
+
+      int        outcount;
+      int        twin_indices[2];
+      MPI_Status twin_status[2];
+      double     start_wait = MPI_Wtime();
+      ASSERT_MPI(
+          MPI_Waitsome(2, twin_req, &outcount, twin_indices, twin_status));
+      m_mpi_wait_time += MPI_Wtime() - start_wait;
+      for (int i = 0; i < outcount; ++i) {
+        if (twin_indices[i] == 0) {  // completed a Iallreduce
+          iallreduce_complete = true;
+          // std::cout << m_comm_rank << ": iallreduce_complete: " <<
+          // global_counts[0] << " " << global_counts[1] << std::endl;
+        } else {
+          handle_next_receive(twin_status[i]);
+          flush_all_local_and_process_incoming();
+        }
+      }
     }
     return {global_counts[0], global_counts[1]};
   }
@@ -285,12 +437,33 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
    */
   void flush_send_buffer(int dest) {
     if (m_vec_send_buffers[dest].size() > 0) {
-      ASSERT_MPI(MPI_Send(m_vec_send_buffers[dest].data(),
-                          m_vec_send_buffers[dest].size(), MPI_BYTE, dest,
-                          to_mpi_tag(ygm_tag::message), m_comm_async));
-      m_send_buffer_bytes -= m_vec_send_buffers[dest].size();
+      mpi_isend_request request;
+      if (m_free_send_buffers.empty()) {
+        request.buffer = std::make_shared<std::vector<std::byte>>();
+      } else {
+        request.buffer = m_free_send_buffers.back();
+        m_free_send_buffers.pop_back();
+      }
+      request.buffer->swap(m_vec_send_buffers[dest]);
+
+      ASSERT_MPI(MPI_Isend(request.buffer->data(), request.buffer->size(),
+                           MPI_BYTE, dest, 0, m_comm_async,
+                           &(request.request)));
+      m_local_isend++;
+      m_isend_bytes += request.buffer->size();
+      m_send_buffer_bytes -= request.buffer->size();
+      m_send_queue.push_back(request);
+      if (!in_process_receive_queue) {
+        process_receive_queue();
+      }
     }
-    m_vec_send_buffers[dest].clear();
+  }
+
+  void check_if_production_halt_required() {
+    while (m_enable_interrupts && !in_process_receive_queue &&
+           m_isend_bytes > m_buffer_capacity_bytes) {
+      process_receive_queue();
+    }
   }
 
   /**
@@ -320,6 +493,12 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
         flush_send_buffer(dest);
         process_receive_queue();
       }
+
+      //
+      // Wait on isends
+      while (!m_send_queue.empty()) {
+        did_something |= process_receive_queue();
+      }
     }
   }
 
@@ -336,60 +515,16 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
     }
   }
 
-  /**
-   * @brief Listener thread
-   *
-   */
-  void listener_thread() {
-    while (true) {
-      MPI_Status status;
-      ASSERT_MPI(MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, m_comm_async, &status));
+  void post_new_irecv(std::shared_ptr<std::byte[]> &recv_buffer) {
+    mpi_irecv_request recv_req;
+    recv_req.buffer = recv_buffer;
 
-      int count{0};
-      ASSERT_MPI(MPI_Get_count(&status, MPI_BYTE, &count));
-
-      int source = status.MPI_SOURCE;
-      int tag    = status.MPI_TAG;
-
-      std::shared_ptr<std::byte[]> recv_buffer{new std::byte[count]};
-
-      ASSERT_MPI(MPI_Recv(recv_buffer.get(), count, MPI_BYTE, source, tag,
-                          m_comm_async, &status));
-
-      // Check for kill signal
-      if (source == m_comm_rank && tag == to_mpi_tag(ygm_tag::kill)) break;
-
-      receive_queue_push_back(recv_buffer, count);
-    }
-  }
-
-  size_t receive_queue_peek_size() const { return m_recv_queue.size(); }
-
-  std::pair<std::shared_ptr<std::byte[]>, size_t> receive_queue_try_pop() {
-    std::scoped_lock lock(m_recv_queue_mutex);
-    if (m_recv_queue.empty()) {
-      ASSERT_RELEASE(m_recv_queue_bytes == 0);
-      return std::make_pair(std::shared_ptr<std::byte[]>{}, size_t{0});
-    } else {
-      auto to_return = m_recv_queue.front();
-      m_recv_queue.pop_front();
-      m_recv_queue_bytes -= to_return.second;
-      return to_return;
-    }
-  }
-
-  void receive_queue_push_back(const std::shared_ptr<std::byte[]> &b,
-                               size_t                              size) {
-    {
-      std::scoped_lock lock(m_recv_queue_mutex);
-      m_recv_queue.push_back({b, size});
-      m_recv_queue_bytes += size;
-    }
-    if (m_recv_queue_bytes > m_buffer_capacity_bytes) {
-      // Sleep a microsecond for every KB over.
-      std::this_thread::sleep_for(std::chrono::microseconds(
-          (m_recv_queue_bytes - m_buffer_capacity_bytes) / 1024));
-    }
+    ASSERT_MPI(MPI_Irecv(recv_req.buffer.get(),
+                         m_buffer_capacity_bytes / m_layout.local_size(),
+                         MPI_BYTE, MPI_ANY_SOURCE, MPI_ANY_TAG, m_comm_async,
+                         &(recv_req.request)));
+    m_local_irecv++;
+    m_recv_queue.push_back(recv_req);
   }
 
   template <typename Lambda, typename... PackArgs>
@@ -402,19 +537,51 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
 
     void (*fun_ptr)(comm *, cereal::YGMInputArchive &) =
         [](comm *c, cereal::YGMInputArchive &bia) {
-          std::tuple<PackArgs...> ta;
-          bia(ta);
           Lambda *pl = nullptr;
-          auto    t1 = std::make_tuple((comm *)c);
+          size_t  l_storage[sizeof(Lambda) / sizeof(size_t) +
+                           (sizeof(Lambda) % sizeof(size_t) > 0)];
+          if constexpr (!std::is_empty<Lambda>::value) {
+            bia.loadBinary(l_storage, sizeof(Lambda));
+            pl = (Lambda *)l_storage;
+          }
+
+          std::tuple<PackArgs...> ta;
+          if constexpr (!std::is_empty<std::tuple<PackArgs...>>::value) {
+            bia(ta);
+          }
+
+          auto t1 = std::make_tuple((comm *)c);
 
           // \pp was: std::apply(*pl, std::tuple_cat(t1, ta));
           ygm::meta::apply_optional(*pl, std::move(t1), std::move(ta));
         };
 
-    cereal::YGMOutputArchive oarchive(packed);  // Create an output archive
-                                                // // oarchive(fun_ptr);
+    // // oarchive(fun_ptr);
     int64_t iptr = (int64_t)fun_ptr - (int64_t)&reference;
-    oarchive(iptr, tuple_args);
+    // ptrdiff_t iptr = (void *)fun_ptr - reinterpret_cast<void *>(&reference);
+    ASSERT_RELEASE(iptr < std::numeric_limits<int32_t>::max() &&
+                   iptr > std::numeric_limits<int32_t>::min());
+    int32_t iptr_32 = iptr;
+
+    {
+      // oarchive(iptr_32);
+      size_t size_before = packed.size();
+      packed.resize(size_before + sizeof(iptr_32));
+      std::memcpy(packed.data() + size_before, &iptr_32, sizeof(iptr_32));
+    }
+
+    if constexpr (!std::is_empty<Lambda>::value) {
+      // oarchive.saveBinary(&l, sizeof(Lambda));
+      size_t size_before = packed.size();
+      packed.resize(size_before + sizeof(Lambda));
+      std::memcpy(packed.data() + size_before, &l, sizeof(Lambda));
+    }
+
+    if constexpr (!std::is_empty<std::tuple<PackArgs...>>::value) {
+      // Only create cereal archive is tuple needs serialization
+      cereal::YGMOutputArchive oarchive(packed);  // Create an output archive
+      oarchive(tuple_args);
+    }
     return packed.size() - size_before;
   }
 
@@ -424,37 +591,166 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
    */
   static void reference() {}
 
+  void handle_next_receive(MPI_Status status) {
+    comm tmp_comm(shared_from_this());
+    int  count{0};
+    ASSERT_MPI(MPI_Get_count(&status, MPI_BYTE, &count));
+    // std::cout << m_comm_rank << ": received " << count << std::endl;
+    cereal::YGMInputArchive iarchive(m_recv_queue.front().buffer.get(), count);
+    while (!iarchive.empty()) {
+      if (m_enable_routing) {
+        header_t h;
+        iarchive(h);
+        if (h.dest == m_comm_rank) {
+          int32_t iptr_32;
+          iarchive(iptr_32);
+          uint64_t iptr = iptr_32;
+          iptr += (int64_t)&reference;
+          void (*fun_ptr)(comm *, cereal::YGMInputArchive &);
+          std::memcpy(&fun_ptr, &iptr, sizeof(iptr));
+          fun_ptr(&tmp_comm, iarchive);
+          m_recv_count++;
+          m_local_rpc_calls++;
+        } else {
+          int next_dest = next_hop(h.dest);
+
+          if (m_vec_send_buffers[next_dest].empty()) {
+            m_send_dest_queue.push_back(next_dest);
+          }
+
+          size_t header_bytes = pack_header(m_vec_send_buffers[next_dest],
+                                            h.dest, h.message_size);
+          m_local_bytes_sent += header_bytes;
+          m_send_buffer_bytes += header_bytes;
+
+          size_t precopy_size = m_vec_send_buffers[next_dest].size();
+          m_vec_send_buffers[next_dest].resize(precopy_size + h.message_size);
+          iarchive.loadBinary(&m_vec_send_buffers[next_dest][precopy_size],
+                              h.message_size);
+
+          m_local_bytes_sent += h.message_size;
+          m_send_buffer_bytes += h.message_size;
+
+          flush_to_capacity();
+        }
+      } else {
+        int32_t iptr_32;
+        iarchive(iptr_32);
+        uint64_t iptr = iptr_32;
+        iptr += (int64_t)&reference;
+        void (*fun_ptr)(comm *, cereal::YGMInputArchive &);
+        std::memcpy(&fun_ptr, &iptr, sizeof(iptr));
+        fun_ptr(&tmp_comm, iarchive);
+        m_recv_count++;
+        m_local_rpc_calls++;
+      }
+      // //////////header_t h;
+      // iarchive(h);
+      // if (h.dest == m_comm_rank) {
+      // int64_t iptr;
+      // iarchive(iptr);
+      // iptr += (int64_t)&reference;
+      // void (*fun_ptr)(comm *, cereal::YGMInputArchive &);
+      // memcpy(&fun_ptr, &iptr, sizeof(uint64_t));
+      // fun_ptr(&tmp_comm, iarchive);
+      // m_recv_count++;
+      // m_local_rpc_calls++;
+      // } else {
+      //   int next_dest = next_hop(h.dest);
+
+      //   if (m_vec_send_buffers[next_dest].empty()) {
+      //     m_send_dest_queue.push_back(next_dest);
+      //   }
+
+      //   size_t header_bytes = pack_header(m_vec_send_buffers[next_dest],
+      //                                     h.dest, h.message_size);
+      //   m_local_bytes_sent += header_bytes;
+      //   m_send_buffer_bytes += header_bytes;
+
+      //   size_t precopy_size = m_vec_send_buffers[next_dest].size();
+      //   m_vec_send_buffers[next_dest].resize(precopy_size + h.message_size);
+      //   iarchive.loadBinary(&m_vec_send_buffers[next_dest][precopy_size],
+      //                       h.message_size);
+
+      //   m_local_bytes_sent += h.message_size;
+      //   m_send_buffer_bytes += h.message_size;
+      // }
+    }
+    post_new_irecv(m_recv_queue.front().buffer);
+    m_recv_queue.pop_front();
+    flush_to_capacity();
+  }
+
   /**
    * @brief Process receive queue of messages received by the listener thread.
    *
    * @return True if receive queue was non-empty, else false
    */
   bool process_receive_queue() {
+    ASSERT_RELEASE(!in_process_receive_queue);
+    in_process_receive_queue = true;
+    bool received_to_return  = false;
+
     if (!m_enable_interrupts) {
-      return false;
+      in_process_receive_queue = false;
+      return received_to_return;
     }
 
-    bool received = false;
-    comm tmp_comm(shared_from_this());
-    while (true) {
-      auto buffer = receive_queue_try_pop();
-      if (buffer.second == 0) break;
-      received = true;
-      cereal::YGMInputArchive iarchive(buffer.first.get(), buffer.second);
-      while (!iarchive.empty()) {
-        int64_t iptr;
-        iarchive(iptr);
-        iptr += (int64_t)&reference;
-        void (*fun_ptr)(comm *, cereal::YGMInputArchive &);
-        memcpy(&fun_ptr, &iptr, sizeof(uint64_t));
-        fun_ptr(&tmp_comm, iarchive);
-        m_recv_count++;
-        m_local_rpc_calls++;
+    //
+    // if we have a pending iRecv, then we can issue a Waitsome
+    if (m_send_queue.size() > config.num_irecvs) {
+      MPI_Request twin_req[2];
+      twin_req[0] = m_send_queue.front().request;
+      twin_req[1] = m_recv_queue.front().request;
 
-        flush_to_capacity();
+      int        outcount;
+      int        twin_indices[2];
+      MPI_Status twin_status[2];
+      double     start_wait = MPI_Wtime();
+      ASSERT_MPI(
+          MPI_Waitsome(2, twin_req, &outcount, twin_indices, twin_status));
+      m_mpi_wait_time += MPI_Wtime() - start_wait;
+      for (int i = 0; i < outcount; ++i) {
+        if (twin_indices[i] == 0) {  // completed a iSend
+          m_isend_bytes -= m_send_queue.front().buffer->size();
+          m_send_queue.front().buffer->clear();
+          m_free_send_buffers.push_back(m_send_queue.front().buffer);
+          m_send_queue.pop_front();
+        } else {  // completed an iRecv -- COPIED FROM BELOW
+          received_to_return = true;
+          handle_next_receive(twin_status[i]);
+        }
+      }
+    } else {
+      if (!m_send_queue.empty()) {
+        int flag(0);
+        ASSERT_MPI(MPI_Test(&(m_send_queue.front().request), &flag,
+                            MPI_STATUS_IGNORE));
+        m_local_isend_test++;
+        if (flag) {
+          m_isend_bytes -= m_send_queue.front().buffer->size();
+          m_send_queue.front().buffer->clear();
+          m_free_send_buffers.push_back(m_send_queue.front().buffer);
+          m_send_queue.pop_front();
+        }
       }
     }
-    return received;
+
+    while (true) {
+      int        flag(0);
+      MPI_Status status;
+      ASSERT_MPI(MPI_Test(&(m_recv_queue.front().request), &flag, &status));
+      m_local_irecv_test++;
+      if (flag) {
+        received_to_return = true;
+        handle_next_receive(status);
+      } else {
+        break;  // not ready yet
+      }
+    }
+
+    in_process_receive_queue = false;
+    return received_to_return;
   }
 
   MPI_Comm m_comm_async;
@@ -470,11 +766,12 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
   size_t                              m_send_buffer_bytes = 0;
   std::deque<int>                     m_send_dest_queue;
 
-  std::deque<std::pair<std::shared_ptr<std::byte[]>, size_t>> m_recv_queue;
-  std::mutex m_recv_queue_mutex;
-  size_t     m_recv_queue_bytes = 0;
+  std::deque<mpi_irecv_request>                        m_recv_queue;
+  std::deque<mpi_isend_request>                        m_send_queue;
+  std::vector<std::shared_ptr<std::vector<std::byte>>> m_free_send_buffers;
 
-  std::thread m_listener;
+  // size_t     m_recv_queue_bytes = 0;
+  size_t m_isend_bytes = 0;
 
   std::deque<std::function<void()>> m_pre_barrier_callbacks;
 
@@ -485,6 +782,22 @@ class comm::impl : public std::enable_shared_from_this<comm::impl> {
 
   int64_t m_local_rpc_calls  = 0;
   int64_t m_local_bytes_sent = 0;
+
+  bool in_process_receive_queue = false;
+
+  size_t m_local_isend           = 0;
+  size_t m_local_isend_test      = 0;
+  size_t m_local_irecv           = 0;
+  size_t m_local_irecv_test      = 0;
+  size_t m_local_iallreduce_test = 0;
+  size_t m_local_iallreduce      = 0;
+  double m_mpi_wait_time         = 0;
+
+  bool m_enable_routing = 0;
+
+  const env_configuration config;  // todo: make const?
+
+  std::vector<std::byte> m_packing_buffer;
 };
 
 inline comm::comm(int *argc, char ***argv,
@@ -520,23 +833,31 @@ inline comm::~comm() {
 
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async(int dest, AsyncFunction fn, const SendArgs &...args) {
-  static_assert(std::is_empty<AsyncFunction>::value,
-                "Only stateless lambdas are supported");
+  static_assert(std::is_trivially_copyable<AsyncFunction>::value &&
+                    std::is_standard_layout<AsyncFunction>::value,
+                "comm::async() AsyncFunction must be is_trivially_copyable & "
+                "is_standard_layout.");
   pimpl->async(dest, fn, std::forward<const SendArgs>(args)...);
 }
 
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async_bcast(AsyncFunction fn, const SendArgs &...args) {
-  static_assert(std::is_empty<AsyncFunction>::value,
-                "Only stateless lambdas are supported");
+  static_assert(
+      std::is_trivially_copyable<AsyncFunction>::value &&
+          std::is_standard_layout<AsyncFunction>::value,
+      "comm::async_bcast() AsyncFunction must be is_trivially_copyable & "
+      "is_standard_layout.");
   pimpl->async_bcast(fn, std::forward<const SendArgs>(args)...);
 }
 
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async_mcast(const std::vector<int> &dests, AsyncFunction fn,
                               const SendArgs &...args) {
-  static_assert(std::is_empty<AsyncFunction>::value,
-                "Only stateless lambdas are supported");
+  static_assert(
+      std::is_trivially_copyable<AsyncFunction>::value &&
+          std::is_standard_layout<AsyncFunction>::value,
+      "comm::async_mcast() AsyncFunction must be is_trivially_copyable & "
+      "is_standard_layout.");
   pimpl->async_mcast(dests, fn, std::forward<const SendArgs>(args)...);
 }
 

--- a/include/ygm/detail/comm_stats.hpp
+++ b/include/ygm/detail/comm_stats.hpp
@@ -1,0 +1,122 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <ygm/comm.hpp>
+
+namespace ygm {
+namespace detail {
+class comm_stats {
+ public:
+  class timer {
+   public:
+    timer(double& _timer) : m_timer(_timer), m_start_time(MPI_Wtime()) {}
+
+    ~timer() { m_timer += (MPI_Wtime() - m_start_time); }
+
+   private:
+    double& m_timer;
+    double  m_start_time;
+  };
+
+  comm_stats() : m_time_start(MPI_Wtime()) {}
+
+  void print(const std::string& name, std::ostream& os, ygm::comm& comm) {
+    std::stringstream sstr;
+    sstr << "============== STATS =================\n"
+         << "NAME                     = " << name << "\n"
+         << "TIME                     = " << MPI_Wtime() - m_time_start << "\n"
+         << "GLOBAL_ASYNC_COUNT       = " << comm.all_reduce_sum(m_async_count)
+         << "\n"
+         << "GLOBAL_ISEND_COUNT       = " << comm.all_reduce_sum(m_isend_count)
+         << "\n"
+         << "GLOBAL_ISEND_BYTES       = " << comm.all_reduce_sum(m_isend_bytes)
+         << "\n"
+         << "MAX_WAITSOME_ISEND_IRECV = "
+         << comm.all_reduce_max(m_waitsome_isend_irecv_time) << "\n"
+         << "MAX_WAITSOME_IALLREDUCE  = "
+         << comm.all_reduce_max(m_waitsome_iallreduce_time) << "\n"
+         << "COUNT_IALLREDUCE         = " << m_iallreduce_count << "\n"
+         << "======================================";
+    if (comm.rank0()) {
+      os << sstr.str() << std::endl;
+    }
+  }
+
+  void isend(int dest, size_t bytes) {
+    m_isend_count += 1;
+    m_isend_bytes += bytes;
+  }
+
+  void irecv(int source, size_t bytes) {
+    m_irecv_count += 1;
+    m_irecv_bytes += bytes;
+  }
+
+  void async(int dest) { m_async_count += 1; }
+
+  void rpc_execute() { m_rpc_count += 1; }
+
+  void routing() { m_route_count += 1; }
+
+  void isend_test() { m_isend_test_count += 1; }
+
+  void irecv_test() { m_irecv_test_count += 1; }
+
+  void iallreduce() { m_iallreduce_count += 1; }
+
+  timer waitsome_isend_irecv() {
+    m_waitsome_isend_irecv_count += 1;
+    return timer(m_waitsome_isend_irecv_time);
+  }
+
+  timer waitsome_iallreduce() {
+    m_waitsome_iallreduce_count += 1;
+    return timer(m_waitsome_iallreduce_time);
+  }
+
+  void reset() {
+    m_async_count                = 0;
+    m_rpc_count                  = 0;
+    m_route_count                = 0;
+    m_isend_count                = 0;
+    m_isend_bytes                = 0;
+    m_isend_test_count           = 0;
+    m_irecv_count                = 0;
+    m_irecv_bytes                = 0;
+    m_irecv_test_count           = 0;
+    m_waitsome_isend_irecv_time  = 0.0f;
+    m_waitsome_isend_irecv_count = 0.0f;
+    m_iallreduce_count           = 0;
+    m_waitsome_iallreduce_time   = 0.0f;
+    m_waitsome_iallreduce_count  = 0;
+    m_time_start                 = MPI_Wtime();
+  }
+
+ private:
+  size_t m_async_count = 0;
+  size_t m_rpc_count   = 0;
+  size_t m_route_count = 0;
+
+  size_t m_isend_count      = 0;
+  size_t m_isend_bytes      = 0;
+  size_t m_isend_test_count = 0;
+
+  size_t m_irecv_count      = 0;
+  size_t m_irecv_bytes      = 0;
+  size_t m_irecv_test_count = 0;
+
+  double m_waitsome_isend_irecv_time  = 0.0f;
+  size_t m_waitsome_isend_irecv_count = 0.0f;
+
+  size_t m_iallreduce_count          = 0;
+  double m_waitsome_iallreduce_time  = 0.0f;
+  size_t m_waitsome_iallreduce_count = 0;
+
+  double m_time_start = 0.0;
+};
+}  // namespace detail
+}  // namespace ygm

--- a/include/ygm/detail/interrupt_mask.hpp
+++ b/include/ygm/detail/interrupt_mask.hpp
@@ -19,7 +19,8 @@ class interrupt_mask {
 
   ~interrupt_mask() {
     m_comm.pimpl->m_enable_interrupts = true;
-    m_comm.pimpl->process_receive_queue();
+    // m_comm.pimpl->process_receive_queue();  //causes recursion into
+    // process_receive_queue
   }
 
  private:

--- a/include/ygm/detail/lambda_map.hpp
+++ b/include/ygm/detail/lambda_map.hpp
@@ -1,0 +1,53 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <vector>
+#include <ygm/detail/mpi.hpp>
+
+namespace ygm {
+namespace detail {
+
+template <typename CFuncPtr, typename FuncId>
+class lambda_map {
+  template <typename LambdaType>
+  struct lambda_enumerator {
+    const static FuncId id;
+  };
+
+ public:
+  using func_id = FuncId;
+
+  template <typename LambdaType>
+  static FuncId register_lambda(LambdaType l) {
+    return lambda_enumerator<LambdaType>::id;
+  }
+  template <typename... Args>
+  void execute(FuncId id, const Args... args) {
+    s_map[id](args...);
+  }
+
+ private:
+  template <typename LambdaType>
+  static FuncId record() {
+    ASSERT_RELEASE(s_map.size() < std::numeric_limits<FuncId>::max());
+    FuncId      to_return = s_map.size();
+    LambdaType *lp;  // scary, but by definition can't capture
+    s_map.push_back(*lp);
+    return to_return;
+  }
+  static std::vector<CFuncPtr> s_map;
+};
+template <typename CFuncPtr, typename FuncId>
+std::vector<CFuncPtr> lambda_map<CFuncPtr, FuncId>::s_map;
+
+template <typename CFuncPtr, typename FuncId>
+template <typename LambdaType>
+const FuncId lambda_map<CFuncPtr, FuncId>::lambda_enumerator<LambdaType>::id =
+    lambda_map<CFuncPtr, FuncId>::record<LambdaType>();
+
+}  // namespace detail
+}  // namespace ygm

--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -12,12 +12,13 @@ namespace ygm::detail {
 class mpi_init_finalize {
  public:
   mpi_init_finalize(int *argc, char ***argv) {
-    int provided;
-    ASSERT_MPI(MPI_Init_thread(argc, argv, MPI_THREAD_MULTIPLE, &provided));
-    if (provided != MPI_THREAD_MULTIPLE) {
-      throw std::runtime_error(
-          "MPI_Init_thread: MPI_THREAD_MULTIPLE not provided.");
-    }
+    ASSERT_MPI(MPI_Init(argc, argv));
+    // int provided;
+    // ASSERT_MPI(MPI_Init_thread(argc, argv, MPI_THREAD_MULTIPLE, &provided));
+    // if (provided != MPI_THREAD_MULTIPLE) {
+    //   throw std::runtime_error(
+    //       "MPI_Init_thread: MPI_THREAD_MULTIPLE not provided.");
+    // }
   }
   ~mpi_init_finalize() {
     ASSERT_RELEASE(MPI_Barrier(MPI_COMM_WORLD) == MPI_SUCCESS);

--- a/include/ygm/detail/ygm_cereal_archive.hpp
+++ b/include/ygm/detail/ygm_cereal_archive.hpp
@@ -44,9 +44,12 @@ class YGMOutputArchive
 
   //! Writes size bytes of data to the output stream
   void saveBinary(const void *data, std::streamsize size) {
-    const std::byte *cdata = reinterpret_cast<const std::byte *>(data);
-    vec_data.reserve(vec_data.size() + size);
-    vec_data.insert(vec_data.end(), cdata, cdata + size);
+    size_t vec_data_size_before = vec_data.size();
+    if (vec_data.capacity() < vec_data.size() + size) {
+      vec_data.reserve(vec_data.capacity() * 2);
+    }
+    vec_data.resize(vec_data.size() + size);
+    std::memcpy(vec_data.data() + vec_data_size_before, data, size);
 
     // if (writtenSize != size)
     //   throw Exception("Failed to write " + std::to_string(size) +
@@ -83,7 +86,7 @@ class YGMInputArchive
   //! Reads size bytes of data from the input stream
   void loadBinary(void *const data, std::streamsize size) {
     ASSERT_DEBUG(m_position + size <= m_capacity);
-    memcpy(data, m_pdata + m_position, size);
+    std::memcpy(data, m_pdata + m_position, size);
     m_position += size;
 
     // if (readSize != size)

--- a/performance/disjoint_set_union_chain.cpp
+++ b/performance/disjoint_set_union_chain.cpp
@@ -27,7 +27,8 @@ int main(int argc, char **argv) {
   world.cout0("Performing unions in random order");
 
   size_t num_local_unions =
-      num_unions / (size_t)world.size() + ((size_t)world.rank() < num_unions % (size_t)world.size());
+      num_unions / (size_t)world.size() +
+      ((size_t)world.rank() < num_unions % (size_t)world.size());
   size_t local_offset =
       (num_unions / (size_t)world.size()) * (size_t)world.rank() +
       std::min<size_t>((size_t)world.rank(), num_unions % (size_t)world.size());
@@ -51,7 +52,7 @@ int main(int argc, char **argv) {
 
     std::shuffle(my_unions.begin(), my_unions.end(), g);
 
-    world.reset_rpc_call_counter();
+    // world.reset_rpc_call_counter();
     world.barrier();
 
     ygm::timer union_timer{};
@@ -66,12 +67,12 @@ int main(int argc, char **argv) {
     world.cout0("Union time: ", union_time);
     cumulative_union_time += union_time;
 
-    world.cout0("\tMin RPC calls: ",
-                world.all_reduce_min(world.local_rpc_calls()));
-    world.cout0("\tMax RPC calls: ",
-                world.all_reduce_max(world.local_rpc_calls()));
+    // world.cout0("\tMin RPC calls: ",
+    //             world.all_reduce_min(world.local_rpc_calls()));
+    // world.cout0("\tMax RPC calls: ",
+    //             world.all_reduce_max(world.local_rpc_calls()));
 
-    world.reset_rpc_call_counter();
+    // world.reset_rpc_call_counter();
 
     world.barrier();
 
@@ -85,10 +86,10 @@ int main(int argc, char **argv) {
     world.cout0("Compress time: ", compress_time);
     cumulative_compress_time += compress_time;
 
-    world.cout0("\tMin RPC calls: ",
-                world.all_reduce_min(world.local_rpc_calls()));
-    world.cout0("\tMax RPC calls: ",
-                world.all_reduce_max(world.local_rpc_calls()));
+    // world.cout0("\tMin RPC calls: ",
+    //             world.all_reduce_min(world.local_rpc_calls()));
+    // world.cout0("\tMax RPC calls: ",
+    //             world.all_reduce_max(world.local_rpc_calls()));
 
     // Checking answer
     auto my_parents_star = dset.all_find(my_unions);
@@ -97,7 +98,7 @@ int main(int argc, char **argv) {
       ASSERT_RELEASE(item_parent.second == 1);
     }
 
-    world.reset_rpc_call_counter();
+    // world.reset_rpc_call_counter();
 
     world.barrier();
 
@@ -111,10 +112,10 @@ int main(int argc, char **argv) {
     world.cout0("Star compress time: ", star_compress_time);
     cumulative_star_compress_time += star_compress_time;
 
-    world.cout0("\tMin RPC calls: ",
-                world.all_reduce_min(world.local_rpc_calls()));
-    world.cout0("\tMax RPC calls: ",
-                world.all_reduce_max(world.local_rpc_calls()));
+    // world.cout0("\tMin RPC calls: ",
+    //             world.all_reduce_min(world.local_rpc_calls()));
+    // world.cout0("\tMax RPC calls: ",
+    //             world.all_reduce_max(world.local_rpc_calls()));
 
     // Checking answer
     auto my_parents = dset.all_find(my_unions);
@@ -123,7 +124,7 @@ int main(int argc, char **argv) {
       ASSERT_RELEASE(item_parent.second == 1);
     }
 
-    world.reset_rpc_call_counter();
+    // world.reset_rpc_call_counter();
     world.barrier();
   }
 

--- a/test/test_interrupt_mask.cpp
+++ b/test/test_interrupt_mask.cpp
@@ -8,7 +8,8 @@
 #include <ygm/detail/interrupt_mask.hpp>
 
 int main(int argc, char** argv) {
-  ygm::comm world(&argc, &argv, 8);
+  ::setenv("YGM_COMM_BUFFER_SIZE_KB", "1", 1);
+  ygm::comm world(&argc, &argv);
 
   int  count{0};
   auto count_ptr = world.make_ygm_ptr(count);

--- a/test/test_large_messages.cpp
+++ b/test/test_large_messages.cpp
@@ -4,16 +4,18 @@
 // SPDX-License-Identifier: MIT
 
 #undef NDEBUG
+#include <cstdlib>
 #include <ygm/comm.hpp>
 #include <ygm/detail/ygm_ptr.hpp>
 
 int main(int argc, char** argv) {
   // Create comm for very small messages
-  ygm::comm world(&argc, &argv, 8);
+  ::setenv("YGM_COMM_BUFFER_SIZE_KB", "1", 1);
+  ygm::comm world(&argc, &argv);
 
   // Test Rank 0 large message to all ranks
   {
-    size_t large_msg_size = 1024;
+    size_t large_msg_size = 1024 * 1024;
     size_t counter{};
     auto   pcounter = world.make_ygm_ptr(counter);
     if (world.rank() == 0) {


### PR DESCRIPTION
Significant overhaul removing listener thread and MPI_THREAD_MULTIPLE.

- Removal of the listener thread.   Removes requirement for MPI_THREAD_MULTIPLE.   Improves performance substantially for the triangle counting benchmark.
- NR & NLNR routing are supported.
- Added the ability to capture primitive values in the async lambda to avoid Cereal overhead.   This improves performance a bit, but mostly it makes user code easier to read/debug.   Caution: there are no safety rails to prevent capturing a local pointer (but does prevent local references).
- Added a full environment setting system, and it now controls the major settings in the runtime.
- comm::welcome() added a welcome banner that prints out the current configuration and MPI settings.
- *API minor change* removed the optional parameter to comm::comm(…, int buffer_capacity) that controlled the buffer size.   Now it must be controlled by the environment.
-  Added new mechanism to indicate remote dispatch functions via static initialization. 
