### PR TITLE
Added missing for_all test for counting set

### DIFF
--- a/test/test_counting_set.cpp
+++ b/test/test_counting_set.cpp
@@ -101,5 +101,40 @@ int main(int argc, char **argv) {
     ASSERT_RELEASE(topk[1].second == 2 * world.size());
   }
 
+  //
+  // Test for_all
+  {
+    ygm::container::counting_set<std::string> cset1(world);
+    ygm::container::counting_set<std::string> cset2(world);
+
+    cset1.async_insert("dog");
+    cset1.async_insert("dog");
+    cset1.async_insert("dog");
+    cset1.async_insert("cat");
+    cset1.async_insert("cat");
+    cset1.async_insert("bird");
+
+    ASSERT_RELEASE(cset1.count("dog")  == (size_t)world.size() * 3);
+    ASSERT_RELEASE(cset1.count("cat")  == (size_t)world.size() * 2);
+    ASSERT_RELEASE(cset1.count("bird") == (size_t)world.size());
+    ASSERT_RELEASE(cset1.count("red")  == 0);
+    ASSERT_RELEASE(cset1.size() == 3);
+    
+
+    cset1.for_all([&cset2](const auto &key, const auto &value) {
+      for (int i = 0; i < value; i++) {
+        cset2.async_insert(key);
+      }
+    });
+
+    ASSERT_RELEASE(cset2.count("dog")  == (size_t)world.size() * 3);
+    ASSERT_RELEASE(cset2.count("cat")  == (size_t)world.size() * 2);
+    ASSERT_RELEASE(cset2.count("bird") == (size_t)world.size());
+    ASSERT_RELEASE(cset2.count("red")  == 0);
+    ASSERT_RELEASE(cset2.size() == 3);
+
+
+  }
+
   return 0;
 }


### PR DESCRIPTION
Noted missing for_all test in counting set's testing suite. Thought I'd push in an update as a hotfix.