### PR TITLE
Feature/ygm ptr constness

### DIFF
--- a/include/ygm/detail/ygm_ptr.hpp
+++ b/include/ygm/detail/ygm_ptr.hpp
@@ -18,10 +18,9 @@ class ygm_ptr {
   ygm_ptr(){};
 
   T       *operator->() { return sptrs[idx]; }
-  const T *operator->() const { return sptrs[idx]; }
+  T *const operator->() const { return sptrs[idx]; }
 
-  T       &operator*() { return *sptrs[idx]; }
-  const T &operator*() const { return *sptrs[idx]; }
+  T &operator*() const { return *sptrs[idx]; }
 
   /**
    * @brief Construct a new ygm ptr object


### PR DESCRIPTION
Fixes constness issue with dereferencing `ygm_ptr<T>`. As is, `operator->()` on a `const ygm_ptr<T>` returns a `const T*`, giving a pointer to const object instead of const pointer to object.

Checking [here](https://en.cppreference.com/w/cpp/memory/shared_ptr/operator*), const smart pointers return a `T *` when calling `operator->()`, but I could see an argument for this returning a const pointer instead.