### PR TITLE
Bugfix/disjoint set compress

### DIFF
--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -411,15 +411,36 @@ class disjoint_set_impl {
     while (level > 0) {
       int outstanding_query_children{0};
       for (const auto &[parent, query] : queries) {
-        outstanding_query_children += query.local_inquiring_items.size();
+        // outstanding_query_children += query.local_inquiring_items.size();
+        if (query.local_inquiring_items.size() > 0) {
+          m_comm.cout() << "Awaiting response from (" << parent << ", "
+                        << query.rep << ", " << query.returned
+                        << ") for items: ";
+          for (const auto &local_item : query.local_inquiring_items) {
+            std::cout << local_item << "\t";
+          }
+          std::cout << std::endl;
+        }
       }
+      /*
       if (outstanding_query_children > 0) {
         m_comm.cout() << "Awaiting query responses: "
                       << outstanding_query_children << std::endl;
       }
+      */
+      /*
       if (held_responses.size() > 0) {
         m_comm.cout() << "Held responses remaining: " << held_responses.size()
                       << std::endl;
+      }
+      */
+      for (const auto &[local_item, inquiring_ranks] : held_responses) {
+        m_comm.cout() << "Still holding response from " << local_item
+                      << " for ranks: ";
+        for (const auto &inquiring_rank : inquiring_ranks) {
+          std::cout << inquiring_rank << "\t";
+        }
+        std::cout << std::endl;
       }
 
       --level;  // Start at second highest level

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -325,27 +325,7 @@ class disjoint_set_impl {
     async_visit(a, simul_parent_walk_functor(), a, b, b, -1, a, b, args...);
   }
 
-  /*
-  void check_parent_ranks() {
-    for (const auto &[local_item, item_info] : m_local_item_parent_map) {
-      if (item_info.get_parent() != local_item) {
-        async_visit(
-            item_info.get_parent(),
-            [](const auto &parent, const auto &child_rank) {
-              if (parent.second.get_rank() <= child_rank) {
-                std::cout << "Child rank: " << child_rank
-                          << "\tParent rank: " << parent.second.get_rank()
-                          << std::endl;
-              }
-            },
-            item_info.get_rank());
-      }
-    }
-  }
-  */
-
   void all_compress() {
-    // check_parent_ranks();
     struct rep_query {
       value_type              rep;
       std::vector<value_type> local_inquiring_items;

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -394,7 +394,7 @@ class disjoint_set_impl {
         p_dset->comm().async(inquiring_rank, update_rep_functor(), p_dset, item,
                              rep);
       } else {  // May need to hold because this item is in the current level
-        query_iter = queries.find(item_info.get_parent());
+        auto query_iter = queries.find(item_info.get_parent());
         if ((query_iter != queries.end()) &&
             (query_iter->second.returned == false)) {
           // if (queries.count(

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -327,17 +327,18 @@ class disjoint_set_impl {
 
   void check_parent_ranks() {
     for (const auto &[local_item, item_info] : m_local_item_parent_map) {
-      async_visit(
-          item_info.get_parent(),
-          [](const auto &parent, const auto &child_rank) {
-            if (parent.second.get_rank() <= child_rank &&
-                parent.second.get_rank() > 0) {
-              std::cout << "Child rank: " << child_rank
-                        << "\tParent rank: " << parent.second.get_rank()
-                        << std::endl;
-            }
-          },
-          item_info.get_rank());
+      if (item_info.get_parent() != local_item) {
+        async_visit(
+            item_info.get_parent(),
+            [](const auto &parent, const auto &child_rank) {
+              if (parent.second.get_rank() <= child_rank) {
+                std::cout << "Child rank: " << child_rank
+                          << "\tParent rank: " << parent.second.get_rank()
+                          << std::endl;
+              }
+            },
+            item_info.get_rank());
+      }
     }
   }
 

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -384,13 +384,13 @@ class disjoint_set_impl {
         local_rep_query.local_inquiring_items.clear();
         */
 
-        auto rep_query_iter      = queries.find(parent);
-        rep_query_iter->rep      = rep;
-        rep_query_iter->returned = true;
+        auto rep_query_iter             = queries.find(parent);
+        rep_query_iter->second.rep      = rep;
+        rep_query_iter->second.returned = true;
 
         // Set parents of local items before any YGM calls
         std::vector<value_type> local_items_copy =
-            rep_query_iter->local_inquiring_items;
+            rep_query_iter->second.local_inquiring_items;
         for (const auto &local_item : local_items_copy) {
           p_dset->local_set_parent(local_item, rep);
         }

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -394,9 +394,12 @@ class disjoint_set_impl {
         p_dset->comm().async(inquiring_rank, update_rep_functor(), p_dset, item,
                              rep);
       } else {  // May need to hold because this item is in the current level
-        if (queries.count(
-                item_info.get_parent())) {  // If query is ongoing for my
-                                            // parent, hold response
+        query_iter = queries.find(item_info.get_parent());
+        if ((query_iter != queries.end()) &&
+            (query_iter->second.returned == false)) {
+          // if (queries.count(
+          // item_info.get_parent())) {  // If query is ongoing for my
+          //  parent, hold response
           held_responses[item].push_back(inquiring_rank);
         } else {
           p_dset->comm().async(inquiring_rank, update_rep_functor(), p_dset,

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -325,6 +325,7 @@ class disjoint_set_impl {
     async_visit(a, simul_parent_walk_functor(), a, b, b, -1, a, b, args...);
   }
 
+  /*
   void check_parent_ranks() {
     for (const auto &[local_item, item_info] : m_local_item_parent_map) {
       if (item_info.get_parent() != local_item) {
@@ -341,9 +342,10 @@ class disjoint_set_impl {
       }
     }
   }
+  */
 
   void all_compress() {
-    check_parent_ranks();
+    // check_parent_ranks();
     struct rep_query {
       value_type              rep;
       std::vector<value_type> local_inquiring_items;
@@ -361,7 +363,7 @@ class disjoint_set_impl {
      public:
       void operator()(self_ygm_ptr_type p_dset, const value_type &parent,
                       const value_type &rep) {
-        auto local_rep_query     = queries.at(parent);
+        auto &local_rep_query    = queries.at(parent);
         local_rep_query.rep      = rep;
         local_rep_query.returned = true;
 
@@ -407,7 +409,6 @@ class disjoint_set_impl {
 
     level = max_rank();
     while (level > 0) {
-      /*
       int outstanding_query_children{0};
       for (const auto &[parent, query] : queries) {
         outstanding_query_children += query.local_inquiring_items.size();
@@ -420,7 +421,6 @@ class disjoint_set_impl {
         m_comm.cout() << "Held responses remaining: " << held_responses.size()
                       << std::endl;
       }
-      */
 
       --level;  // Start at second highest level
       queries.clear();

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -330,7 +330,8 @@ class disjoint_set_impl {
       async_visit(
           item_info.get_parent(),
           [](const auto &parent, const auto &child_rank) {
-            if (parent.second.get_rank() <= child_rank) {
+            if (parent.second.get_rank() <= child_rank &&
+                parent.second.get_rank() > 0) {
               std::cout << "Child rank: " << child_rank
                         << "\tParent rank: " << parent.second.get_rank()
                         << std::endl;

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -389,6 +389,7 @@ class disjoint_set_impl {
 
     level = max_rank();
     while (level > 0) {
+      /*
       int outstanding_query_children{0};
       for (const auto &[parent, query] : queries) {
         outstanding_query_children += query.local_inquiring_items.size();
@@ -401,6 +402,7 @@ class disjoint_set_impl {
         m_comm.cout() << "Held responses remaining: " << held_responses.size()
                       << std::endl;
       }
+      */
 
       --level;  // Start at second highest level
       queries.clear();

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -325,7 +325,23 @@ class disjoint_set_impl {
     async_visit(a, simul_parent_walk_functor(), a, b, b, -1, a, b, args...);
   }
 
+  void check_parent_ranks() {
+    for (const auto &[local_item, item_info] : m_local_item_parent_map) {
+      async_visit(
+          item_info.get_parent(),
+          [](const auto &parent, const auto &child_rank) {
+            if (parent.second.get_rank() <= child_rank) {
+              std::cout << "Child rank: " << child_rank
+                        << "\tParent rank: " << parent.second.get_rank()
+                        << std::endl;
+            }
+          },
+          item_info.get_rank());
+    }
+  }
+
   void all_compress() {
+    check_parent_ranks();
     struct rep_query {
       value_type              rep;
       std::vector<value_type> local_inquiring_items;

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -428,7 +428,8 @@ class disjoint_set_impl {
 
       // Prepare all queries for this round
       for (const auto &[local_item, item_info] : m_local_item_parent_map) {
-        if (item_info.get_rank() == level) {
+        if (item_info.get_rank() == level &&
+            item_info.get_parent() != local_item) {
           auto query_iter = queries.find(item_info.get_parent());
           if (query_iter == queries.end()) {  // Have not queried for parent's
                                               // rep. Begin new query.

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -389,6 +389,19 @@ class disjoint_set_impl {
 
     level = max_rank();
     while (level > 0) {
+      int outstanding_query_children{0};
+      for (const auto &[parent, query] : queries) {
+        outstanding_query_children += query.local_inquiring_items.size();
+      }
+      if (outstanding_query_children > 0) {
+        m_comm.cout() << "Awaiting query responses: "
+                      << outstanding_query_children << std::endl;
+      }
+      if (held_responses.size() > 0) {
+        m_comm.cout() << "Held responses remaining: " << held_responses.size()
+                      << std::endl;
+      }
+
       --level;  // Start at second highest level
       queries.clear();
       held_responses.clear();


### PR DESCRIPTION
Fixes a race condition in disjoint_set::all_compress(). Previously when a rank received a parent query, it would use the status of its query of the item's parent to determine whether to hold onto response. The item's parent could have been updated to the root already while another item held locally was waiting on a query directly to the root, causing the incoming query to be erroneously held onto.