### PR TITLE
Adds batch erase functionality to ygm::container::multiset

### DIFF
--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -1,0 +1,30 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+#include <ygm/container/detail/base_concepts.hpp>
+
+namespace ygm::container::detail {
+
+template <typename derived_type, typename for_all_args>
+struct base_batch_erase_key {
+  template <typename Container>
+  void erase(const Container &cont) requires detail::HasForAll<Container> &&
+      detail::SingleItemTuple<typename Container::for_all_args> &&
+      detail::AtLeastOneItemTuple<for_all_args> && std::convertible_to<
+          std::tuple_element_t<0, typename Container::for_all_args>,
+          std::tuple_element_t<0, for_all_args>> {
+    derived_type *derived_this = static_cast<derived_type *>(this);
+
+    cont.for_all(
+        [derived_this](const auto &key) { derived_this->async_erase(key); });
+
+    derived_this->comm().barrier();
+  }
+};
+}  // namespace ygm::container::detail

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -11,6 +11,7 @@
 #include <ygm/container/detail/base_async_erase.hpp>
 #include <ygm/container/detail/base_async_insert.hpp>
 #include <ygm/container/detail/base_async_insert_contains.hpp>
+#include <ygm/container/detail/base_batch_erase.hpp>
 #include <ygm/container/detail/base_count.hpp>
 #include <ygm/container/detail/base_iteration.hpp>
 #include <ygm/container/detail/base_misc.hpp>
@@ -23,6 +24,7 @@ class multiset
     : public detail::base_async_insert_value<multiset<Value>,
                                              std::tuple<Value>>,
       public detail::base_async_erase_key<multiset<Value>, std::tuple<Value>>,
+      public detail::base_batch_erase_key<multiset<Value>, std::tuple<Value>>,
       public detail::base_async_contains<multiset<Value>, std::tuple<Value>>,
       public detail::base_async_insert_contains<multiset<Value>,
                                                 std::tuple<Value>>,
@@ -71,9 +73,9 @@ class multiset
   }
 
   template <typename STLContainer>
-  multiset(ygm::comm &comm, const STLContainer &cont)
-    requires detail::STLContainer<STLContainer> &&
-                 std::convertible_to<typename STLContainer::value_type, Value>
+  multiset(ygm::comm &comm, const STLContainer &cont) requires
+      detail::STLContainer<STLContainer> &&
+      std::convertible_to<typename STLContainer::value_type, Value>
       : m_comm(comm), pthis(this), partitioner(comm) {
     pthis.check(m_comm);
 
@@ -85,10 +87,9 @@ class multiset
   }
 
   template <typename YGMContainer>
-  multiset(ygm::comm &comm, const YGMContainer &yc)
-    requires detail::HasForAll<YGMContainer> &&
-                 detail::SingleItemTuple<
-                     typename YGMContainer::for_all_args>  //&&
+  multiset(ygm::comm          &comm,
+           const YGMContainer &yc) requires detail::HasForAll<YGMContainer> &&
+      detail::SingleItemTuple<typename YGMContainer::for_all_args>  //&&
       // std::same_as<typename TYGMContainer::for_all_args, std::tuple<Value>>
       : m_comm(comm), pthis(this), partitioner(comm) {
     pthis.check(m_comm);
@@ -151,6 +152,7 @@ template <typename Value>
 class set
     : public detail::base_async_insert_value<set<Value>, std::tuple<Value>>,
       public detail::base_async_erase_key<set<Value>, std::tuple<Value>>,
+      public detail::base_batch_erase_key<set<Value>, std::tuple<Value>>,
       public detail::base_async_contains<set<Value>, std::tuple<Value>>,
       public detail::base_async_insert_contains<set<Value>, std::tuple<Value>>,
       public detail::base_count<set<Value>, std::tuple<Value>>,
@@ -197,9 +199,9 @@ class set
   }
 
   template <typename STLContainer>
-  set(ygm::comm &comm, const STLContainer &cont)
-    requires detail::STLContainer<STLContainer> &&
-                 std::convertible_to<typename STLContainer::value_type, Value>
+  set(ygm::comm          &comm,
+      const STLContainer &cont) requires detail::STLContainer<STLContainer> &&
+      std::convertible_to<typename STLContainer::value_type, Value>
       : m_comm(comm), pthis(this), partitioner(comm) {
     pthis.check(m_comm);
 
@@ -210,10 +212,9 @@ class set
   }
 
   template <typename YGMContainer>
