### PR TITLE
Created container propogation functions

### DIFF
--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -108,8 +108,15 @@ class array {
 
   ygm::comm& comm() { return m_impl.comm(); }
 
+  const value_type& default_value() const { return m_impl.default_value(); }
+
  private:
   impl_type m_impl;
 };
+
+template <typename... Ts>
+array<Ts...> make_similar(array<Ts...>& rhs) {
+  return {rhs.comm(), rhs.size(), rhs.default_value()};
+}
 
 }  // namespace ygm::container

--- a/include/ygm/container/bag.hpp
+++ b/include/ygm/container/bag.hpp
@@ -38,11 +38,20 @@ class bag {
 
   void serialize(const std::string &fname) { m_impl.serialize(fname); }
   void deserialize(const std::string &fname) { m_impl.deserialize(fname); }
-  std::vector<value_type> gather_to_vector(int dest) { return m_impl.gather_to_vector(dest); }
-  std::vector<value_type> gather_to_vector() { return m_impl.gather_to_vector(); }
-
+  std::vector<value_type> gather_to_vector(int dest) {
+    return m_impl.gather_to_vector(dest);
+  }
+  std::vector<value_type> gather_to_vector() {
+    return m_impl.gather_to_vector();
+  }
 
  private:
   detail::bag_impl<value_type> m_impl;
 };
+
+template <typename... Ts>
+bag<Ts...> make_similar(bag<Ts...> &rhs) {
+  return {rhs.comm()};
+}
+
 }  // namespace ygm::container

--- a/include/ygm/container/counting_set.hpp
+++ b/include/ygm/container/counting_set.hpp
@@ -146,4 +146,9 @@ class counting_set {
   typename ygm::ygm_ptr<self_type>                  pthis;
 };
 
+template <typename... Ts>
+counting_set<Ts...> make_similar(counting_set<Ts...> &rhs) {
+  return {rhs.comm()};
+}
+
 }  // namespace ygm::container

--- a/include/ygm/container/detail/array_impl.hpp
+++ b/include/ygm/container/detail/array_impl.hpp
@@ -143,6 +143,8 @@ class array_impl {
     return m_comm.rank() * m_block_size + index;
   }
 
+  const value_type &default_value() const { return m_default_value; }
+
  protected:
   array_impl() = delete;
 

--- a/include/ygm/container/disjoint_set.hpp
+++ b/include/ygm/container/disjoint_set.hpp
@@ -24,7 +24,7 @@ class disjoint_set {
 
   template <typename Function, typename... FunctionArgs>
   void async_union_and_execute(const value_type &a, const value_type &b,
-                               Function fn, const FunctionArgs &... args) {
+                               Function fn, const FunctionArgs &...args) {
     m_impl.async_union_and_execute(a, b, fn,
                                    std::forward<const FunctionArgs>(args)...);
   }
@@ -47,9 +47,15 @@ class disjoint_set {
 
   typename ygm::ygm_ptr<impl_type> get_ygm_ptr() const {
     return m_impl.get_ygm_ptr();
-  }  
- 
-private:
+  }
+
+ private:
   impl_type m_impl;
 };
+
+template <typename... Ts>
+disjoint_set<Ts...> make_similar(disjoint_set<Ts...> &rhs) {
+  return {rhs.comm()};
+}
+
 }  // namespace ygm::container

--- a/include/ygm/container/experimental/detail/maptrix_impl.hpp
+++ b/include/ygm/container/experimental/detail/maptrix_impl.hpp
@@ -87,13 +87,13 @@ class maptrix_impl {
   }
 
   template <typename... VisitorArgs>
