### PR TITLE
Update ReadTheDocs Ubuntu Version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 
 # Set OS and Python versions
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 


### PR DESCRIPTION
Updating readthedocs to use Ubuntu 24.04 when building docs to get newer version of Doxygen