### PR TITLE
wip/reducing adapter

### DIFF
--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -14,6 +14,7 @@ class array {
   using self_type  = array<Value, Index>;
   using value_type = Value;
   using index_type = Index;
+  using key_type   = Index;
   using impl_type  = detail::array_impl<value_type, index_type>;
 
   array() = delete;

--- a/include/ygm/container/detail/container_traits.hpp
+++ b/include/ygm/container/detail/container_traits.hpp
@@ -1,0 +1,66 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <type_traits>
+#include <ygm/container/array.hpp>
+#include <ygm/container/bag.hpp>
+#include <ygm/container/disjoint_set.hpp>
+#include <ygm/container/map.hpp>
+#include <ygm/container/set.hpp>
+
+namespace ygm::container::detail {
+
+// is_map
+template <typename T>
+struct is_map_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_map_impl<map<Ts...>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_map = is_map_impl<T>::value;
+
+// is_array
+template <typename T>
+struct is_array_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_array_impl<array<Ts...>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_array = is_array_impl<T>::value;
+
+// is_bag
+template <typename T>
+struct is_bag_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_bag_impl<bag<Ts...>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_bag = is_bag_impl<T>::value;
+
+// is_set
+template <typename T>
+struct is_set_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_set_impl<set<Ts...>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_set = is_set_impl<T>::value;
+
+// is_disjoint_set
+template <typename T>
+struct is_disjoint_set_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_disjoint_set_impl<disjoint_set<Ts...>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_disjoint_set = is_disjoint_set_impl<T>::value;
+
+}  // namespace ygm::container::detail

--- a/include/ygm/container/detail/container_traits.hpp
+++ b/include/ygm/container/detail/container_traits.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <ygm/container/array.hpp>
 #include <ygm/container/bag.hpp>
+#include <ygm/container/counting_set.hpp>
 #include <ygm/container/disjoint_set.hpp>
 #include <ygm/container/map.hpp>
 #include <ygm/container/set.hpp>
@@ -62,5 +63,15 @@ struct is_disjoint_set_impl<disjoint_set<Ts...>> : std::true_type {};
 
 template <typename T>
 constexpr bool is_disjoint_set = is_disjoint_set_impl<T>::value;
+
+// is_counting_set
+template <typename T>
+struct is_counting_set_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_counting_set_impl<counting_set<Ts...>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_counting_set = is_counting_set_impl<T>::value;
 
 }  // namespace ygm::container::detail

--- a/include/ygm/container/detail/map_impl.hpp
+++ b/include/ygm/container/detail/map_impl.hpp
@@ -12,11 +12,9 @@
 #include <ygm/container/detail/hash_partitioner.hpp>
 #include <ygm/detail/interrupt_mask.hpp>
 #include <ygm/detail/ygm_ptr.hpp>
+#include <ygm/detail/ygm_traits.hpp>
 
 namespace ygm::container::detail {
-
-template <class...>
-constexpr std::false_type always_false{};
 
 template <typename Key, typename Value,
           typename Partitioner = detail::hash_partitioner<Key>,
@@ -318,7 +316,8 @@ class map_impl {
                                   std::forward_as_tuple(*itr, args...));
       }
     } else {
-      static_assert(always_false<>);  // check your lambda signatures!
+      static_assert(
+          ygm::detail::always_false<>);  // check your lambda signatures!
     }
   }
 
@@ -347,7 +346,8 @@ class map_impl {
       }
       // std::for_each(m_local_map.begin(), m_local_map.end(), fn);
     } else {
-      static_assert(always_false<>);  // check your lambda signatures!
+      static_assert(
+          ygm::detail::always_false<>);  // check your lambda signatures!
     }
   }
 

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -67,6 +67,12 @@ class map {
         key, value, visitor, std::forward<const VisitorArgs>(args)...);
   }
 
+  template <typename ReductionOp>
+  void async_reduce(const key_type& key, const value_type& value,
+                    ReductionOp reducer) {
+    m_impl.async_reduce(key, value, reducer);
+  }
+
   void async_erase(const key_type& key) { m_impl.async_erase(key); }
 
   size_t local_count(const key_type& key) { return m_impl.local_count(key); }

