### PR TITLE
Preparation for Shared Memory Exchanges

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -189,8 +189,8 @@ class comm {
   void queue_message_bytes(const std::vector<std::byte> &packed,
                            const int                     dest);
 
-  void handle_next_receive(MPI_Status                   status,
-                           std::shared_ptr<std::byte[]> buffer);
+  void handle_next_receive(std::shared_ptr<std::byte[]> buffer,
+                           const size_t                 buffer_size);
 
   bool process_receive_queue();
 


### PR DESCRIPTION
Changes MPI_Waitsome to MPI_Testsome loop and reworks ygm::comm::handle_next_receive to not require an MPI_Status object