### PR TITLE
adding inline definition for release_assert_fail; Fix for Issue #126

### DIFF
--- a/include/ygm/detail/assert.hpp
+++ b/include/ygm/detail/assert.hpp
@@ -10,7 +10,7 @@
 #include <cassert>
 
 // work  on this:  https://github.com/lattera/glibc/blob/master/assert/assert.c
-void release_assert_fail(const char *assertion, const char *file,
+inline void release_assert_fail(const char *assertion, const char *file,
                          unsigned int line, const char *function) {
   std::stringstream ss;
   ss << " " << assertion << " " << file << ":" << line << " " << function


### PR DESCRIPTION
Adding inline function definition for `release_assert_fail`; fix for Issue #126 that allows us to build multi-object targets without link-time failures.