--- a/include/ygm/container/reducing_adapter.hpp
+++ b/include/ygm/container/reducing_adapter.hpp
@@ -1,0 +1,31 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace ygm::container {
+
+template <typename Container, typename ReductionOp>
+class reducing_adapter {
+ public:
+  reducing_adapter(Container &c, ReductionOp reducer) : m_container(c) {}
+
+  void async_reduce(const typename Container::key_type   &key,
+                    const typename Container::value_type &value) {
+    ReductionOp *r;
+    m_container.async_reduce(key, value, *r);
+  }
+
+ private:
+  Container &m_container;
+};
+
+template <typename Container, typename ReductionOp>
+reducing_adapter<Container, ReductionOp> make_reducing_adapter(
+    Container &c, ReductionOp reducer) {
+  return reducing_adapter<Container, ReductionOp>(c, reducer);
+}
+
+}  // namespace ygm::container

--- a/include/ygm/container/reducing_adapter.hpp
+++ b/include/ygm/container/reducing_adapter.hpp
@@ -12,16 +12,15 @@ namespace ygm::container {
 template <typename Container, typename ReductionOp>
 class reducing_adapter {
  public:
-  reducing_adapter(Container &c, ReductionOp reducer) : m_container(c) {}
+  reducing_adapter(Container &c, ReductionOp reducer)
+      : m_container(c), m_reducer(reducer) {}
 
   void async_reduce(const typename Container::key_type   &key,
                     const typename Container::value_type &value) {
-    ReductionOp *r;
-
     if constexpr (ygm::container::detail::is_map<Container>) {
-      m_container.async_reduce(key, value, *r);
+      m_container.async_reduce(key, value, m_reducer);
     } else if constexpr (ygm::container::detail::is_array<Container>) {
-      m_container.async_binary_op_update_value(key, value, *r);
+      m_container.async_binary_op_update_value(key, value, m_reducer);
     } else {
       static_assert(ygm::detail::always_false<>,
                     "Container unsuitable for reducing_adapter");
@@ -29,7 +28,8 @@ class reducing_adapter {
   }
 
  private:
-  Container &m_container;
+  Container  &m_container;
+  ReductionOp m_reducer;
 };
 
 template <typename Container, typename ReductionOp>

--- a/include/ygm/container/reducing_adapter.hpp
+++ b/include/ygm/container/reducing_adapter.hpp
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <ygm/container/detail/container_traits.hpp>
+#include <ygm/detail/ygm_traits.hpp>
 
 namespace ygm::container {
 
@@ -15,7 +17,15 @@ class reducing_adapter {
   void async_reduce(const typename Container::key_type   &key,
                     const typename Container::value_type &value) {
     ReductionOp *r;
-    m_container.async_reduce(key, value, *r);
+
+    if constexpr (ygm::container::detail::is_map<Container>) {
+      m_container.async_reduce(key, value, *r);
+    } else if constexpr (ygm::container::detail::is_array<Container>) {
+      m_container.async_binary_op_update_value(key, value, *r);
+    } else {
+      static_assert(ygm::detail::always_false<>,
+                    "Container unsuitable for reducing_adapter");
+    }
   }
 
  private:

--- a/include/ygm/detail/ygm_traits.hpp
+++ b/include/ygm/detail/ygm_traits.hpp
@@ -1,0 +1,14 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <type_traits>
+
+namespace ygm::detail {
+
+template <class...>
+constexpr std::false_type always_false{};
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ add_ygm_test(test_csv_parser)
 add_ygm_test(test_multi_output)
 add_ygm_test(test_daily_output)
 add_ygm_test(test_interrupt_mask)
+add_ygm_test(test_reducing_adapter)
 
 if (Boost_FOUND)
     add_ygm_seq_test(test_cereal_boost_json)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ add_ygm_test(test_multi_output)
 add_ygm_test(test_daily_output)
 add_ygm_test(test_interrupt_mask)
 add_ygm_test(test_reducing_adapter)
+add_ygm_test(test_container_traits)
 
 if (Boost_FOUND)
     add_ygm_seq_test(test_cereal_boost_json)

--- a/test/test_container_traits.cpp
+++ b/test/test_container_traits.cpp
@@ -1,0 +1,116 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+
+#include <ygm/comm.hpp>
+#include <ygm/container/detail/container_traits.hpp>
+#include <ygm/detail/ygm_traits.hpp>
+
+int main(int argc, char** argv) {
+  ygm::comm world(&argc, &argv);
+
+  ygm::container::bag<int>          test_bag(world);
+  ygm::container::set<int>          test_set(world);
+  ygm::container::map<int, int>     test_map(world);
+  ygm::container::array<int>        test_array(world, 10);
+  ygm::container::counting_set<int> test_counting_set(world);
+  ygm::container::disjoint_set<int> test_disjoint_set(world);
+  int                               i;
+
+  //
+  // Test is_bag
+  {
+    static_assert(ygm::container::detail::is_bag<decltype(test_bag)>);
+    static_assert(not ygm::container::detail::is_bag<decltype(test_set)>);
+    static_assert(not ygm::container::detail::is_bag<decltype(test_map)>);
+    static_assert(not ygm::container::detail::is_bag<decltype(test_array)>);
+    static_assert(
+        not ygm::container::detail::is_bag<decltype(test_counting_set)>);
+    static_assert(
+        not ygm::container::detail::is_bag<decltype(test_disjoint_set)>);
+    static_assert(not ygm::container::detail::is_bag<decltype(i)>);
+  }
+
+  //
+  // Test is_set
+  {
+    static_assert(not ygm::container::detail::is_set<decltype(test_bag)>);
+    static_assert(ygm::container::detail::is_set<decltype(test_set)>);
+    static_assert(not ygm::container::detail::is_set<decltype(test_map)>);
+    static_assert(not ygm::container::detail::is_set<decltype(test_array)>);
+    static_assert(
+        not ygm::container::detail::is_set<decltype(test_counting_set)>);
+    static_assert(
+        not ygm::container::detail::is_set<decltype(test_disjoint_set)>);
+    static_assert(not ygm::container::detail::is_set<decltype(i)>);
+  }
+
+  //
+  // Test is_map
+  {
+    static_assert(not ygm::container::detail::is_map<decltype(test_bag)>);
+    static_assert(not ygm::container::detail::is_map<decltype(test_set)>);
+    static_assert(ygm::container::detail::is_map<decltype(test_map)>);
+    static_assert(not ygm::container::detail::is_map<decltype(test_array)>);
+    static_assert(
+        not ygm::container::detail::is_map<decltype(test_counting_set)>);
+    static_assert(
+        not ygm::container::detail::is_map<decltype(test_disjoint_set)>);
+    static_assert(not ygm::container::detail::is_map<decltype(i)>);
+  }
+
+  //
+  // Test is_array
+  {
+    static_assert(not ygm::container::detail::is_array<decltype(test_bag)>);
+    static_assert(not ygm::container::detail::is_array<decltype(test_set)>);
+    static_assert(not ygm::container::detail::is_array<decltype(test_map)>);
+    static_assert(ygm::container::detail::is_array<decltype(test_array)>);
+    static_assert(
+        not ygm::container::detail::is_array<decltype(test_counting_set)>);
+    static_assert(
+        not ygm::container::detail::is_array<decltype(test_disjoint_set)>);
+    static_assert(not ygm::container::detail::is_array<decltype(i)>);
+  }
+
+  //
+  // Test is_counting_set
+  {
+    static_assert(
+        not ygm::container::detail::is_counting_set<decltype(test_bag)>);
+    static_assert(
+        not ygm::container::detail::is_counting_set<decltype(test_set)>);
+    static_assert(
+        not ygm::container::detail::is_counting_set<decltype(test_map)>);
+    static_assert(
+        not ygm::container::detail::is_counting_set<decltype(test_array)>);
+    static_assert(
+        ygm::container::detail::is_counting_set<decltype(test_counting_set)>);
+    static_assert(not ygm::container::detail::is_counting_set<
+                  decltype(test_disjoint_set)>);
+    static_assert(not ygm::container::detail::is_counting_set<decltype(i)>);
+  }
+
+  //
+  // Test is_disjoint_set
+  {
+    static_assert(
+        not ygm::container::detail::is_disjoint_set<decltype(test_bag)>);
+    static_assert(
+        not ygm::container::detail::is_disjoint_set<decltype(test_set)>);
+    static_assert(
+        not ygm::container::detail::is_disjoint_set<decltype(test_map)>);
+    static_assert(
+        not ygm::container::detail::is_disjoint_set<decltype(test_array)>);
+    static_assert(not ygm::container::detail::is_disjoint_set<
+                  decltype(test_counting_set)>);
+    static_assert(
+        ygm::container::detail::is_disjoint_set<decltype(test_disjoint_set)>);
+    static_assert(not ygm::container::detail::is_disjoint_set<decltype(i)>);
+  }
+
+  return 0;
+}

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
     smap.for_all([&world, &num_reductions](const auto &key, const auto &value) {
       if (key == "sum") {
         ASSERT_RELEASE(value == world.size() * num_reductions *
-                                    (num_reductions + 1) / 2);
+                                    (num_reductions - 1) / 2);
       } else if (key == "min") {
         ASSERT_RELEASE(value == 0);
       } else if (key == "max") {

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #undef NDEBUG
+#include <algorithm>
 #include <string>
 #include <ygm/comm.hpp>
 #include <ygm/container/map.hpp>
@@ -136,6 +137,38 @@ int main(int argc, char **argv) {
   }
 
   //
+  // Test async_reduce
+  {
+    ygm::container::map<std::string, int> smap(world);
+
+    int num_reductions = 5;
+    for (int i = 0; i < num_reductions; ++i) {
+      smap.async_reduce("sum", i, std::plus<int>());
+      smap.async_reduce("min", i, [](const int &a, const int &b) {
+        return std::min<int>(a, b);
+      });
+      smap.async_reduce("max", i, [](const int &a, const int &b) {
+        return std::max<int>(a, b);
+      });
+    }
+
+    world.barrier();
+
+    smap.for_all([&world, &num_reductions](const auto &key, const auto &value) {
+      if (key == "sum") {
+        ASSERT_RELEASE(value == world.size() * num_reductions *
+                                    (num_reductions + 1) / 2);
+      } else if (key == "min") {
+        ASSERT_RELEASE(value == 0);
+      } else if (key == "max") {
+        ASSERT_RELEASE(value == num_reductions - 1);
+      } else {
+        ASSERT_RELEASE(false);
+      }
+    });
+  }
+
+  //
   // Test swap & async_set
   {
     ygm::container::map<std::string, std::string> smap(world);
@@ -161,7 +194,7 @@ int main(int argc, char **argv) {
   {
     ygm::container::map<std::string, std::vector<std::string>> smap(world);
     auto str_push_back = [](std::pair<const auto, auto> &key_value,
-                            const std::string &          str) {
+                            const std::string           &str) {
       // auto str_push_back = [](auto key_value, const std::string &str) {
       key_value.second.push_back(str);
     };

--- a/test/test_reducing_adapter.cpp
+++ b/test/test_reducing_adapter.cpp
@@ -1,0 +1,40 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+
+#include <string>
+#include <ygm/comm.hpp>
+#include <ygm/container/map.hpp>
+#include <ygm/container/reducing_adapter.hpp>
+
+int main(int argc, char **argv) {
+  ygm::comm world(&argc, &argv);
+
+  {
+    ygm::container::map<std::string, int> test_map(world);
+
+    auto test_reducing_map = ygm::container::make_reducing_adapter(
+        test_map,
+        [](const int &a, const int &b) { return std::max<int>(a, b); });
+
+    int num_reductions = 6;
+    for (int i = 0; i < num_reductions; ++i) {
+      test_reducing_map.async_reduce("max", i);
+    }
+
+    world.barrier();
+
+    test_map.for_all([&num_reductions](const auto &key, const auto &value) {
+      if (key == "max") {
+        ASSERT_RELEASE(value == num_reductions - 1);
+      } else {
+        ASSERT_RELEASE(false);
+      }
+    });
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This line of work seeks to create a structure that can be added to a `ygm::container::map` or `ygm::container::array` to allow efficient reductions.