### PR TITLE
Rewrites ygm::container::disjoint_set to use union by rank with path-splitting and local caches on each process

### DIFF
--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -341,8 +341,6 @@ class disjoint_set_impl {
         if (my_parent == my_item) {  // Has not found new parent
           item_data.second.increase_rank(merging_rank + 1);
         } else {  // Tell merging item about new parent
-          p_dset->m_stats
-              .template increment_counter<"stale_successful_merges">();
           p_dset->async_visit(
               merging_item,
               [](auto p_dset, auto &item_data, const value_type &new_parent,

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -487,6 +487,8 @@ class disjoint_set_impl {
   }
 
   void all_compress() {
+    m_comm.barrier();
+
     // Exit if no async_union(_and_execute) since last compress
     if (logical_and(m_is_compressed, m_comm) == true) {
       return;
@@ -507,6 +509,8 @@ class disjoint_set_impl {
         local_item_status;  // For holding incoming queries while my items are
                             // waiting for their representatives (only needed
                             // for when parent rank is same as mine)
+    queries.clear();
+    local_item_status.clear();
 
     struct update_rep_functor {
      public:

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -4,19 +4,23 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <fstream>
 #include <unordered_map>
 #include <vector>
+#include <ygm/collective.hpp>
 #include <ygm/comm.hpp>
 #include <ygm/container/container_traits.hpp>
 #include <ygm/container/detail/hash_partitioner.hpp>
 #include <ygm/detail/ygm_ptr.hpp>
 #include <ygm/detail/ygm_traits.hpp>
+#include <ygm/stats_tracker.hpp>
 
 namespace ygm::container::detail {
 template <typename Item, typename Partitioner>
 class disjoint_set_impl {
  public:
-  class rank_parent_t;
+  struct data_t;
+
   using self_type          = disjoint_set_impl<Item, Partitioner>;
   using self_ygm_ptr_type  = typename ygm::ygm_ptr<self_type>;
   using value_type         = Item;
@@ -24,46 +28,124 @@ class disjoint_set_impl {
   using ygm_for_all_types  = std::tuple<Item, Item>;
   using ygm_container_type = ygm::container::disjoint_set_tag;
   using rank_type          = int16_t;
-  using parent_map_type    = std::map<value_type, rank_parent_t>;
+  using item_map_type      = std::map<value_type, data_t>;
 
   Partitioner partitioner;
 
-  class rank_parent_t {
+  struct data_t {
    public:
-    rank_parent_t() : m_rank{-1} {}
+    friend disjoint_set_impl;
 
-    rank_parent_t(const rank_type rank, const value_type &parent)
-        : m_rank(rank), m_parent(parent) {}
-
-    bool increase_rank(rank_type new_rank) {
-      if (new_rank > m_rank) {
-        m_rank = new_rank;
-        return true;
-      } else {
-        return false;
-      }
-    }
-
-    void set_parent(const value_type &new_parent) { m_parent = new_parent; }
-
-    const rank_type   get_rank() const { return m_rank; }
     const value_type &get_parent() const { return m_parent; }
+
+    const rank_type get_rank() const { return m_rank; }
+
+    const rank_type get_parent_rank_estimate() const {
+      return m_parent_rank_est;
+    }
 
     template <typename Archive>
     void serialize(Archive &ar) {
-      ar(m_parent, m_rank);
+      ar(m_parent, m_rank, m_parent_rank_est);
     }
 
    private:
-    rank_type  m_rank;
+    void increase_rank(const rank_type new_rank) {
+      ASSERT_RELEASE(m_rank < new_rank);
+      m_rank = new_rank;
+
+      // Only called on roots
+      m_parent_rank_est = new_rank;
+    }
+
+    // Set parent if estimated parent rank is no worse than current estimate
+    void set_parent(const value_type &parent, const rank_type parent_rank_est) {
+      if (parent_rank_est >= m_parent_rank_est) {
+        m_parent          = parent;
+        m_parent_rank_est = parent_rank_est;
+      }
+    }
+
+    void set_parent(const value_type &parent) { m_parent = parent; }
+
     value_type m_parent;
+    rank_type  m_rank            = 0;
+    rank_type  m_parent_rank_est = 0;
   };
 
-  disjoint_set_impl(ygm::comm &comm) : m_comm(comm), pthis(this) {
+  class hash_cache {
+   public:
+    class cache_entry {
+     public:
+      cache_entry() : occupied(false) {}
+
+      cache_entry(const value_type &_item, const value_type &_parent,
+                  const rank_type _parent_rank_est)
+          : item(_item), parent(_parent), parent_rank_est(_parent_rank_est) {}
+
+      bool       occupied = false;
+      value_type item;
+      value_type parent;
+      rank_type  parent_rank_est;
+    };
+
+    hash_cache(const size_t cache_size)
+        : m_cache_size(cache_size), m_cache(cache_size) {
+      for (size_t i = 0; i < m_cache_size; ++i) {
+        m_cache[i] = cache_entry();
+      }
+    }
+
+    void add_cache_entry(const value_type &item, const value_type &parent,
+                         const rank_type parent_rank_est) {
+      size_t index = std::hash<value_type>()(item) % m_cache_size;
+
+      auto &current_entry = m_cache[index];
+
+      // Only replace cached value if current slot is empty or if new entry's
+      // rank is higher
+      if (current_entry.occupied == false ||
+          parent_rank_est >= current_entry.parent_rank_est) {
+        // m_stats.increment_counter<"successful_cache_additions">();
+        current_entry.occupied        = true;
+        current_entry.item            = item;
+        current_entry.parent          = parent;
+        current_entry.parent_rank_est = parent_rank_est;
+      }
+    }
+
+    const cache_entry &get_cache_entry(const value_type &item) {
+      size_t index = std::hash<value_type>()(item) % m_cache_size;
+
+      return m_cache[index];
+    }
+
+    void clear() {
+      for (auto &entry : m_cache) {
+        entry.occupied = false;
+      }
+    }
+
+    // private:
+    size_t                   m_cache_size;
+    std::vector<cache_entry> m_cache;
+  };
+
+  disjoint_set_impl(ygm::comm &comm, const size_t cache_size)
+      : m_comm(comm),
+        pthis(this),
+        m_stats(m_comm),
+        m_cache(cache_size) /*,
+         m_log_ofs("/p/lustre1/steil1/amst_log/rank" +
+                   std::to_string(m_comm.rank()) + ".log")*/
+  {
     pthis.check(m_comm);
   }
 
-  ~disjoint_set_impl() { m_comm.barrier(); }
+  ~disjoint_set_impl() {
+    m_comm.barrier();
+    m_stats.print();
+  }
 
   typename ygm::ygm_ptr<self_type> get_ygm_ptr() const { return pthis; }
 
@@ -73,19 +155,19 @@ class disjoint_set_impl {
     int  dest          = owner(item);
     auto visit_wrapper = [](auto p_dset, const value_type &item,
                             const VisitorArgs &...args) {
-      auto rank_parent_pair_iter = p_dset->m_local_item_parent_map.find(item);
-      if (rank_parent_pair_iter == p_dset->m_local_item_parent_map.end()) {
-        rank_parent_t new_ranked_item = rank_parent_t(0, item);
-        rank_parent_pair_iter =
-            p_dset->m_local_item_parent_map
-                .insert(std::make_pair(item, new_ranked_item))
+      auto item_data_iter = p_dset->m_local_item_map.find(item);
+      if (item_data_iter == p_dset->m_local_item_map.end()) {
+        data_t new_item_data;
+        new_item_data.set_parent(item, 0);
+        item_data_iter =
+            p_dset->m_local_item_map.insert(std::make_pair(item, new_item_data))
                 .first;
       }
       Visitor *vis = nullptr;
 
       ygm::meta::apply_optional(
           *vis, std::make_tuple(p_dset),
-          std::forward_as_tuple(*rank_parent_pair_iter, args...));
+          std::forward_as_tuple(*item_data_iter, args...));
     };
 
     m_comm.async(dest, visit_wrapper, pthis, item,
@@ -93,74 +175,119 @@ class disjoint_set_impl {
   }
 
   void async_union(const value_type &a, const value_type &b) {
-    static auto update_parent_lambda = [](auto             &item_info,
-                                          const value_type &new_parent) {
-      item_info.second.set_parent(new_parent);
-    };
+    m_is_compressed = false;
+    m_stats.increment_counter<"async_union">();
+    static auto update_parent_and_cache_lambda =
+        [](auto p_dset, auto &item_data, const value_type &old_parent,
+           const value_type &new_parent, const rank_type &new_parent_rank_est) {
+          p_dset->m_cache.add_cache_entry(old_parent, new_parent,
+                                          new_parent_rank_est);
 
-    static auto resolve_merge_lambda = [](auto p_dset, auto &item_info,
+          p_dset->m_stats.template increment_counter<"update_parent">();
+          item_data.second.set_parent(new_parent, new_parent_rank_est);
+        };
+
+    static auto resolve_merge_lambda = [](auto p_dset, auto &item_data,
                                           const value_type &merging_item,
                                           const rank_type   merging_rank) {
-      const auto &my_item   = item_info.first;
-      const auto  my_rank   = item_info.second.get_rank();
-      const auto &my_parent = item_info.second.get_parent();
+      p_dset->m_stats.template increment_counter<"merge_resolutions">();
+      const auto &my_item   = item_data.first;
+      const auto  my_rank   = item_data.second.get_rank();
+      const auto &my_parent = item_data.second.get_parent();
+      const auto  my_parent_rank_est =
+          item_data.second.get_parent_rank_estimate();
       ASSERT_RELEASE(my_rank >= merging_rank);
 
       if (my_rank > merging_rank) {
+        p_dset->m_stats
+            .template increment_counter<"unsuccessful_merge_resolutions">();
         return;
       } else {
         ASSERT_RELEASE(my_rank == merging_rank);
         if (my_parent ==
             my_item) {  // Merging new item onto root. Need to increase rank.
-          item_info.second.increase_rank(merging_rank + 1);
+          p_dset->m_stats.template increment_counter<"rank_increases">();
+          item_data.second.increase_rank(merging_rank + 1);
         } else {  // Tell merging item about new parent
+          p_dset->m_stats
+              .template increment_counter<"stale_successful_merges">();
           p_dset->async_visit(
               merging_item,
-              [](auto &item_info, const value_type &new_parent) {
-                item_info.second.set_parent(new_parent);
+              [](auto p_dset, auto &item_data, const value_type &new_parent,
+                 const rank_type &new_parent_rank_est) {
+                item_data.second.set_parent(new_parent, new_parent_rank_est);
               },
-              my_parent);
+              my_parent, my_parent_rank_est);
         }
       }
     };
 
     // Walking up parent trees can be expressed as a recursive operation
     struct simul_parent_walk_functor {
-      void operator()(self_ygm_ptr_type                           p_dset,
-                      std::pair<const value_type, rank_parent_t> &my_item_info,
-                      const value_type                           &my_child,
-                      const value_type                           &other_parent,
-                      const value_type                           &other_item,
-                      const rank_type                             other_rank) {
+      void operator()(self_ygm_ptr_type                    p_dset,
+                      std::pair<const value_type, data_t> &my_item_data,
+                      const value_type &my_child, value_type other_parent,
+                      value_type other_item, rank_type other_rank) {
         // Note: other_item needs rank info for comparison with my_item's
         // parent. All others need rank and item to determine if other_item
         // has been visited/initialized.
+        p_dset->m_stats.template increment_counter<"walk_functors">();
 
-        const value_type &my_item   = my_item_info.first;
-        const rank_type  &my_rank   = my_item_info.second.get_rank();
-        const value_type &my_parent = my_item_info.second.get_parent();
+        value_type my_item   = my_item_data.first;
+        rank_type  my_rank   = my_item_data.second.get_rank();
+        value_type my_parent = my_item_data.second.get_parent();
+        rank_type  my_parent_rank_est =
+            my_item_data.second.get_parent_rank_estimate();
+
+        std::tie(my_parent, my_parent_rank_est) =
+            p_dset->walk_cache(my_parent, my_rank);
+        std::tie(other_parent, other_rank) =
+            p_dset->walk_cache(other_parent, other_rank);
 
         // Path splitting
         if (my_child != my_item) {
-          p_dset->async_visit(my_child, update_parent_lambda, my_parent);
+          p_dset->async_visit(my_child, update_parent_and_cache_lambda, my_item,
+                              my_parent, my_parent_rank_est);
         }
 
         if (my_parent == other_parent || my_parent == other_item) {
           return;
         }
 
-        if (my_rank > other_rank) {  // Other path has lower rank
+        if (my_parent_rank_est > other_rank) {  // Other path has lower rank
           p_dset->async_visit(other_parent, simul_parent_walk_functor(),
-                              other_item, my_parent, my_item, my_rank);
-        } else if (my_rank == other_rank) {
+                              other_item, my_parent, my_item,
+                              my_parent_rank_est);
+        }
+
+        if (my_parent_rank_est < other_rank) {  // Current path has lower rank
+          if (my_parent == my_item) {           // At a root
+            p_dset->m_stats.template increment_counter<"roots_reached">();
+            p_dset->m_stats.template increment_counter<"successful_merges">();
+            my_item_data.second.set_parent(
+                other_parent, other_rank);  // Safe to attach to other path
+
+            return;
+          } else {  // Not at a root
+            // Continue walking current path
+            p_dset->async_visit(my_parent, simul_parent_walk_functor(), my_item,
+                                other_parent, other_item, other_rank);
+          }
+        }
+
+        if (my_parent_rank_est == other_rank) {
           if (my_parent == my_item) {  // At a root
+            p_dset->m_stats.template increment_counter<"roots_reached">();
 
             if (my_item < other_parent) {  // Need to break ties in rank before
                                            // merging to avoid cycles of merges
                                            // creating cycles in disjoint set
               // Perform merge
-              my_item_info.second.set_parent(
-                  other_parent);  // other_parent may be of same rank as my_item
+              p_dset->m_stats.template increment_counter<"successful_merges">();
+              my_item_data.second.set_parent(
+                  other_parent,
+                  my_rank);  // other_parent may be of same rank as my_item
+
               p_dset->async_visit(other_parent, resolve_merge_lambda, my_item,
                                   my_rank);
             } else {
@@ -173,96 +300,226 @@ class disjoint_set_impl {
             p_dset->async_visit(my_parent, simul_parent_walk_functor(), my_item,
                                 other_parent, other_item, other_rank);
           }
-        } else {                       // Current path has lower rank
-          if (my_parent == my_item) {  // At a root
-            my_item_info.second.set_parent(
-                other_parent);  // Safe to attach to other path
-          } else {              // Not at a root
-            // Continue walking current path
-            p_dset->async_visit(my_parent, simul_parent_walk_functor(), my_item,
-                                other_parent, other_item, other_rank);
-          }
         }
       }
     };
 
-    async_visit(a, simul_parent_walk_functor(), a, b, b, -1);
+    // Walk cache for initial items
+    value_type my_item   = a;
+    rank_type  my_rank   = -1;
+    value_type my_parent = a;
+
+    value_type other_item   = b;
+    rank_type  other_rank   = -1;
+    value_type other_parent = b;
+
+    std::tie(my_parent, my_rank)       = walk_cache(my_parent, my_rank);
+    std::tie(other_parent, other_rank) = walk_cache(other_parent, other_rank);
+
+    if (my_rank <= other_rank) {
+      async_visit(my_parent, simul_parent_walk_functor(), my_item, other_parent,
+                  other_item, other_rank);
+    } else {
+      async_visit(other_parent, simul_parent_walk_functor(), other_item,
+                  my_parent, my_item, my_rank);
+    }
   }
 
   template <typename Function, typename... FunctionArgs>
   void async_union_and_execute(const value_type &a, const value_type &b,
                                Function fn, const FunctionArgs &...args) {
-    static auto update_parent_lambda = [](auto             &item_info,
-                                          const value_type &new_parent) {
-      item_info.second.set_parent(new_parent);
-    };
+    m_is_compressed = false;
+    m_stats.increment_counter<"async_union_and_execute">();
+    static auto update_parent_and_cache_lambda =
+        [](auto p_dset, auto &item_data, const value_type &old_parent,
+           const value_type &new_parent, const rank_type &new_parent_rank_est) {
+          size_t index = std::hash<value_type>()(old_parent) %
+                         p_dset->m_cache.m_cache_size;
 
-    static auto resolve_merge_lambda = [](auto p_dset, auto &item_info,
+          auto &current_entry = p_dset->m_cache.m_cache[index];
+
+          /*
+          boost::json::object log_entry;
+          log_entry["curr_cache_item"]   = current_entry.item;
+          log_entry["curr_cache_parent"] = current_entry.parent;
+          log_entry["curr_cache_parent_rank_est"] =
+              current_entry.parent_rank_est;
+          log_entry["new_cache_item"]            = old_parent;
+          log_entry["new_cache_parent"]          = new_parent;
+          log_entry["new_cache_parent_rank_est"] = new_parent_rank_est;
+          */
+          if (current_entry.occupied == false ||
+              new_parent_rank_est >= current_entry.parent_rank_est) {
+            // log_entry["action"] = "replace";
+          } else {
+            // log_entry["action"] = "ignore";
+          }
+          // p_dset->m_log_ofs << log_entry << "\n";
+
+          p_dset->m_stats.template increment_counter<"update_parent">();
+          p_dset->m_cache.add_cache_entry(old_parent, new_parent,
+                                          new_parent_rank_est);
+
+          item_data.second.set_parent(new_parent, new_parent_rank_est);
+        };
+
+    static auto resolve_merge_lambda = [](auto p_dset, auto &item_data,
                                           const value_type &merging_item,
                                           const rank_type   merging_rank) {
-      const auto &my_item   = item_info.first;
-      const auto  my_rank   = item_info.second.get_rank();
-      const auto &my_parent = item_info.second.get_parent();
+      p_dset->m_stats.template increment_counter<"merge_resolutions">();
+      const auto &my_item   = item_data.first;
+      const auto  my_rank   = item_data.second.get_rank();
+      const auto &my_parent = item_data.second.get_parent();
+      const auto  my_parent_rank_est =
+          item_data.second.get_parent_rank_estimate();
       ASSERT_RELEASE(my_rank >= merging_rank);
 
       if (my_rank > merging_rank) {
+        p_dset->m_stats
+            .template increment_counter<"unsuccessful_merge_resolutions">();
         return;
       } else {
         ASSERT_RELEASE(my_rank == merging_rank);
         if (my_parent == my_item) {  // Has not found new parent
-          item_info.second.increase_rank(merging_rank + 1);
+          p_dset->m_stats.template increment_counter<"rank_increases">();
+          item_data.second.increase_rank(merging_rank + 1);
         } else {  // Tell merging item about new parent
+          p_dset->m_stats
+              .template increment_counter<"stale_successful_merges">();
           p_dset->async_visit(
               merging_item,
-              [](auto &item_info, const value_type &new_parent) {
-                item_info.second.set_parent(new_parent);
+              [](auto p_dset, auto &item_data, const value_type &new_parent,
+                 const rank_type new_parent_rank_est) {
+                item_data.second.set_parent(new_parent, new_parent_rank_est);
               },
-              my_parent);
+              my_parent, my_parent_rank_est);
         }
       }
     };
 
     // Walking up parent trees can be expressed as a recursive operation
     struct simul_parent_walk_functor {
-      void operator()(self_ygm_ptr_type                           p_dset,
-                      std::pair<const value_type, rank_parent_t> &my_item_info,
-                      const value_type                           &my_child,
-                      const value_type                           &other_parent,
-                      const value_type &other_item, const rank_type other_rank,
+      void operator()(self_ygm_ptr_type                    p_dset,
+                      std::pair<const value_type, data_t> &my_item_data,
+                      const value_type &my_child, value_type other_parent,
+                      value_type other_item, rank_type other_rank,
                       const value_type &orig_a, const value_type &orig_b,
                       const FunctionArgs &...args) {
+        // boost::json::object log_entry;
+
         // Note: other_item needs rank info for comparison with my_item's
         // parent. All others need rank and item to determine if other_item
         // has been visited/initialized.
+        p_dset->m_stats.template increment_counter<"walk_functors">();
 
-        const value_type &my_item   = my_item_info.first;
-        const rank_type  &my_rank   = my_item_info.second.get_rank();
-        const value_type &my_parent = my_item_info.second.get_parent();
+        value_type my_item   = my_item_data.first;
+        rank_type  my_rank   = my_item_data.second.get_rank();
+        value_type my_parent = my_item_data.second.get_parent();
+        rank_type  my_parent_rank_est =
+            my_item_data.second.get_parent_rank_estimate();
+
+        my_parent_rank_est = std::max<rank_type>(my_rank, my_parent_rank_est);
+
+        /*
+        log_entry["comm_rank"]    = p_dset->m_comm.rank();
+        log_entry["item"]         = my_item;
+        log_entry["child"]        = my_child;
+        log_entry["parent"]       = my_parent;
+        log_entry["rank"]         = my_rank;
+        log_entry["other_item"]   = other_item;
+        log_entry["other_parent"] = other_parent;
+        log_entry["other_rank"]   = other_rank;
+        */
+
+        std::tie(my_parent, my_parent_rank_est) =
+            p_dset->walk_cache(my_parent, my_rank);
+        std::tie(other_parent, other_rank) =
+            p_dset->walk_cache(other_parent, other_rank);
+
+        /*
+        log_entry["parent_walk"]       = my_parent;
+        log_entry["rank_walk"]         = my_rank;
+        log_entry["other_parent_walk"] = other_parent;
+        log_entry["other_rank_walk"]   = other_rank;
+        */
 
         // Path splitting
         if (my_child != my_item) {
-          p_dset->async_visit(my_child, update_parent_lambda, my_parent);
+          p_dset->async_visit(my_child, update_parent_and_cache_lambda, my_item,
+                              my_parent, my_rank);
         }
 
         if (my_parent == other_parent || my_parent == other_item) {
+          // log_entry["action"] = "return";
+          // p_dset->m_log_ofs << log_entry << "\n";
           return;
         }
 
-        if (my_rank > other_rank) {  // Other path has lower rank
+        if (my_parent_rank_est > other_rank) {  // Other path has lower rank
+                                                /*
+          log_entry["next"]   = other_parent;
+          log_entry["action"] = "switch";
+          p_dset->m_log_ofs << log_entry << "\n";
+          */
           p_dset->async_visit(other_parent, simul_parent_walk_functor(),
-                              other_item, my_parent, my_item, my_rank, orig_a,
-                              orig_b, args...);
-        } else if (my_rank == other_rank) {
+                              other_item, my_parent, my_item,
+                              my_parent_rank_est, orig_a, orig_b, args...);
+        }
+
+        if (my_parent_rank_est < other_rank) {  // Current path has lower rank
+          if (my_parent == my_item) {           // At a root
+                                                /*
+            log_entry["root"]   = my_item;
+            log_entry["action"] = "attach";
+            p_dset->m_log_ofs << log_entry << "\n";
+            */
+            p_dset->m_stats.template increment_counter<"roots_reached">();
+            p_dset->m_stats.template increment_counter<"successful_merges">();
+            my_item_data.second.set_parent(
+                other_parent, other_rank);  // Safe to attach to other path
+
+            // Perform user function after merge
+            Function *f = nullptr;
+            ygm::meta::apply_optional(
+                *f, std::make_tuple(p_dset),
+                std::forward_as_tuple(orig_a, orig_b, args...));
+
+            return;
+
+          } else {  // Not at a root
+                    /*
+            log_entry["next"]   = my_parent;
+            log_entry["action"] = "continue";
+            p_dset->m_log_ofs << log_entry << "\n";
+            */
+            //   Continue walking current path
+            p_dset->async_visit(my_parent, simul_parent_walk_functor(), my_item,
+                                other_parent, other_item, other_rank, orig_a,
+                                orig_b, args...);
+          }
+        }
+
+        if (my_parent_rank_est == other_rank) {
           if (my_parent == my_item) {  // At a root
+            // log_entry["root"] = my_item;
+            p_dset->m_stats.template increment_counter<"roots_reached">();
 
             if (my_item < other_parent) {  // Need to break ties in rank before
-                                           // merging to avoid cycles of merges
-                                           // creating cycles in disjoint set
+              // merging to avoid cycles of merges
+              // creating cycles in disjoint set
               // Perform merge
-              my_item_info.second.set_parent(
-                  other_parent);  // Guaranteed any path through current
-                                  // item will find an item with rank >=
-                                  // my_rank+1 by going to other_parent
+              /*
+              log_entry["action"] = "attach";
+              p_dset->m_log_ofs << log_entry << "\n";
+              */
+              p_dset->m_stats.template increment_counter<"successful_merges">();
+
+              // Guaranteed any path through current
+              // item will find an item with rank >=
+              // my_rank+1 by going to other_parent
+              // Cannot set parent_rank_est to my_rank+1 until certain new
+              // parent's rank has been updated
+              my_item_data.second.set_parent(other_parent, my_rank);
 
               // Perform user function after merge
               Function *f = nullptr;
@@ -283,37 +540,26 @@ class disjoint_set_impl {
                     "with (const value_type &, const value_type &) signature");
               }
 
-              return;
-
               p_dset->async_visit(other_parent, resolve_merge_lambda, my_item,
                                   my_rank);
             } else {
-              // Switch to other path to attempt merge
+              /*
+              log_entry["next"]   = other_parent;
+              log_entry["action"] = "switch";
+              p_dset->m_log_ofs << log_entry << "\n";
+              */
+              //   Switch to other path to attempt merge
               p_dset->async_visit(other_parent, simul_parent_walk_functor(),
                                   other_item, my_parent, my_item, my_rank,
                                   orig_a, orig_b, args...);
             }
           } else {  // Not at a root
-            // Continue walking current path
-            p_dset->async_visit(my_parent, simul_parent_walk_functor(), my_item,
-                                other_parent, other_item, other_rank, orig_a,
-                                orig_b, args...);
-          }
-        } else {                       // Current path has lower rank
-          if (my_parent == my_item) {  // At a root
-            my_item_info.second.set_parent(
-                other_parent);  // Safe to attach to other path
-
-            // Perform user function after merge
-            Function *f = nullptr;
-            ygm::meta::apply_optional(
-                *f, std::make_tuple(p_dset),
-                std::forward_as_tuple(orig_a, orig_b, args...));
-
-            return;
-
-          } else {  // Not at a root
-            // Continue walking current path
+                    /*
+            log_entry["next"]   = my_parent;
+            log_entry["action"] = "continue";
+            p_dset->m_log_ofs << log_entry << "\n";
+            */
+            //   Continue walking current path
             p_dset->async_visit(my_parent, simul_parent_walk_functor(), my_item,
                                 other_parent, other_item, other_rank, orig_a,
                                 orig_b, args...);
@@ -322,10 +568,33 @@ class disjoint_set_impl {
       }
     };
 
-    async_visit(a, simul_parent_walk_functor(), a, b, b, -1, a, b, args...);
+    // Walk cache for initial items
+    value_type my_item   = a;
+    rank_type  my_rank   = -1;
+    value_type my_parent = a;
+
+    value_type other_item   = b;
+    rank_type  other_rank   = -1;
+    value_type other_parent = b;
+
+    std::tie(my_parent, my_rank)       = walk_cache(my_parent, my_rank);
+    std::tie(other_parent, other_rank) = walk_cache(other_parent, other_rank);
+
+    if (my_rank <= other_rank) {
+      async_visit(my_parent, simul_parent_walk_functor(), my_item, other_parent,
+                  other_item, other_rank, a, b, args...);
+    } else {
+      async_visit(other_parent, simul_parent_walk_functor(), other_item,
+                  my_parent, my_item, my_rank, a, b, args...);
+    }
   }
 
   void all_compress() {
+    // Exit if no async_union(_and_execute) since last compress
+    if (logical_and(m_is_compressed, m_comm) == true) {
+      return;
+    }
+
     struct rep_query {
       value_type              rep;
       std::vector<value_type> local_inquiring_items;
@@ -336,7 +605,6 @@ class disjoint_set_impl {
       std::vector<int> held_responses;
     };
 
-    static rank_type                                 level;
     static std::unordered_map<value_type, rep_query> queries;
     static std::unordered_map<value_type, item_status>
         local_item_status;  // For holding incoming queries while my items are
@@ -351,7 +619,7 @@ class disjoint_set_impl {
         local_rep_query.rep   = rep;
 
         for (const auto &local_item : local_rep_query.local_inquiring_items) {
-          p_dset->local_set_parent(local_item, rep);
+          p_dset->m_local_item_map[local_item].set_parent(rep);
 
           // Forward rep for any held responses
           auto local_item_statuses_iter = local_item_status.find(local_item);
@@ -370,64 +638,51 @@ class disjoint_set_impl {
 
     auto query_rep_lambda = [](self_ygm_ptr_type p_dset, const value_type &item,
                                int inquiring_rank) {
-      const auto &item_info = p_dset->m_local_item_parent_map[item];
+      const auto &item_info = p_dset->m_local_item_map[item];
 
-      if (item_info.get_rank() > level) {
-        const value_type &rep = item_info.get_parent();
-
+      // May need to hold because this item is in the current level
+      auto local_item_status_iter = local_item_status.find(item);
+      // If query is ongoing for my parent, hold response
+      if ((local_item_status_iter != local_item_status.end()) &&
+          (local_item_status_iter->second.found_root == false)) {
+        local_item_status[item].held_responses.push_back(inquiring_rank);
+      } else {
         p_dset->comm().async(inquiring_rank, update_rep_functor(), p_dset, item,
-                             rep);
-      } else {  // May need to hold because this item is in the current level
-        auto local_item_status_iter = local_item_status.find(item);
-        // If query is ongoing for my parent, hold response
-        if ((local_item_status_iter != local_item_status.end()) &&
-            (local_item_status_iter->second.found_root == false)) {
-          local_item_status[item].held_responses.push_back(inquiring_rank);
-        } else {
-          p_dset->comm().async(inquiring_rank, update_rep_functor(), p_dset,
-                               item, item_info.get_parent());
-        }
+                             item_info.get_parent());
       }
     };
 
     m_comm.barrier();
 
-    level = max_rank();
-    while (level >= 0) {
-      queries.clear();
-      local_item_status.clear();
+    // Prepare all queries and local_item_status objects for rank
+    for (const auto &[local_item, item_info] : m_local_item_map) {
+      if (item_info.get_parent() != local_item) {
+        local_item_status[local_item].found_root = false;
 
-      // Prepare all queries for this round
-      for (const auto &[local_item, item_info] : m_local_item_parent_map) {
-        if (item_info.get_rank() == level &&
-            item_info.get_parent() != local_item) {
-          local_item_status[local_item].found_root = false;
+        auto query_iter = queries.find(item_info.get_parent());
+        if (query_iter == queries.end()) {  // Have not queried for parent's
+                                            // rep. Begin new query.
+          auto &new_query = queries[item_info.get_parent()];
+          new_query.rep   = item_info.get_parent();
+          new_query.local_inquiring_items.push_back(local_item);
 
-          auto query_iter = queries.find(item_info.get_parent());
-          if (query_iter == queries.end()) {  // Have not queried for parent's
-                                              // rep. Begin new query.
-            auto &new_query = queries[item_info.get_parent()];
-            new_query.rep   = item_info.get_parent();
-            new_query.local_inquiring_items.push_back(local_item);
-
-          } else {
-            query_iter->second.local_inquiring_items.push_back(local_item);
-          }
+        } else {
+          query_iter->second.local_inquiring_items.push_back(local_item);
         }
       }
-
-      m_comm.cf_barrier();
-
-      // Start all queries for this round
-      for (const auto &[item, query] : queries) {
-        int dest = owner(item);
-        m_comm.async(dest, query_rep_lambda, pthis, item, m_comm.rank());
-      }
-
-      m_comm.barrier();
-
-      --level;
     }
+
+    m_comm.cf_barrier();
+
+    // Start all queries
+    for (const auto &[item, query] : queries) {
+      int dest = owner(item);
+      m_comm.async(dest, query_rep_lambda, pthis, item, m_comm.rank());
+    }
+
+    m_comm.barrier();
+
+    m_is_compressed = true;
   }
 
   template <typename Function>
@@ -436,10 +691,10 @@ class disjoint_set_impl {
 
     if constexpr (std::is_invocable<decltype(fn), const value_type &,
                                     const value_type &>()) {
-      const auto end = m_local_item_parent_map.end();
-      for (auto iter = m_local_item_parent_map.begin(); iter != end; ++iter) {
-        const auto &[item, rank_parent_pair] = *iter;
-        fn(item, rank_parent_pair.get_parent());
+      const auto end = m_local_item_map.end();
+      for (auto iter = m_local_item_map.begin(); iter != end; ++iter) {
+        const auto &[item, item_data] = *iter;
+        fn(item, item_data.get_parent());
       }
     } else {
       static_assert(ygm::detail::always_false<>,
@@ -460,7 +715,7 @@ class disjoint_set_impl {
       void operator()(self_ygm_ptr_type pdset, ygm_ptr<return_type> p_to_return,
                       const value_type &source_item, const int source_rank,
                       const value_type &local_item) {
-        const auto parent = pdset->local_get_parent(local_item);
+        const auto parent = pdset->m_local_item_map[local_item].get_parent();
 
         // Found root
         if (parent == local_item) {
@@ -470,7 +725,7 @@ class disjoint_set_impl {
               dest,
               [](self_ygm_ptr_type pdset, const value_type &source_item,
                  const value_type &root) {
-                pdset->local_set_parent(source_item, root);
+                pdset->m_local_item_map[source_item].set_parent(root);
               },
               pdset, source_item, parent);
           // Send message to store return value
@@ -500,19 +755,20 @@ class disjoint_set_impl {
 
   void clear() {
     m_comm.barrier();
-    m_local_item_parent_map.clear();
+    m_local_item_map.clear();
+    m_cache.clear();
   }
 
-  size_type size() {
+  size_t size() {
     m_comm.barrier();
-    return m_comm.all_reduce_sum(m_local_item_parent_map.size());
+    return m_comm.all_reduce_sum(m_local_item_map.size());
   }
 
   size_type num_sets() {
     m_comm.barrier();
     size_t num_local_sets{0};
-    for (const auto &item_parent_pair : m_local_item_parent_map) {
-      if (item_parent_pair.first == item_parent_pair.second.get_parent()) {
+    for (const auto &[item, item_data] : m_local_item_map) {
+      if (item == item_data.get_parent()) {
         ++num_local_sets;
       }
     }
@@ -529,54 +785,59 @@ class disjoint_set_impl {
     return owner(item) == m_comm.rank();
   }
 
-  const value_type &local_get_parent(const value_type &item) {
-    ASSERT_DEBUG(is_mine(item) == true);
-
-    auto itr = m_local_item_parent_map.find(item);
-
-    // Create new set if item is not found
-    if (itr == m_local_item_parent_map.end()) {
-      m_local_item_parent_map.insert(
-          std::make_pair(item, rank_parent_t(0, item)));
-      return m_local_item_parent_map[item].get_parent();
-    } else {
-      return itr->second.get_parent();
-    }
-    return m_local_item_parent_map[item].get_parent();
-  }
-
-  const rank_type local_get_rank(const value_type &item) {
-    ASSERT_DEBUG(is_mine(item) == true);
-
-    auto itr = m_local_item_parent_map.find(item);
-
-    if (itr != m_local_item_parent_map.end()) {
-      return itr->second.get_rank();
-    }
-    return 0;
-  }
-
-  void local_set_parent(const value_type &item, const value_type &parent) {
-    m_local_item_parent_map[item].set_parent(parent);
-  }
-
   rank_type max_rank() {
     rank_type local_max{0};
 
-    for (const auto &local_item : m_local_item_parent_map) {
-      local_max = std::max<rank_type>(local_max, local_item.second.get_rank());
+    for (const auto &[item, item_data] : m_local_item_map) {
+      local_max = std::max<rank_type>(local_max, item_data.get_rank());
     }
 
-    return m_comm.all_reduce_max(local_max);
+    return max(local_max, m_comm);
   }
 
   ygm::comm &comm() { return m_comm; }
+
+ private:
+  const std::pair<value_type, rank_type> walk_cache(const value_type &item,
+                                                    const rank_type  &r) {
+    m_stats.increment_counter<"cache_walks">();
+    const typename hash_cache::cache_entry *prev_cache_entry = nullptr;
+    const typename hash_cache::cache_entry *curr_cache_entry =
+        &m_cache.get_cache_entry(item);
+
+    // Don't walk cache if first item is wrong
+    if (curr_cache_entry->item != item || not curr_cache_entry->occupied ||
+        curr_cache_entry->parent_rank_est < r) {
+      m_stats.increment_counter<"cache_walk_early_returns">();
+      return std::make_pair(item, r);
+    }
+
+    do {
+      m_stats.increment_counter<"cache_walk_steps">();
+      prev_cache_entry = curr_cache_entry;
+      curr_cache_entry = &m_cache.get_cache_entry(prev_cache_entry->parent);
+    } while (prev_cache_entry->parent == curr_cache_entry->item &&
+             curr_cache_entry->occupied &&
+             prev_cache_entry->item != curr_cache_entry->item &&
+             prev_cache_entry->parent_rank_est <=
+                 curr_cache_entry->parent_rank_est);
+
+    return std::make_pair(prev_cache_entry->parent,
+                          prev_cache_entry->parent_rank_est);
+  }
 
  protected:
   disjoint_set_impl() = delete;
 
   ygm::comm        &m_comm;
   self_ygm_ptr_type pthis;
-  parent_map_type   m_local_item_parent_map;
+  item_map_type     m_local_item_map;
+
+  ygm::stats_tracker m_stats;
+  hash_cache         m_cache;
+
+  bool m_is_compressed = true;
+
+  std::ofstream m_log_ofs;
 };
 }  // namespace ygm::container::detail

--- a/include/ygm/container/disjoint_set.hpp
+++ b/include/ygm/container/disjoint_set.hpp
@@ -21,7 +21,7 @@ class disjoint_set {
 
   disjoint_set() = delete;
 
-  disjoint_set(ygm::comm &comm, const size_t cache_size = 4096)
+  disjoint_set(ygm::comm &comm, const size_t cache_size = 8192)
       : m_impl(comm, cache_size) {}
 
   template <typename Visitor, typename... VisitorArgs>

--- a/include/ygm/container/disjoint_set.hpp
+++ b/include/ygm/container/disjoint_set.hpp
@@ -21,7 +21,7 @@ class disjoint_set {
 
   disjoint_set() = delete;
 
-  disjoint_set(ygm::comm &comm, const size_t cache_size = 2048)
+  disjoint_set(ygm::comm &comm, const size_t cache_size = 4096)
       : m_impl(comm, cache_size) {}
 
   template <typename Visitor, typename... VisitorArgs>

--- a/include/ygm/container/disjoint_set.hpp
+++ b/include/ygm/container/disjoint_set.hpp
@@ -21,7 +21,8 @@ class disjoint_set {
 
   disjoint_set() = delete;
 
-  disjoint_set(ygm::comm &comm) : m_impl(comm) {}
+  disjoint_set(ygm::comm &comm, const size_t cache_size = 2048)
+      : m_impl(comm, cache_size) {}
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const value_type &item, Visitor visitor,


### PR DESCRIPTION
Finally happy with the performance of the disjoint set. This implementation features union by rank with path-splitting and local caches of (possibly stale) parent values on each rank. More changes may come as I test this more.