-  set(ygm::comm &comm, const YGMContainer &yc)
-    requires detail::HasForAll<YGMContainer> &&
-                 detail::SingleItemTuple<
-                     typename YGMContainer::for_all_args>  //&&
+  set(ygm::comm          &comm,
+      const YGMContainer &yc) requires detail::HasForAll<YGMContainer> &&
+      detail::SingleItemTuple<typename YGMContainer::for_all_args>  //&&
       // std::same_as<typename TYGMContainer::for_all_args, std::tuple<Value>>
       : m_comm(comm), pthis(this), partitioner(comm) {
     pthis.check(m_comm);

--- a/test/test_multiset.cpp
+++ b/test/test_multiset.cpp
@@ -58,14 +58,12 @@ int main(int argc, char** argv) {
   //
   // Test async_contains
   {
-    static bool              set_contains = false;
+    static bool                   set_contains = false;
     ygm::container::multiset<int> iset(world);
     world.barrier();
     int val = 42;
 
-    auto f = [](bool contains, const int& i) {
-      set_contains = contains;
-    };   
+    auto f = [](bool contains, const int& i) { set_contains = contains; };
 
     if (world.rank0()) {
       iset.async_contains(val, f);
@@ -87,13 +85,13 @@ int main(int argc, char** argv) {
   //
   // Test async_insert_contains
   {
-    static bool              already_contains = false;
+    static bool                           already_contains = false;
     ygm::container::multiset<std::string> sset(world);
     world.barrier();
 
     auto f = [](bool& contains, const std::string& s) {
       already_contains = contains;
-    };   
+    };
 
     if (world.rank0()) {
       sset.async_insert_contains("dog", f);
@@ -106,6 +104,45 @@ int main(int argc, char** argv) {
     }
     world.barrier();
     YGM_ASSERT_RELEASE(ygm::logical_or(already_contains, world));
+  }
+
+  // Test batch erase
+  {
+    int                           num_items            = 100;
+    int                           num_insertion_rounds = 5;
+    int                           remove_size          = 20;
+    ygm::container::multiset<int> iset(world);
+
+    if (world.rank0()) {
+      for (int round = 0; round < num_insertion_rounds; ++round) {
+        for (int i = 0; i < num_items; ++i) {
+          iset.async_insert(i);
+        }
+      }
+    }
+
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(iset.size() == num_insertion_rounds * num_items);
+
+    ygm::container::set<int> to_remove(world);
+
+    if (world.rank0()) {
+      for (int i = 0; i < remove_size; ++i) {
+        to_remove.async_insert(i);
+      }
+    }
+
+    world.barrier();
+
+    iset.erase(to_remove);
+
+    iset.for_all([remove_size, &world](const auto& item) {
+      YGM_ASSERT_RELEASE(item >= remove_size);
+    });
+
+    YGM_ASSERT_RELEASE(iset.size() ==
+                       num_insertion_rounds * (num_items - remove_size));
   }
 
   //
@@ -139,7 +176,7 @@ int main(int argc, char** argv) {
     sset1.async_insert("apple");
     sset1.async_insert("red");
 
-    sset1.for_all([&sset2](const auto &key) { sset2.async_insert(key); });
+    sset1.for_all([&sset2](const auto& key) { sset2.async_insert(key); });
 
     YGM_ASSERT_RELEASE(sset2.count("dog") == world.size());
     YGM_ASSERT_RELEASE(sset2.count("apple") == world.size());
@@ -149,7 +186,7 @@ int main(int argc, char** argv) {
   //
   // Test vector of sets
   {
-    int                                   num_sets = 4;
+    int                                        num_sets = 4;
     std::vector<ygm::container::multiset<int>> vec_sets;
 
     for (int i = 0; i < num_sets; ++i) {

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -9,10 +9,10 @@
 #include <string>
 
 #include <ygm/comm.hpp>
-#include <ygm/container/set.hpp>
 #include <ygm/container/bag.hpp>
+#include <ygm/container/set.hpp>
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
 
   //
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 
   //
   // Test Rank 0 async_insert
-  { 
+  {
     ygm::container::set<std::string> sset(world);
     if (world.rank() == 0) {
       sset.async_insert("dog");
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
   // Test Rank 0 async_insert with ygm set pointer
   {
     ygm::container::set<std::string> sset(world);
-    auto sset_ptr = sset.get_ygm_ptr();
+    auto                             sset_ptr = sset.get_ygm_ptr();
     if (world.rank() == 0) {
       sset_ptr->async_insert("dog");
       sset_ptr->async_insert("apple");
@@ -69,7 +69,6 @@ int main(int argc, char **argv) {
     YGM_ASSERT_RELEASE(sset.size() == 3);
   }
 
-  
   //
   // Test all ranks async_insert
   {
@@ -88,17 +87,14 @@ int main(int argc, char **argv) {
     YGM_ASSERT_RELEASE(sset.size() == 2);
   }
 
-
   //
   // Test async_contains
   {
     static bool              set_contains = false;
     ygm::container::set<int> iset(world);
-    int val = 42;
+    int                      val = 42;
 
-    auto f = [](bool& contains, const int& i) {
-      set_contains = contains;
-    };   
+    auto f = [](bool& contains, const int& i) { set_contains = contains; };
 
     if (world.rank0()) {
       iset.async_contains(val, f);
@@ -121,12 +117,12 @@ int main(int argc, char **argv) {
   //
   // Test async_insert_contains
   {
-    static bool              did_contain = false;
+    static bool                      did_contain = false;
     ygm::container::set<std::string> sset(world);
 
     auto f = [](bool& contains, const std::string& s) {
       did_contain = contains;
-    };   
+    };
 
     if (world.rank0()) {
       sset.async_insert_contains("dog", f);
@@ -141,10 +137,45 @@ int main(int argc, char **argv) {
     YGM_ASSERT_RELEASE(ygm::logical_or(did_contain, world));
   }
 
+  // Test batch erase
+  {
+    int                      num_items   = 100;
+    int                      remove_size = 20;
+    ygm::container::set<int> iset(world);
+
+    if (world.rank0()) {
+      for (int i = 0; i < num_items; ++i) {
+        iset.async_insert(i);
+      }
+    }
+
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(iset.size() == num_items);
+
+    ygm::container::set<int> to_remove(world);
+
+    if (world.rank0()) {
+      for (int i = 0; i < remove_size; ++i) {
+        to_remove.async_insert(i);
+      }
+    }
+
+    world.barrier();
+
+    iset.erase(to_remove);
+
+    iset.for_all([remove_size, &world](const auto& item) {
+      YGM_ASSERT_RELEASE(item >= remove_size);
+    });
+
+    YGM_ASSERT_RELEASE(iset.size() == num_items - remove_size);
+  }
 
   // Test from bag
   {
-    ygm::container::bag<std::string> sbag(world, {"one", "two", "three", "one", "two"});
+    ygm::container::bag<std::string> sbag(
+        world, {"one", "two", "three", "one", "two"});
     YGM_ASSERT_RELEASE(sbag.size() == 5);
 
     ygm::container::set<std::string> sset(world, sbag);
@@ -153,27 +184,26 @@ int main(int argc, char **argv) {
 
   // Test initializer list
   {
-    ygm::container::set<std::string> sset(world, {"one", "two", "three", "one", "two"});
+    ygm::container::set<std::string> sset(
+        world, {"one", "two", "three", "one", "two"});
     YGM_ASSERT_RELEASE(sset.size() == 3);
   }
 
   // Test from STL vector
   {
-    std::vector<int> v({1,2,3,4,5,1,1,1,3});
+    std::vector<int>         v({1, 2, 3, 4, 5, 1, 1, 1, 3});
     ygm::container::set<int> iset(world, v);
     YGM_ASSERT_RELEASE(iset.size() == 5);
   }
-
 
   //
   // Test additional arguments of async_contains
   // {
   //   ygm::container::set<std::string> sset(world);
-  //   sset.async_contains("howdy", [](bool c, const std::string s, int i, float f){}, 3, 3.14);
-  //   sset.async_contains("howdy", [](auto ptr_set, bool c, const std::string s){});
-  //   world.barrier();
+  //   sset.async_contains("howdy", [](bool c, const std::string s, int i, float
+  //   f){}, 3, 3.14); sset.async_contains("howdy", [](auto ptr_set, bool c,
+  //   const std::string s){}); world.barrier();
   // }
-
 
   //
   // Test swap
@@ -206,7 +236,7 @@ int main(int argc, char **argv) {
     sset1.async_insert("apple");
     sset1.async_insert("red");
 
-    sset1.for_all([&sset2](const auto &key) { sset2.async_insert(key); });
+    sset1.for_all([&sset2](const auto& key) { sset2.async_insert(key); });
 
     YGM_ASSERT_RELEASE(sset2.count("dog") == 1);
     YGM_ASSERT_RELEASE(sset2.count("apple") == 1);
@@ -223,7 +253,8 @@ int main(int argc, char **argv) {
   //   sset1.async_insert("apple");
   //   sset1.async_insert("red");
 
-  //   sset1.consume_all([&sset2](const auto &key) { sset2.async_insert(key); });
+  //   sset1.consume_all([&sset2](const auto &key) { sset2.async_insert(key);
+  //   });
 
   //   YGM_ASSERT_RELEASE(sset1.empty());
   //   YGM_ASSERT_RELEASE(sset2.count("dog") == 1);


### PR DESCRIPTION
Adds batch erase functionality to set and multiset that takes keys to erase from ygm containers with for_all_args that contain a single item (e.g. bag and set).

Will continue to expand batch erase functionality.