### PR TITLE
Synchronizes returns from comm::barrier()

### DIFF
--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -244,6 +244,8 @@ inline void comm::barrier() {
   }
   ASSERT_RELEASE(m_pre_barrier_callbacks.empty());
   ASSERT_RELEASE(m_send_dest_queue.empty());
+
+  cf_barrier();
 }
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_ygm_seq_test(test_cereal_archive)
 
 add_ygm_test(test_comm)
 add_ygm_test(test_comm_2)
+add_ygm_test(test_barrier)
 add_ygm_test(test_layout)
 add_ygm_test(test_large_messages)
 add_ygm_test(test_map)

--- a/test/test_barrier.cpp
+++ b/test/test_barrier.cpp
@@ -1,0 +1,28 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+
+#include <ygm/comm.hpp>
+
+int main(int argc, char **argv) {
+  ygm::comm world(&argc, &argv);
+
+  // Test barriers for early exit
+  {
+    int        num_rounds = 100;
+    static int round      = 0;
+    for (int i = 0; i < num_rounds; ++i) {
+      world.async_bcast(
+          [](int curr_round) { ASSERT_RELEASE(curr_round == round); }, round);
+
+      world.barrier();
+
+      ++round;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Fixes a subtle bug in which a rank could complete a `comm::barrier()` and spawn an async that gets processed by a different rank immediately before the second rank completes the same `comm::barrier()`. A simple fix is to add a call to `comm::cf_barrier()` at the very end of `comm::barrier()`.

The bug arose because of the use of the nonblocking allreduce interleaved with the checking of nonblocking receives. When `comm::barrier_reduce_counts()` call completes in a way that the associated `comm::barrier()` will complete, a rank can identify this earlier than other ranks by testing the nonblocking allreduce request object. It is then able to send an async that matches a receive on another rank that hasn't tested its allreduce request object yet.

This erroneous situation does not cause ranks to become stuck in the `comm::barrier()` because the counts were consistent with a completing barrier when `comm::barrier_reduce_counts()` was called.

This PR adds a test that demonstrates this unsynchronized returns from `comm::barrier()` probabilistically. The behavior is more frequently encountered when running more MPI ranks than cores.