### PR TITLE
Fixes compilation error when using functors with containers

### DIFF
--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -126,9 +126,10 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
-      detail::SingleItemTuple<typename T::for_all_args> &&
-      std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
+  array(ygm::comm& comm, const T& t)
+    requires detail::HasForAll<T> &&
+                 detail::SingleItemTuple<typename T::for_all_args> &&
+                 std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     pthis.check(m_comm);
 
@@ -144,17 +145,19 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
-      detail::SingleItemTuple<typename T::for_all_args> && detail::
-          DoubleItemTuple<std::tuple_element_t<0, typename T::for_all_args>> &&
-      std::convertible_to<
-          std::tuple_element_t<
-              0, std::tuple_element_t<0, typename T::for_all_args>>,
-          key_type> &&
-      std::convertible_to<
-          std::tuple_element_t<
-              1, std::tuple_element_t<0, typename T::for_all_args>>,
-          mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::HasForAll<T> &&
+                 detail::SingleItemTuple<typename T::for_all_args> &&
+                 detail::DoubleItemTuple<
+                     std::tuple_element_t<0, typename T::for_all_args>> &&
+                 std::convertible_to<
+                     std::tuple_element_t<
+                         0, std::tuple_element_t<0, typename T::for_all_args>>,
+                     key_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<
+                         1, std::tuple_element_t<0, typename T::for_all_args>>,
+                     mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     pthis.check(m_comm);
 
@@ -175,12 +178,16 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
-      detail::DoubleItemTuple<typename T::for_all_args> && std::convertible_to<
+  array(ygm::comm& comm, const T& t)
+    requires detail::HasForAll<T> &&
+                 detail::DoubleItemTuple<typename T::for_all_args> &&
+                 std::convertible_to<
 
-          std::tuple_element_t<0, typename T::for_all_args>, key_type> &&
-      std::convertible_to<std::tuple_element_t<0, typename T::for_all_args>,
-                          mapped_type>
+                     std::tuple_element_t<0, typename T::for_all_args>,
+                     key_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<0, typename T::for_all_args>,
+                     mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     pthis.check(m_comm);
 
@@ -201,9 +208,10 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::STLContainer<T> &&
-      (not detail::SingleItemTuple<typename T::value_type>)&&std::
-          convertible_to<typename T::value_type, mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::STLContainer<T> &&
+                 (not detail::SingleItemTuple<typename T::value_type>) &&
+                 std::convertible_to<typename T::value_type, mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     pthis.check(m_comm);
 
@@ -221,11 +229,15 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::STLContainer<T> &&
-      detail::DoubleItemTuple<typename T::value_type> && std::convertible_to<
-          std::tuple_element_t<0, typename T::value_type>, key_type> &&
-      std::convertible_to<std::tuple_element_t<1, typename T::value_type>,
-                          mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::STLContainer<T> &&
+                 detail::DoubleItemTuple<typename T::value_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<0, typename T::value_type>,
+                     key_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<1, typename T::value_type>,
+                     mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     pthis.check(m_comm);
 
@@ -446,7 +458,8 @@ class array
     }
     m_comm.barrier();
 
-    YGM_ASSERT_RELEASE(samples.size() == samples_per_pivot * (m_comm.size() - 1));
+    YGM_ASSERT_RELEASE(samples.size() ==
+                       samples_per_pivot * (m_comm.size() - 1));
     std::sort(samples.begin(), samples.end());
     for (size_t i = samples_per_pivot - 1; i < samples.size();
          i += samples_per_pivot) {

--- a/include/ygm/container/detail/base_async_contains.hpp
+++ b/include/ygm/container/detail/base_async_contains.hpp
@@ -24,9 +24,9 @@ struct base_async_contains {
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [fn](auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) {
+    auto lambda = [&fn](auto                                             pcont,
+                        const std::tuple_element<0, for_all_args>::type& value,
+                        const FuncArgs&... args) {
       bool contains = static_cast<bool>(pcont->local_count(value));
       ygm::meta::apply_optional(
           fn, std::make_tuple(pcont),

--- a/include/ygm/container/detail/base_async_insert_contains.hpp
+++ b/include/ygm/container/detail/base_async_insert_contains.hpp
@@ -25,9 +25,9 @@ struct base_async_insert_contains {
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [fn](auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) {
+    auto lambda = [&fn](auto                                             pcont,
+                        const std::tuple_element<0, for_all_args>::type& value,
+                        const FuncArgs&... args) {
       bool contains = static_cast<bool>(pcont->local_count(value));
       if (!contains) {
         pcont->local_insert(value);

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -17,15 +17,16 @@ template <typename derived_type, typename for_all_args>
 struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const std::tuple_element<0, for_all_args>::type& key,
-                   Visitor visitor, const VisitorArgs&... args) requires
-      DoubleItemTuple<for_all_args> {
+                   Visitor visitor, const VisitorArgs&... args)
+    requires DoubleItemTuple<for_all_args>
+  {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, ygm::container::async_visit());
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
+    auto vlambda = [&visitor](
                        auto                                             pcont,
                        const std::tuple_element<0, for_all_args>::type& key,
                        const VisitorArgs&... args) {
@@ -39,7 +40,9 @@ struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args) requires DoubleItemTuple<for_all_args> {
+      const VisitorArgs&... args)
+    requires DoubleItemTuple<for_all_args>
+  {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
         Visitor, ygm::container::async_visit_if_contains());
 
@@ -47,7 +50,7 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
+    auto vlambda = [&visitor](
                        auto                                             pcont,
                        const std::tuple_element<0, for_all_args>::type& key,
                        const VisitorArgs&... args) {
@@ -61,7 +64,9 @@ struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args) const requires DoubleItemTuple<for_all_args> {
+      const VisitorArgs&... args) const
+    requires DoubleItemTuple<for_all_args>
+  {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
         Visitor, ygm::container::async_visit_if_contains());
 
@@ -69,7 +74,7 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
+    auto vlambda = [&visitor](
                        const auto                                       pcont,
                        const std::tuple_element<0, for_all_args>::type& key,
                        const VisitorArgs&... args) {

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -174,6 +174,31 @@ int main(int argc, char **argv) {
     }
   }
 
+  // Test async_visit functor
+  {
+    struct visit_functor {
+      void operator()(const size_t index, const int value) {
+        YGM_ASSERT_RELEASE(value == index);
+      }
+    };
+
+    int size = 64;
+
+    ygm::container::array<int> arr(world, size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        arr.async_set(i, i);
+      }
+    }
+
+    world.barrier();
+
+    for (int i = 0; i < size; ++i) {
+      arr.async_visit(i, visit_functor());
+    }
+  }
+
   // Test value-only for_all
   {
     int size = 64;

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -90,6 +90,30 @@ int main(int argc, char **argv) {
   }
 
   //
+  // Test async_visit with functor
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+
+    smap.async_insert("dog", "cat");
+    smap.async_insert("apple", "orange");
+
+    world.barrier();
+
+    smap.async_insert("dog", "dog");
+    smap.async_insert("red", "green");
+
+    world.barrier();
+
+    struct dog_check {
+      void operator()(const std::string &key, std::string &value) {
+        YGM_ASSERT_RELEASE(value == "cat");
+      }
+    };
+
+    smap.async_visit("dog", dog_check());
+  }
+
+  //
   // Test all ranks default & async_visit_if_contains
   {
     ygm::container::map<std::string, std::string> smap(world);


### PR DESCRIPTION
Passes wrapped visitor functions to wrapper lambdas by reference in ygm::container::detail::base_async_visit and related classes. Passing a copy of visitor functions prevents functors from being usable in async_visit-type operations.