### PR TITLE
explicitly defining an MPI_Datatype for size_t because gcc gets confu…

### DIFF
--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <limits.h>
 #include <mpi.h>
 #include <ygm/detail/assert.hpp>
 #include <ygm/detail/ygm_traits.hpp>
@@ -80,11 +81,13 @@ inline MPI_Datatype mpi_typeof<uint64_t>(uint64_t) {
   return MPI_UINT64_T;
 }
 
+#if UINT_MAX != SIZE_MAX
 // This appears to be needed for std::size_t on some platforms
 template <>
-inline MPI_Datatype mpi_typeof<long unsigned int>(long unsigned int) {
+inline MPI_Datatype mpi_typeof<size_t>(size_t) {
   return MPI_UINT64_T;
 }
+#endif
 
 template <>
 inline MPI_Datatype mpi_typeof<float>(float) {

--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -81,6 +81,11 @@ inline MPI_Datatype mpi_typeof<uint64_t>(uint64_t) {
 }
 
 template <>
+inline MPI_Datatype mpi_typeof<size_t>(size_t) {
+  return MPI_UINT64_T;
+}
+
+template <>
 inline MPI_Datatype mpi_typeof<float>(float) {
   return MPI_FLOAT;
 }

--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <limits.h>
 #include <mpi.h>
 #include <ygm/detail/assert.hpp>
 #include <ygm/detail/ygm_traits.hpp>

--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -80,8 +80,9 @@ inline MPI_Datatype mpi_typeof<uint64_t>(uint64_t) {
   return MPI_UINT64_T;
 }
 
+// This appears to be needed for std::size_t on some platforms
 template <>
-inline MPI_Datatype mpi_typeof<size_t>(size_t) {
+inline MPI_Datatype mpi_typeof<long unsigned int>(long unsigned int) {
   return MPI_UINT64_T;
 }
 

--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -77,17 +77,14 @@ inline MPI_Datatype mpi_typeof<uint32_t>(uint32_t) {
 }
 
 template <>
-inline MPI_Datatype mpi_typeof<uint64_t>(uint64_t) {
+inline MPI_Datatype mpi_typeof<unsigned long int>(unsigned long int) {
   return MPI_UINT64_T;
 }
 
-#if UINT_MAX != SIZE_MAX
-// This appears to be needed for std::size_t on some platforms
 template <>
-inline MPI_Datatype mpi_typeof<size_t>(size_t) {
+inline MPI_Datatype mpi_typeof<unsigned long long int>(unsigned long long int) {
   return MPI_UINT64_T;
 }
-#endif
 
 template <>
 inline MPI_Datatype mpi_typeof<float>(float) {


### PR DESCRIPTION
…sed on some platforms.