### PR TITLE
Lambda Compliance Macro Cleanup

### DIFF
--- a/include/ygm/container/detail/base_async_contains.hpp
+++ b/include/ygm/container/detail/base_async_contains.hpp
@@ -18,7 +18,7 @@ struct base_async_contains {
   void async_contains(const std::tuple_element<0, for_all_args>::type& value,
                       Function fn, const FuncArgs&... args) {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Function,
-                                      ygm::container::async_contains());
+                                      "ygm::container::async_contains()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 

--- a/include/ygm/container/detail/base_async_insert_contains.hpp
+++ b/include/ygm/container/detail/base_async_insert_contains.hpp
@@ -18,8 +18,8 @@ struct base_async_insert_contains {
   void async_insert_contains(
       const std::tuple_element<0, for_all_args>::type& value, Function fn,
       const FuncArgs&... args) {
-    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Function,
-                                      ygm::container::async_insert_contains());
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
+        Function, "ygm::container::async_insert_contains()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 

--- a/include/ygm/container/detail/base_async_reduce.hpp
+++ b/include/ygm/container/detail/base_async_reduce.hpp
@@ -20,7 +20,7 @@ struct base_async_reduce {
       const typename std::tuple_element<1, for_all_args>::type& value,
       ReductionOp                                               reducer) {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(ReductionOp,
-                                      ygm::container::async_reduce());
+                                      "ygm::container::async_reduce()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -17,7 +17,6 @@ template <typename derived_type, typename for_all_args>
 struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const std::tuple_element<0, for_all_args>::type& key,
-
                    Visitor visitor, const VisitorArgs&... args)
     requires DoubleItemTuple<for_all_args>
   {

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -19,7 +19,7 @@ struct base_async_visit {
   void async_visit(const std::tuple_element<0, for_all_args>::type& key,
                    Visitor visitor, const VisitorArgs&... args) requires
       DoubleItemTuple<for_all_args> {
-    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, ygm::container::async_visit());
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, "ygm::container::async_visit()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 
@@ -41,7 +41,7 @@ struct base_async_visit {
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
       const VisitorArgs&... args) requires DoubleItemTuple<for_all_args> {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
-        Visitor, ygm::container::async_visit_if_contains());
+        Visitor, "ygm::container::async_visit_if_contains()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 
@@ -63,7 +63,7 @@ struct base_async_visit {
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
       const VisitorArgs&... args) const requires DoubleItemTuple<for_all_args> {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
-        Visitor, ygm::container::async_visit_if_contains());
+        Visitor, "ygm::container::async_visit_if_contains()");
 
     const derived_type* derived_this = static_cast<const derived_type*>(this);
 

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -20,8 +20,7 @@ struct base_async_visit {
                    Visitor visitor, const VisitorArgs&... args)
     requires DoubleItemTuple<for_all_args>
   {
-    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, ygm::container::async_visit());
-
+    YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, "ygm::container::async_visit()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -200,7 +200,7 @@ inline void comm::async_bcast(AsyncFunction fn, const SendArgs &...args) {
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async_mcast(const std::vector<int> &dests, AsyncFunction fn,
                               const SendArgs &...args) {
-  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, "ygm::comm::async_bcast()");
+  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, "ygm::comm::async_mcast()");
 
   for (auto dest : dests) {
     async(dest, fn, std::forward<const SendArgs>(args)...);

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -133,7 +133,7 @@ inline comm::~comm() {
 
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async(int dest, AsyncFunction fn, const SendArgs &...args) {
-  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, ygm::comm::async());
+  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, "ygm::comm::async()");
 
   YGM_ASSERT_RELEASE(dest < m_layout.size());
   stats.async(dest);
@@ -184,7 +184,7 @@ inline void comm::async(int dest, AsyncFunction fn, const SendArgs &...args) {
 
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async_bcast(AsyncFunction fn, const SendArgs &...args) {
-  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, ygm::comm::async_bcast());
+  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, "ygm::comm::async_bcast()");
 
   check_if_production_halt_required();
 
@@ -200,7 +200,7 @@ inline void comm::async_bcast(AsyncFunction fn, const SendArgs &...args) {
 template <typename AsyncFunction, typename... SendArgs>
 inline void comm::async_mcast(const std::vector<int> &dests, AsyncFunction fn,
                               const SendArgs &...args) {
-  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, ygm::comm::async_bcast());
+  YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(AsyncFunction, "ygm::comm::async_bcast()");
 
   for (auto dest : dests) {
     async(dest, fn, std::forward<const SendArgs>(args)...);

--- a/include/ygm/detail/lambda_compliance.hpp
+++ b/include/ygm/detail/lambda_compliance.hpp
@@ -10,5 +10,7 @@
 
 #define YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(func, location) \
   static_assert(                                          \
-      std::is_trivially_copyable<func>::value, #location  \
+      std::is_trivially_copyable<func>::value &&          \
+          std::is_standard_layout<func>::value,           \
+      location                                            \
       " function object must be is_trivially_copyable & is_standard_layout.")


### PR DESCRIPTION
Makes locations in YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE macro appear as string literals and adds missing check for std::is_standard_layout