### PR TITLE
Removing all clever tricks and introducing duplicate code so doxygen can create docs

### DIFF
--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -27,8 +27,8 @@ class array
       public detail::base_misc<array<Value, Index>, std::tuple<Index, Value>>,
       public detail::base_async_visit<array<Value, Index>,
                                       std::tuple<Index, Value>>,
-      public detail::base_iteration<array<Value, Index>,
-                                    std::tuple<Index, Value>> {
+      public detail::base_iteration_key_value<array<Value, Index>,
+                                              std::tuple<Index, Value>> {
   friend class detail::base_misc<array<Value, Index>, std::tuple<Index, Value>>;
 
  public:
@@ -446,7 +446,8 @@ class array
     }
     m_comm.barrier();
 
-    YGM_ASSERT_RELEASE(samples.size() == samples_per_pivot * (m_comm.size() - 1));
+    YGM_ASSERT_RELEASE(samples.size() ==
+                       samples_per_pivot * (m_comm.size() - 1));
     std::sort(samples.begin(), samples.end());
     for (size_t i = samples_per_pivot - 1; i < samples.size();
          i += samples_per_pivot) {

--- a/include/ygm/container/bag.hpp
+++ b/include/ygm/container/bag.hpp
@@ -21,7 +21,7 @@ template <typename Item>
 class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
             public detail::base_count<bag<Item>, std::tuple<Item>>,
             public detail::base_misc<bag<Item>, std::tuple<Item>>,
-            public detail::base_iteration<bag<Item>, std::tuple<Item>> {
+            public detail::base_iteration_value<bag<Item>, std::tuple<Item>> {
   friend class detail::base_misc<bag<Item>, std::tuple<Item>>;
 
  public:
@@ -47,9 +47,9 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   }
 
   template <typename STLContainer>
-  bag(ygm::comm &comm, const STLContainer &cont)
-    requires detail::STLContainer<STLContainer> &&
-                 std::convertible_to<typename STLContainer::value_type, Item>
+  bag(ygm::comm          &comm,
+      const STLContainer &cont) requires detail::STLContainer<STLContainer> &&
+      std::convertible_to<typename STLContainer::value_type, Item>
       : m_comm(comm), pthis(this), partitioner(comm) {
     pthis.check(m_comm);
 
@@ -60,10 +60,9 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   }
 
   template <typename YGMContainer>
-  bag(ygm::comm &comm, const YGMContainer &yc)
-    requires detail::HasForAll<YGMContainer> &&
-                 detail::SingleItemTuple<
-                     typename YGMContainer::for_all_args>
+  bag(ygm::comm          &comm,
+      const YGMContainer &yc) requires detail::HasForAll<YGMContainer> &&
+      detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm) {
     pthis.check(m_comm);
 

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -12,17 +12,11 @@
 namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
-struct base_batch_erase {
-  static_assert(sizeof(for_all_args) != sizeof(for_all_args),
-                "Unsupported batch erase operation");
-};
-
-template <typename derived_type, SingleItemTuple for_all_args>
-struct base_batch_erase<derived_type, for_all_args> {
+struct base_batch_erase_key {
   using value_type = std::tuple_element_t<0, for_all_args>;
 
   template <typename Container>
-  void erase(const Container &cont) requires HasForAll<Container> &&
+  void erase(const Container &cont) requires detail::HasForAll<Container> &&
       SingleItemTuple<typename Container::for_all_args> && std::convertible_to<
           std::tuple_element_t<0, typename Container::for_all_args>,
           value_type> {
@@ -48,14 +42,14 @@ struct base_batch_erase<derived_type, for_all_args> {
   }
 };
 
-template <typename derived_type, DoubleItemTuple for_all_args>
-struct base_batch_erase<derived_type, for_all_args>
-    : public base_batch_erase<
+template <typename derived_type, typename for_all_args>
+struct base_batch_erase_key_value
+    : public base_batch_erase_key<
           derived_type, std::tuple<std::tuple_element_t<0, for_all_args>>> {
   using key_type    = std::tuple_element_t<0, for_all_args>;
   using mapped_type = std::tuple_element_t<1, for_all_args>;
 
-  using base_batch_erase<derived_type, std::tuple<key_type>>::erase;
+  using base_batch_erase_key<derived_type, std::tuple<key_type>>::erase;
 
   template <typename Container>
   void erase(const Container &cont) requires HasForAll<Container> &&

--- a/include/ygm/container/detail/filter_proxy.hpp
+++ b/include/ygm/container/detail/filter_proxy.hpp
@@ -5,17 +5,16 @@
 
 #pragma once
 
-
 namespace ygm::container::detail {
 
 template <typename Container, typename FilterFunction>
-class filter_proxy
-    : public base_iteration<filter_proxy<Container, FilterFunction>,
-                            typename Container::for_all_args> {
+class filter_proxy_value
+    : public base_iteration_value<filter_proxy_value<Container, FilterFunction>,
+                                  typename Container::for_all_args> {
  public:
   using for_all_args = typename Container::for_all_args;
 
-  filter_proxy(Container& rc, FilterFunction filter)
+  filter_proxy_value(Container& rc, FilterFunction filter)
       : m_rcontainer(rc), m_filter_fn(filter) {}
 
   template <typename Function>
@@ -51,4 +50,48 @@ class filter_proxy
   FilterFunction m_filter_fn;
 };
 
-}
+template <typename Container, typename FilterFunction>
+class filter_proxy_key_value
+    : public base_iteration_key_value<
+          filter_proxy_key_value<Container, FilterFunction>,
+          typename Container::for_all_args> {
+ public:
+  using for_all_args = typename Container::for_all_args;
+
+  filter_proxy_key_value(Container& rc, FilterFunction filter)
+      : m_rcontainer(rc), m_filter_fn(filter) {}
+
+  template <typename Function>
+  void for_all(Function fn) {
+    auto flambda = [fn, this](auto&... xs) {
+      bool b = m_filter_fn(std::forward<decltype(xs)>(xs)...);
+      if (b) {
+        fn(std::forward<decltype(xs)>(xs)...);
+      }
+    };
+
+    m_rcontainer.for_all(flambda);
+  }
+
+  template <typename Function>
+  void for_all(Function fn) const {
+    auto flambda = [fn, this](const auto&... xs) {
+      bool b = m_filter_fn(std::forward<decltype(xs)>(xs)...);
+      if (b) {
+        fn(std::forward<decltype(xs)>(xs)...);
+      }
+    };
+
+    m_rcontainer.for_all(flambda);
+  }
+
+  ygm::comm& comm() { return m_rcontainer.comm(); }
+
+  const ygm::comm& comm() const { return m_rcontainer.comm(); }
+
+ private:
+  Container&     m_rcontainer;
+  FilterFunction m_filter_fn;
+};
+
+}  // namespace ygm::container::detail

--- a/include/ygm/container/detail/flatten_proxy.hpp
+++ b/include/ygm/container/detail/flatten_proxy.hpp
@@ -8,15 +8,15 @@
 namespace ygm::container::detail {
 
 template <typename Container>
-class flatten_proxy
-    : public base_iteration<flatten_proxy<Container>,
-                            std::tuple<std::tuple_element_t<
-                                0, typename Container::for_all_args>>> {
+class flatten_proxy_value
+    : public base_iteration_value<flatten_proxy_value<Container>,
+                                  std::tuple<std::tuple_element_t<
+                                      0, typename Container::for_all_args>>> {
  public:
   using for_all_args =
       std::tuple<std::tuple_element_t<0, typename Container::for_all_args>>;
 
-  flatten_proxy(Container& rc) : m_rcontainer(rc) {}
+  flatten_proxy_value(Container& rc) : m_rcontainer(rc) {}
 
   template <typename Function>
   void for_all(Function fn) {
@@ -52,4 +52,49 @@ class flatten_proxy
   Container& m_rcontainer;
 };
 
+template <typename Container>
+class flatten_proxy_key_value
+    : public base_iteration_key_value<
+          flatten_proxy_value<Container>,
+          std::tuple<
+              std::tuple_element_t<0, typename Container::for_all_args>>> {
+ public:
+  using for_all_args =
+      std::tuple<std::tuple_element_t<0, typename Container::for_all_args>>;
+
+  flatten_proxy_key_value(Container& rc) : m_rcontainer(rc) {}
+
+  template <typename Function>
+  void for_all(Function fn) {
+    auto flambda =
+        [fn](std::tuple_element_t<0, typename Container::for_all_args>&
+                 stlcont) {
+          for (auto& v : stlcont) {
+            fn(v);
+          }
+        };
+
+    m_rcontainer.for_all(flambda);
+  }
+
+  template <typename Function>
+  void for_all(Function fn) const {
+    auto flambda =
+        [fn](std::tuple_element_t<0, typename Container::for_all_args>&
+                 stlcont) {
+          for (const auto& v : stlcont) {
+            fn(v);
+          }
+        };
+
+    m_rcontainer.for_all(flambda);
+  }
+
+  ygm::comm& comm() { return m_rcontainer.comm(); }
+
+  const ygm::comm& comm() const { return m_rcontainer.comm(); }
+
+ private:
+  Container& m_rcontainer;
+};
 }  // namespace ygm::container::detail

--- a/include/ygm/container/detail/transform_proxy.hpp
+++ b/include/ygm/container/detail/transform_proxy.hpp
@@ -12,12 +12,10 @@
 
 namespace ygm::container::detail {
 
-
-
 template <typename Container, typename MapFunction>
-class transform_proxy
-    : public base_iteration<
-          transform_proxy<Container, MapFunction>,
+class transform_proxy_value
+    : public base_iteration_value<
+          transform_proxy_value<Container, MapFunction>,
           typename type_traits::tuple_wrapper<decltype(std::apply(
               std::declval<MapFunction>(),
               std::declval<typename Container::for_all_args>()))>::type> {
@@ -29,7 +27,62 @@ class transform_proxy
  public:
   using for_all_args = type_traits::tuple_wrapper<map_function_ret>::type;
 
-  transform_proxy(Container& rc, MapFunction filter)
+  transform_proxy_value(Container& rc, MapFunction filter)
+      : m_rcontainer(rc), m_map_fn(filter) {}
+
+  template <typename Function>
+  void for_all(Function fn) {
+    auto mlambda = [fn, this](auto&... xs) {
+      auto map_result = m_map_fn(std::forward<decltype(xs)>(xs)...);
+      if constexpr (type_traits::is_tuple<decltype(map_result)>::value) {
+        std::apply(fn, map_result);
+      } else {
+        fn(map_result);
+      }
+    };
+
+    m_rcontainer.for_all(mlambda);
+  }
+
+  template <typename Function>
+  void for_all(Function fn) const {
+    auto mlambda = [fn, this](const auto&... xs) {
+      auto map_result = m_map_fn(std::forward<decltype(xs)>(xs)...);
+      if constexpr (type_traits::is_tuple<decltype(map_result)>::value) {
+        std::apply(fn, std::move(map_result));
+      } else {
+        fn(std::move(map_result));
+      }
+    };
+
+    m_rcontainer.for_all(mlambda);
+  }
+
+  ygm::comm& comm() { return m_rcontainer.comm(); }
+
+  const ygm::comm& comm() const { return m_rcontainer.comm(); }
+
+ private:
+  Container&  m_rcontainer;
+  MapFunction m_map_fn;
+};
+
+template <typename Container, typename MapFunction>
+class transform_proxy_key_value
+    : public base_iteration_value<
+          transform_proxy_key_value<Container, MapFunction>,
+          typename type_traits::tuple_wrapper<decltype(std::apply(
+              std::declval<MapFunction>(),
+              std::declval<typename Container::for_all_args>()))>::type> {
+ private:
+  using map_function_ret =
+      decltype(std::apply(std::declval<MapFunction>(),
+                          std::declval<typename Container::for_all_args>()));
+
+ public:
+  using for_all_args = type_traits::tuple_wrapper<map_function_ret>::type;
+
+  transform_proxy_key_value(Container& rc, MapFunction filter)
       : m_rcontainer(rc), m_map_fn(filter) {}
 
   template <typename Function>

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -34,9 +34,11 @@ class map
                                           std::tuple<Key, Value>>,
       public detail::base_async_erase_key_value<map<Key, Value>,
                                                 std::tuple<Key, Value>>,
-      public detail::base_batch_erase<map<Key, Value>, std::tuple<Key, Value>>,
+      public detail::base_batch_erase_key_value<map<Key, Value>,
+                                                std::tuple<Key, Value>>,
       public detail::base_async_visit<map<Key, Value>, std::tuple<Key, Value>>,
-      public detail::base_iteration<map<Key, Value>, std::tuple<Key, Value>> {
+      public detail::base_iteration_key_value<map<Key, Value>,
+                                              std::tuple<Key, Value>> {
   friend class detail::base_misc<map<Key, Value>, std::tuple<Key, Value>>;
 
  public:
@@ -98,6 +100,8 @@ class map
                                      for_all_args>::async_erase;
   using detail::base_async_erase_key_value<map<Key, Value>,
                                            for_all_args>::async_erase;
+  using detail::base_batch_erase_key_value<map<Key, Value>,
+                                           for_all_args>::erase;
 
   void local_insert(const key_type& key) { m_local_map[key]; }
 
@@ -340,12 +344,12 @@ class multimap
                                           std::tuple<Key, Value>>,
       public detail::base_async_erase_key_value<multimap<Key, Value>,
                                                 std::tuple<Key, Value>>,
-      public detail::base_batch_erase<multimap<Key, Value>,
-                                      std::tuple<Key, Value>>,
+      public detail::base_batch_erase_key_value<multimap<Key, Value>,
+                                                std::tuple<Key, Value>>,
       public detail::base_async_visit<multimap<Key, Value>,
                                       std::tuple<Key, Value>>,
-      public detail::base_iteration<multimap<Key, Value>,
-                                    std::tuple<Key, Value>> {
+      public detail::base_iteration_key_value<multimap<Key, Value>,
+                                              std::tuple<Key, Value>> {
   friend class detail::base_misc<multimap<Key, Value>, std::tuple<Key, Value>>;
 
  public:

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -24,13 +24,13 @@ class multiset
     : public detail::base_async_insert_value<multiset<Value>,
                                              std::tuple<Value>>,
       public detail::base_async_erase_key<multiset<Value>, std::tuple<Value>>,
-      public detail::base_batch_erase<multiset<Value>, std::tuple<Value>>,
+      public detail::base_batch_erase_key<multiset<Value>, std::tuple<Value>>,
       public detail::base_async_contains<multiset<Value>, std::tuple<Value>>,
       public detail::base_async_insert_contains<multiset<Value>,
                                                 std::tuple<Value>>,
       public detail::base_count<multiset<Value>, std::tuple<Value>>,
       public detail::base_misc<multiset<Value>, std::tuple<Value>>,
-      public detail::base_iteration<multiset<Value>, std::tuple<Value>> {
+      public detail::base_iteration_value<multiset<Value>, std::tuple<Value>> {
   friend class detail::base_misc<multiset<Value>, std::tuple<Value>>;
 
  public:
@@ -152,12 +152,12 @@ template <typename Value>
 class set
     : public detail::base_async_insert_value<set<Value>, std::tuple<Value>>,
       public detail::base_async_erase_key<set<Value>, std::tuple<Value>>,
-      public detail::base_batch_erase<set<Value>, std::tuple<Value>>,
+      public detail::base_batch_erase_key<set<Value>, std::tuple<Value>>,
       public detail::base_async_contains<set<Value>, std::tuple<Value>>,
       public detail::base_async_insert_contains<set<Value>, std::tuple<Value>>,
       public detail::base_count<set<Value>, std::tuple<Value>>,
       public detail::base_misc<set<Value>, std::tuple<Value>>,
-      public detail::base_iteration<set<Value>, std::tuple<Value>> {
+      public detail::base_iteration_value<set<Value>, std::tuple<Value>> {
   friend class detail::base_misc<set<Value>, std::tuple<Value>>;
 
  public:
@@ -234,6 +234,8 @@ class set
     std::swap(m_local_set, other.m_local_set);
     return *this;
   }
+
+  using detail::base_batch_erase_key<set<Value>, for_all_args>::erase;
 
   void local_insert(const value_type &val) { m_local_set.insert(val); }
 

--- a/include/ygm/io/csv_parser.hpp
+++ b/include/ygm/io/csv_parser.hpp
@@ -68,6 +68,10 @@ class csv_parser : public ygm::container::detail::base_iteration_value<
     return m_has_headers && (m_header_map.find(label) != m_header_map.end());
   }
 
+  ygm::comm& comm() { return m_lp.comm(); }
+
+  const ygm::comm& comm() const { return m_lp.comm(); }
+
  private:
   line_parser m_lp;
 

--- a/include/ygm/io/csv_parser.hpp
+++ b/include/ygm/io/csv_parser.hpp
@@ -15,7 +15,7 @@
 
 namespace ygm::io {
 
-class csv_parser : public ygm::container::detail::base_iteration<
+class csv_parser : public ygm::container::detail::base_iteration_value<
                        csv_parser, std::tuple<std::vector<detail::csv_field>>> {
  public:
   using for_all_args = std::tuple<std::vector<detail::csv_field>>;
@@ -67,10 +67,6 @@ class csv_parser : public ygm::container::detail::base_iteration<
   bool has_header(const std::string& label) {
     return m_has_headers && (m_header_map.find(label) != m_header_map.end());
   }
-
-  ygm::comm& comm() { return m_lp.comm(); }
-
-  const ygm::comm& comm() const { return m_lp.comm(); }
 
  private:
   line_parser m_lp;

--- a/include/ygm/io/line_parser.hpp
+++ b/include/ygm/io/line_parser.hpp
@@ -19,7 +19,8 @@ namespace fs = std::filesystem;
  * @brief Distributed text file parsing.
  *
  */
-class line_parser: public ygm::container::detail::base_iteration<line_parser, std::tuple<std::string>> {
+class line_parser : public ygm::container::detail::base_iteration_value<
+                        line_parser, std::tuple<std::string>> {
  public:
   using for_all_args = std::tuple<std::string>;
   /**
@@ -163,10 +164,6 @@ class line_parser: public ygm::container::detail::base_iteration<line_parser, st
   }
 
   void set_skip_first_line(bool skip_first) { m_skip_first_line = skip_first; }
-
-  ygm::comm& comm() { return m_comm; }
-
-  const ygm::comm& comm() const { return m_comm; }
 
  private:
   /**

--- a/include/ygm/io/line_parser.hpp
+++ b/include/ygm/io/line_parser.hpp
@@ -165,6 +165,10 @@ class line_parser : public ygm::container::detail::base_iteration_value<
 
   void set_skip_first_line(bool skip_first) { m_skip_first_line = skip_first; }
 
+  ygm::comm& comm() { return m_comm; }
+
+  const ygm::comm& comm() const { return m_comm; }
+
  private:
   /**
    * @brief Check readability of paths and iterates through directories

--- a/include/ygm/io/ndjson_parser.hpp
+++ b/include/ygm/io/ndjson_parser.hpp
@@ -37,7 +37,7 @@ std::size_t json_filter(boost::json::object            &obj,
   return json_erase(obj, keys_to_erase);
 }
 
-class ndjson_parser : public ygm::container::detail::base_iteration<
+class ndjson_parser : public ygm::container::detail::base_iteration_value<
                           ndjson_parser, std::tuple<boost::json::object>> {
  public:
   using for_all_args = std::tuple<boost::json::object>;


### PR DESCRIPTION
Removes template specializations for `ygm::container::detail::base_iteration` and splits into `_value` and `_key_value` names. This leads to `_value` and `_key_value` variants of the `ygm::container::detail::*_proxy` classes. This is being done to allow doxygen to understand the code well enough to make reasonable documentation.

A similar split was performed with `ygm::container::detail::base_batch_erase`. Because the `_key_value` variant is still inheriting from the `_key` variant, not all of the generated `erase()` functions end up in the Doxygen output. This still needs to be pulled apart (with more duplicated code).

Developing locally, I encountered a bug in doxygen that makes it unable to handle trailing `requires` clauses, causing most of the functions to remain undocumented. This was fixed in doxygen [here](https://github.com/doxygen/doxygen/issues/8726). A new enough version of doxygen should be available on Ubuntu 24.04, but I'm not sure if this is being used by readthedocs. If it's not by default, it looks like it is possible to set our repo to [use 24.04 for generating docs](https://about.readthedocs.com/blog/2024/06/ubuntu-24-04/).