### PR TITLE
Parallel Parquet File Reading (v2)

### DIFF
--- a/include/ygm/io/arrow_parquet_parser.hpp
+++ b/include/ygm/io/arrow_parquet_parser.hpp
@@ -328,10 +328,6 @@ class arrow_parquet_parser {
         }
         num_assigned_rows += range.num_rows;
 
-        // std::cout << rank_no << " " << range.begin_file_no
-        // << " " << range.begin_row_offset
-        // << " " << range.num_rows << std::endl; // Debug
-
         // Send the read range to the rank
         m_comm.async(
             rank_no,

--- a/include/ygm/io/arrow_parquet_parser.hpp
+++ b/include/ygm/io/arrow_parquet_parser.hpp
@@ -85,6 +85,34 @@ class arrow_parquet_parser {
   size_t local_file_count() { return m_paths.size(); }
 
  private:
+  /// @brief Holds the information about the range of file data to be read by a
+  /// rank.
+  struct read_range {
+    size_t begin_file_no{0};
+    size_t begin_row_offset{0};
+    size_t num_rows{0};
+
+    template <typename Archive>
+    void serialize(Archive& ar) {
+      ar(begin_file_no, begin_row_offset, num_rows);
+    }
+  };
+
+  /// @brief Count the number of lines in a file.
+  static size_t count_rows(const stdfs::path& input_filename) {
+    std::shared_ptr<arrow::io::ReadableFile> input_file;
+    PARQUET_ASSIGN_OR_THROW(input_file,
+                            arrow::io::ReadableFile::Open(input_filename));
+    std::unique_ptr<parquet::ParquetFileReader> parquet_file_reader =
+        parquet::ParquetFileReader::Open(input_file);
+
+    std::shared_ptr<parquet::FileMetaData> file_metadata =
+        parquet_file_reader->metadata();
+    const size_t num_rows = file_metadata->num_rows();
+
+    return num_rows;
+  }
+
   /**
    * @brief Check readability of paths and iterates through directories
    *
@@ -162,60 +190,154 @@ class arrow_parquet_parser {
    */
   bool is_file_good(const stdfs::path& p) {
     std::shared_ptr<arrow::io::ReadableFile> input_file;
-    PARQUET_ASSIGN_OR_THROW(input_file, arrow::io::ReadableFile::Open(p));
+    try {
+      PARQUET_ASSIGN_OR_THROW(input_file, arrow::io::ReadableFile::Open(p));
+    } catch(...) {
+      return false;
+    }
     return true;
   }
 
   template <typename Function>
   void read_files(Function fn) {
-    for (size_t i = 0; i < m_paths.size(); ++i) {
-      if (is_owner(i)) {
-        read_file(m_paths[i], fn);
+    m_comm.barrier();
+
+    if (ARROW_VERSION_MAJOR < 14) {
+      // Due to a bug in parquet::StreamReader::SkipRows() in < v14,
+      // we can not read a single file using multiple ranks.
+      for (size_t i = 0; i < m_paths.size(); ++i) {
+        if (is_owner(i)) {
+          read_parquet_stream(m_paths[i], fn);
+        }
       }
-    }  // for
+    } else {
+      assign_read_range();
+
+      // If n is 0, fno and offset could contain invalid values
+      ssize_t n      = ssize_t(m_read_range.num_rows);
+      size_t  fno    = m_read_range.begin_file_no;
+      size_t  offset = m_read_range.begin_row_offset;
+
+      while (n > 0) {
+        n -= read_parquet_stream(m_paths[fno], fn, offset, n);
+        assert(n >= 0);
+        offset = 0;
+        ++fno;
+      }
+    }
   }
 
-  template <typename Function>
-  void read_file(const stdfs::path& file_path, Function fn) {
-    read_parquet_stream(file_path.string(), fn);
-  }
-
-  void read_file_schema() {
-    read_parquet_stream(
-        m_paths[0], [](auto& stream_reader, const auto& field_count) {}, true);
-  }
-
-  template <typename Function>
-  void read_parquet_stream(std::string&& input_filename, Function fn,
-                           bool read_schema_only = false) {
+  std::unique_ptr<parquet::ParquetFileReader> open_file(
+      const stdfs::path& input_filename) {
     // Open the Parquet file
     std::shared_ptr<arrow::io::ReadableFile> input_file;
     PARQUET_ASSIGN_OR_THROW(input_file,
                             arrow::io::ReadableFile::Open(input_filename));
 
     // Create a ParquetFileReader object
-    std::unique_ptr<parquet::ParquetFileReader> parquet_file_reader =
-        parquet::ParquetFileReader::Open(input_file);
+    return parquet::ParquetFileReader::Open(input_file);
+  }
+
+  void read_file_schema() {
+    auto reader = open_file(m_paths[0]);
 
     // Get the file schema
     parquet::SchemaDescriptor const* const file_schema =
-        parquet_file_reader->metadata()->schema();
+        reader->metadata()->schema();
 
-    if (read_schema_only) {
-      const size_t field_count = file_schema->num_columns();
-      for (size_t i = 0; i < field_count; ++i) {
-        parquet::ColumnDescriptor const* const column = file_schema->Column(i);
-        m_schema.emplace_back(std::forward_as_tuple(
-            parquet_data_type{column->physical_type()}, column->name()));
-      }  // for
-      m_schema_string = file_schema->ToString();
-      return;
+    const size_t field_count = file_schema->num_columns();
+    for (size_t i = 0; i < field_count; ++i) {
+      parquet::ColumnDescriptor const* const column = file_schema->Column(i);
+      m_schema.emplace_back(std::forward_as_tuple(
+          parquet_data_type{column->physical_type()}, column->name()));
+    }
+    m_schema_string = file_schema->ToString();
+  }
+
+  template <typename Function>
+  size_t read_parquet_stream(const stdfs::path& input_filename, Function fn,
+                             const size_t  offset           = 0,
+                             const ssize_t num_rows_to_read = -1) {
+    auto                  reader = open_file(input_filename);
+    parquet_stream_reader stream{std::move(reader)};
+
+    if (offset > 0) {
+      // SkipRows() has a bug in < v14
+      assert(ARROW_VERSION_MAJOR >= 14);
+      stream.SkipRows(offset);
     }
 
-    parquet_stream_reader stream_reader{std::move(parquet_file_reader)};
-    for (size_t i = 0; !stream_reader.eof(); ++i) {
-      fn(stream_reader, m_schema.size());
-    }  // for
+    size_t cnt_read_rows = 0;
+    while (!stream.eof()) {
+      if (cnt_read_rows >= size_t(num_rows_to_read)) break;
+      fn(stream, m_schema.size());
+      ++cnt_read_rows;
+    }
+
+    return cnt_read_rows;
+  }
+
+  /// @brief Assigns the range each rank reads.
+  /// This function tries to assign the equal number of rows to every rank.
+  /// Thus, some files may be read by more than one rank.
+  void assign_read_range() {
+    // Count the number of lines in each file
+    // Can do in parallel, but use a single rank for now for simplicity.
+    if (m_comm.rank0()) {
+      std::vector<size_t> num_rows(m_paths.size());
+      for (size_t i = 0; i < m_paths.size(); ++i) {
+        num_rows[i] = count_rows(m_paths[i]);
+      }
+
+      const size_t total_num_rows =
+          std::accumulate(num_rows.begin(), num_rows.end(), size_t(0));
+      // std::cout << total_num_rows << std::endl; //DB
+
+      size_t file_no           = 0;
+      size_t row_no_offset     = 0;
+      size_t num_assigned_rows = 0;  // For sanity check
+      for (int rank_no = 0; rank_no < m_comm.size(); ++rank_no) {
+        size_t per_rank_num_rows = total_num_rows / m_comm.size();
+        if (rank_no < (total_num_rows % m_comm.size())) {
+          per_rank_num_rows += 1;
+        }
+
+        read_range range;
+        range.begin_file_no    = file_no;
+        range.begin_row_offset = row_no_offset;
+        range.num_rows         = 0;
+
+        for (; file_no < m_paths.size(); ++file_no) {
+          // #of rows to read from this file
+          const size_t n = std::min(per_rank_num_rows - range.num_rows,
+                                    num_rows[file_no] - row_no_offset);
+          range.num_rows += n;
+          if (range.num_rows < per_rank_num_rows) {
+            // Can read more rows from the next file
+            row_no_offset = 0;
+          } else {
+            // Found the enough rows to read
+            row_no_offset += n;
+            break;
+          }
+        }
+        num_assigned_rows += range.num_rows;
+
+        // std::cout << rank_no << " " << range.begin_file_no << " " << range.begin_row_offset << " " << range.num_rows << std::endl; //DB
+
+        // Send the read range to the rank
+        m_comm.async(
+            rank_no,
+            [](auto parquet_reader_ptr, const auto& range) {
+              parquet_reader_ptr->m_read_range = range;
+            },
+            pthis, range);
+      }
+
+      // Sanity check
+      assert(num_assigned_rows == total_num_rows);
+    }
+    m_comm.barrier();
   }
 
   bool is_owner(const size_t& item_ID) {
@@ -227,6 +349,7 @@ class arrow_parquet_parser {
   std::vector<stdfs::path>         m_paths;
   file_schema_container            m_schema;
   std::string                      m_schema_string;
+  read_range                       m_read_range;
 };
 
 }  // namespace ygm::io


### PR DESCRIPTION
This Pull Request enables every MPI rank to read an equal number of lines, regardless of the differing line counts across multiple files.
For instance, in a scenario where 100 lines of data are unevenly distributed among several files, and there are four MPI ranks, each rank will be responsible for reading 25 lines. Specifically, MPI rank 0 will process the first 25 lines, followed by MPI rank 1 with the subsequent 25 lines, and so on. This means that a file may be read in parallel by multiple ranks.

This new feature requires at least Arrow v14. If an older version is used, the reader falls back to the old mode, which assigns an equal number of files to each rank regardless of the number of lines in the files.