### PR TITLE
Added missing limits include

### DIFF
--- a/include/ygm/detail/lambda_map.hpp
+++ b/include/ygm/detail/lambda_map.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <limits>
 #include <vector>
 #include <ygm/detail/mpi.hpp>
 


### PR DESCRIPTION
Added in a `include <limits>` that was necessary to build the library as a dependency.