### PR TITLE
Adds check for async lambdas attempting to capture

### DIFF
--- a/include/ygm/container/detail/base_async_contains.hpp
+++ b/include/ygm/container/detail/base_async_contains.hpp
@@ -7,32 +7,34 @@
 
 #include <tuple>
 #include <utility>
+#include <ygm/detail/lambda_compliance.hpp>
 
 namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
 struct base_async_contains {
-
-  template<typename Function, typename... FuncArgs>
+  template <typename Function, typename... FuncArgs>
   void async_contains(const std::tuple_element<0, for_all_args>::type& value,
-                             Function fn, const FuncArgs&... args) {
+                      Function fn, const FuncArgs&... args) {
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Function,
+                                      ygm::container::async_contains());
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [](auto pcont,
-                      const std::tuple_element<0, for_all_args>::type& value,
-                      const FuncArgs&... args) {
-
-      Function* fn = nullptr;
-      bool contains = static_cast<bool>(pcont->local_count(value));
-      ygm::meta::apply_optional(*fn, std::make_tuple(pcont),
-                                std::forward_as_tuple(contains, value, args...));
+    auto lambda = [](auto                                             pcont,
+                     const std::tuple_element<0, for_all_args>::type& value,
+                     const FuncArgs&... args) {
+      Function* fn       = nullptr;
+      bool      contains = static_cast<bool>(pcont->local_count(value));
+      ygm::meta::apply_optional(
+          *fn, std::make_tuple(pcont),
+          std::forward_as_tuple(contains, value, args...));
     };
 
-    derived_this->comm().async(dest, lambda, derived_this->get_ygm_ptr(),
-                              value, args...);
+    derived_this->comm().async(dest, lambda, derived_this->get_ygm_ptr(), value,
+                               args...);
   }
 };
 

--- a/include/ygm/container/detail/base_async_insert_contains.hpp
+++ b/include/ygm/container/detail/base_async_insert_contains.hpp
@@ -7,36 +7,39 @@
 
 #include <tuple>
 #include <utility>
+#include <ygm/detail/lambda_compliance.hpp>
 
 namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
 struct base_async_insert_contains {
-
-  template<typename Function, typename... FuncArgs>
-  void async_insert_contains(const std::tuple_element<0, for_all_args>::type& value,
-                             Function fn, const FuncArgs&... args) {
+  template <typename Function, typename... FuncArgs>
+  void async_insert_contains(
+      const std::tuple_element<0, for_all_args>::type& value, Function fn,
+      const FuncArgs&... args) {
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Function,
+                                      ygm::container::async_insert_contains());
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [](auto pcont,
-                      const std::tuple_element<0, for_all_args>::type& value,
-                      const FuncArgs&... args) {
-
-      Function* fn = nullptr;
-      bool contains = static_cast<bool>(pcont->local_count(value));
+    auto lambda = [](auto                                             pcont,
+                     const std::tuple_element<0, for_all_args>::type& value,
+                     const FuncArgs&... args) {
+      Function* fn       = nullptr;
+      bool      contains = static_cast<bool>(pcont->local_count(value));
       if (!contains) {
         pcont->local_insert(value);
-      } 
+      }
 
-      ygm::meta::apply_optional(*fn, std::make_tuple(pcont),
-                                std::forward_as_tuple(contains, value, args...));
+      ygm::meta::apply_optional(
+          *fn, std::make_tuple(pcont),
+          std::forward_as_tuple(contains, value, args...));
     };
 
-    derived_this->comm().async(dest, lambda, derived_this->get_ygm_ptr(),
-                              value, args...);
+    derived_this->comm().async(dest, lambda, derived_this->get_ygm_ptr(), value,
+                               args...);
   }
 };
 

--- a/include/ygm/container/detail/base_async_reduce.hpp
+++ b/include/ygm/container/detail/base_async_reduce.hpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <utility>
 #include <ygm/container/detail/base_concepts.hpp>
+#include <ygm/detail/lambda_compliance.hpp>
 
 namespace ygm::container::detail {
 
@@ -18,6 +19,9 @@ struct base_async_reduce {
       const typename std::tuple_element<0, for_all_args>::type& key,
       const typename std::tuple_element<1, for_all_args>::type& value,
       ReductionOp                                               reducer) {
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(ReductionOp,
+                                      ygm::container::async_reduce());
+
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <ygm/container/detail/base_concepts.hpp>
 #include <ygm/detail/interrupt_mask.hpp>
+#include <ygm/detail/lambda_compliance.hpp>
 
 namespace ygm::container::detail {
 
@@ -16,9 +17,10 @@ template <typename derived_type, typename for_all_args>
 struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const std::tuple_element<0, for_all_args>::type& key,
-                   Visitor visitor, const VisitorArgs&... args)
-    requires DoubleItemTuple<for_all_args>
-  {
+                   Visitor visitor, const VisitorArgs&... args) requires
+      DoubleItemTuple<for_all_args> {
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, ygm::container::async_visit());
+
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
@@ -37,9 +39,10 @@ struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args)
-    requires DoubleItemTuple<for_all_args>
-  {
+      const VisitorArgs&... args) requires DoubleItemTuple<for_all_args> {
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
+        Visitor, ygm::container::async_visit_if_contains());
+
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
@@ -58,9 +61,10 @@ struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args) const
-    requires DoubleItemTuple<for_all_args>
-  {
+      const VisitorArgs&... args) const requires DoubleItemTuple<for_all_args> {
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
+        Visitor, ygm::container::async_visit_if_contains());
+
     const derived_type* derived_this = static_cast<const derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);

--- a/include/ygm/detail/lambda_compliance.hpp
+++ b/include/ygm/detail/lambda_compliance.hpp
@@ -1,0 +1,14 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#define YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(func, location) \
+  static_assert(                                          \
+      std::is_trivially_copyable<func>::value, #location  \
+      " function object must be is_trivially_copyable & is_standard_layout.")


### PR DESCRIPTION
Fixes issue where `comm::async()` would check for lambdas attempting to capture but other operations calling `comm::async()` (e.g. `container::async_visit()` calls) would circumvent this check through their wrapping of lambdas.

This check is now done through a macro using `static_assert`. A solution without a macro would be preferred, but the error message printed by `static_assert` is currently required to be a string literal (until C++26).