-  void print_all(std::ostream &os, VisitorArgs const &... args) {
+  void print_all(std::ostream &os, VisitorArgs const &...args) {
     ((os << args), ...);
   }
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_exists(const key_type &row, const key_type &col,
-                             Visitor visitor, const VisitorArgs &... args) {
+                             Visitor visitor, const VisitorArgs &...args) {
     m_row_view.async_visit_if_exists(row, col, visitor,
                                      std::forward<const VisitorArgs>(args)...);
     m_column_view.async_visit_if_exists(
@@ -102,7 +102,7 @@ class maptrix_impl {
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_col_mutate(const key_type &col, Visitor visitor,
-                              const VisitorArgs &... args) {
+                              const VisitorArgs &...args) {
     auto &m_map     = m_column_view.column_view();
     auto &inner_map = m_map.find(col)->second;
     for (auto itr = inner_map.begin(); itr != inner_map.end(); ++itr) {
@@ -116,24 +116,24 @@ class maptrix_impl {
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_row_const(const key_type &row, Visitor visitor,
-                             const VisitorArgs &... args) {
+                             const VisitorArgs &...args) {
     m_row_view.async_visit_row_const(row, visitor,
                                      std::forward<const VisitorArgs>(args)...);
   }
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_col_const(const key_type &col, Visitor visitor,
-                             const VisitorArgs &... args) {
+                             const VisitorArgs &...args) {
     m_column_view.async_visit_col_const(
         col, visitor, std::forward<const VisitorArgs>(args)...);
   }
 
   template <typename Visitor, typename... VisitorArgs>
-  void async_insert_if_missing_else_visit(const key_type &  row,
-                                          const key_type &  col,
+  void async_insert_if_missing_else_visit(const key_type   &row,
+                                          const key_type   &col,
                                           const value_type &value,
                                           Visitor           visitor,
-                                          const VisitorArgs &... args) {
+                                          const VisitorArgs &...args) {
     m_row_view.async_insert_if_missing_else_visit(
         row, col, value, visitor, std::forward<const VisitorArgs>(args)...);
     m_column_view.async_insert_if_missing_else_visit(
@@ -151,6 +151,8 @@ class maptrix_impl {
     m_row_view.swap(s.row_view);
     m_column_view.swap(s.column_view);
   }
+
+  const value_type &default_value() const { return m_default_value; }
 
  protected:
   maptrix_impl() = delete;

--- a/include/ygm/container/experimental/maptrix.hpp
+++ b/include/ygm/container/experimental/maptrix.hpp
@@ -98,6 +98,8 @@ class maptrix {
 
   void swap(self_type& s) { m_impl.swap(s); }
 
+  const value_type& default_value() const { return m_impl.default_value(); }
+
 #ifdef api_creation
   void async_erase(const key_type& row, const key_type& col) {
     m_impl.async_erase(row, col);
@@ -108,6 +110,12 @@ class maptrix {
  private:
   impl_type m_impl;
 };
+
+template <typename... Ts>
+maptrix<Ts...> make_similar(maptrix<Ts...>& rhs) {
+  return {rhs.comm(), rhs.default_value()};
+}
+
 }  // namespace ygm::container::experimental
 
 #include <ygm/container/experimental/detail/algorithms/spmv.hpp>

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -132,6 +132,11 @@ class map {
   impl_type m_impl;
 };
 
+template <typename... Ts>
+map<Ts...> make_similar(map<Ts...>& rhs) {
+  return {rhs.comm(), rhs.default_value()};
+}
+
 template <typename Key, typename Value,
           typename Partitioner = detail::hash_partitioner<Key>,
           typename Compare     = std::less<Key>,
@@ -237,5 +242,10 @@ class multimap {
  private:
   impl_type m_impl;
 };
+
+template <typename... Ts>
+multimap<Ts...> make_similar(multimap<Ts...>& rhs) {
+  return {rhs.comm(), rhs.default_value()};
+}
 
 }  // namespace ygm::container

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -59,6 +59,12 @@ class multiset {
  private:
   impl_type m_impl;
 };
+
+template <typename... Ts>
+multiset<Ts...> make_similar(multiset<Ts...>& rhs) {
+  return {rhs.comm()};
+}
+
 template <typename Key, typename Partitioner = detail::hash_partitioner<Key>,
           typename Compare = std::less<Key>,
           class Alloc      = std::allocator<const Key>>
@@ -110,5 +116,10 @@ class set {
  private:
   impl_type m_impl;
 };
+
+template <typename... Ts>
+set<Ts...> make_similar(set<Ts...>& rhs) {
+  return {rhs.comm()};
+}
 
 }  // namespace ygm::container

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -111,5 +111,27 @@ int main(int argc, char **argv) {
     });
   }
 
+  //
+  // Test make_similar (unset default)
+  {
+    int size = 64;
+
+    ygm::container::array<std::string> arr1(world, size);
+    ygm::container::array<std::string> arr2 = make_similar(arr1);
+    ASSERT_RELEASE(arr1.size() == arr2.size());
+    ASSERT_RELEASE(arr1.default_value() == arr2.default_value());
+  }
+
+  //
+  // Test make_similar (set default)
+  {
+    int size = 64;
+
+    ygm::container::array<std::string> arr1(world, size, "string");
+    ygm::container::array<std::string> arr2 = make_similar(arr1);
+    ASSERT_RELEASE(arr1.size() == arr2.size());
+    ASSERT_RELEASE(arr1.default_value() == arr2.default_value());
+  }
+
   return 0;
 }

--- a/test/test_bag.cpp
+++ b/test/test_bag.cpp
@@ -32,9 +32,9 @@ int main(int argc, char** argv) {
     bbag.async_insert("apple");
     bbag.async_insert("red");
     ASSERT_RELEASE(bbag.size() == 3 * (size_t)world.size());
-    
+
     auto all_data = bbag.gather_to_vector(0);
-    if(world.rank0()) {
+    if (world.rank0()) {
       ASSERT_RELEASE(all_data.size() == 3 * (size_t)world.size());
     }
   }

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 #include <ygm/comm.hpp>
+#include <ygm/container/detail/container_traits.hpp>
 #include <ygm/container/map.hpp>
 
 int main(int argc, char **argv) {
@@ -277,6 +278,22 @@ int main(int argc, char **argv) {
     ASSERT_RELEASE(smap2.count("dog") == 1);
     ASSERT_RELEASE(smap2.count("apple") == 1);
     ASSERT_RELEASE(smap2.count("red") == 1);
+  }
+
+  //
+  // Test make_similar (unset default)
+  {
+    ygm::container::map<std::string, std::string> smap1(world);
+    ygm::container::map<std::string, std::string> smap2 = make_similar(smap1);
+    ASSERT_RELEASE(smap1.default_value() == smap2.default_value());
+  }
+
+  //
+  // Test make_similar (set default)
+  {
+    ygm::container::map<std::string, std::string> smap1(world, "thing");
+    ygm::container::map<std::string, std::string> smap2 = make_similar(smap1);
+    ASSERT_RELEASE(smap1.default_value() == smap2.default_value());
   }
 
   return 0;


### PR DESCRIPTION
The idea here is to be able to spawn empty copies of existing template containers whose type is only known at compile time. Containers have different basic parameters, e.g. array has (comm, size, default_value), map has (comm, default_value), and bag has (comm). In a function with a template parameter container, spawning new containers must have a uniform interface so they can be compiled. This PR is an attempt to provide such and interface.

Unresolved questions:
- What is the right function name? Using `make_similar` now, but we might want something more descriptive
- What is the right pattern?
```
container_type con2 = make_similar(con1);  // external method; current version
container_type con2 = con1.make_similar();  // member function
```