### PR TITLE
Feature/container functor visit

### DIFF
--- a/include/ygm/container/detail/base_async_contains.hpp
+++ b/include/ygm/container/detail/base_async_contains.hpp
@@ -26,7 +26,7 @@ struct base_async_contains {
 
     auto lambda = [fn](auto                                             pcont,
                        const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) {
+                       const FuncArgs&... args) mutable {
       bool contains = static_cast<bool>(pcont->local_count(value));
       ygm::meta::apply_optional(
           fn, std::make_tuple(pcont),

--- a/include/ygm/container/detail/base_async_insert_contains.hpp
+++ b/include/ygm/container/detail/base_async_insert_contains.hpp
@@ -27,7 +27,7 @@ struct base_async_insert_contains {
 
     auto lambda = [fn](auto                                             pcont,
                        const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) {
+                       const FuncArgs&... args) mutable {
       bool contains = static_cast<bool>(pcont->local_count(value));
       if (!contains) {
         pcont->local_insert(value);

--- a/include/ygm/container/detail/base_async_reduce.hpp
+++ b/include/ygm/container/detail/base_async_reduce.hpp
@@ -26,12 +26,12 @@ struct base_async_reduce {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto rlambda = [reducer](
-                       auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const std::tuple_element<1, for_all_args>::type& value) {
-      pcont->local_reduce(key, value, reducer);
-    };
+    auto rlambda =
+        [reducer](
+            auto pcont, const std::tuple_element<0, for_all_args>::type& key,
+            const std::tuple_element<1, for_all_args>::type& value) mutable {
+          pcont->local_reduce(key, value, reducer);
+        };
 
     derived_this->comm().async(dest, rlambda, derived_this->get_ygm_ptr(), key,
                                value);

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -17,8 +17,9 @@ template <typename derived_type, typename for_all_args>
 struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const std::tuple_element<0, for_all_args>::type& key,
-                   Visitor visitor, const VisitorArgs&... args) requires
-      DoubleItemTuple<for_all_args> {
+                   Visitor visitor, const VisitorArgs&... args)
+    requires DoubleItemTuple<for_all_args>
+  {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, ygm::container::async_visit());
 
     derived_type* derived_this = static_cast<derived_type*>(this);
@@ -28,7 +29,7 @@ struct base_async_visit {
     auto vlambda = [visitor](
                        auto                                             pcont,
                        const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) {
+                       const VisitorArgs&... args) mutable {
       pcont->local_visit(key, visitor, args...);
     };
 
@@ -39,7 +40,9 @@ struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args) requires DoubleItemTuple<for_all_args> {
+      const VisitorArgs&... args)
+    requires DoubleItemTuple<for_all_args>
+  {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
         Visitor, ygm::container::async_visit_if_contains());
 
@@ -50,7 +53,7 @@ struct base_async_visit {
     auto vlambda = [visitor](
                        auto                                             pcont,
                        const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) {
+                       const VisitorArgs&... args) mutable {
       pcont->local_visit_if_contains(key, visitor, args...);
     };
 
@@ -61,7 +64,9 @@ struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
       const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args) const requires DoubleItemTuple<for_all_args> {
+      const VisitorArgs&... args) const
+    requires DoubleItemTuple<for_all_args>
+  {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
         Visitor, ygm::container::async_visit_if_contains());
 
@@ -72,7 +77,7 @@ struct base_async_visit {
     auto vlambda = [visitor](
                        const auto                                       pcont,
                        const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) {
+                       const VisitorArgs&... args) mutable {
       pcont->local_visit_if_contains(key, visitor, args...);
     };
 

--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -152,8 +152,7 @@ struct base_iteration_value {
                   "value_type must be a std::pair");
 
     auto rbklambda =
-        [&map,
-         reducer](std::pair<reduce_key_type, reduce_value_type> kvp) mutable {
+        [&map, reducer](std::pair<reduce_key_type, reduce_value_type> kvp) {
           map.async_reduce(kvp.first, kvp.second, reducer);
         };
     derived_this->for_all(rbklambda);

--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -68,9 +68,10 @@ struct base_iteration_value {
   }
 
   template <typename Compare = std::greater<value_type>>
-  std::vector<value_type> gather_topk(size_t  k,
-                                      Compare comp = std::greater<value_type>())
-      const requires SingleItemTuple<for_all_args> {
+  std::vector<value_type> gather_topk(
+      size_t k, Compare comp = std::greater<value_type>()) const
+    requires SingleItemTuple<for_all_args>
+  {
     const derived_type* derived_this = static_cast<const derived_type*>(this);
     const ygm::comm&    mycomm       = derived_this->comm();
     std::vector<value_type> local_topk;
@@ -151,7 +152,8 @@ struct base_iteration_value {
                   "value_type must be a std::pair");
 
     auto rbklambda =
-        [&map, reducer](std::pair<reduce_key_type, reduce_value_type> kvp) {
+        [&map,
+         reducer](std::pair<reduce_key_type, reduce_value_type> kvp) mutable {
           map.async_reduce(kvp.first, kvp.second, reducer);
         };
     derived_this->for_all(rbklambda);
@@ -168,13 +170,13 @@ struct base_iteration_value {
 
  private:
   template <typename STLContainer, typename Value>
-  requires requires(STLContainer stc, Value v) { stc.push_back(v); }
+    requires requires(STLContainer stc, Value v) { stc.push_back(v); }
   static void generic_insert(STLContainer& stc, const Value& value) {
     stc.push_back(value);
   }
 
   template <typename STLContainer, typename Value>
-  requires requires(STLContainer stc, Value v) { stc.insert(v); }
+    requires requires(STLContainer stc, Value v) { stc.insert(v); }
   static void generic_insert(STLContainer& stc, const Value& value) {
     stc.insert(value);
   }
@@ -342,13 +344,13 @@ struct base_iteration_key_value {
 
  private:
   template <typename STLContainer, typename Value>
-  requires requires(STLContainer stc, Value v) { stc.push_back(v); }
+    requires requires(STLContainer stc, Value v) { stc.push_back(v); }
   static void generic_insert(STLContainer& stc, const Value& value) {
     stc.push_back(value);
   }
 
   template <typename STLContainer, typename Value>
-  requires requires(STLContainer stc, Value v) { stc.insert(v); }
+    requires requires(STLContainer stc, Value v) { stc.insert(v); }
   static void generic_insert(STLContainer& stc, const Value& value) {
     stc.insert(value);
   }

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -174,6 +174,31 @@ int main(int argc, char **argv) {
     }
   }
 
+  // Test async_visit functor
+  {
+    struct visit_functor {
+      void operator()(const size_t index, const int value) {
+        YGM_ASSERT_RELEASE(value == index);
+      }
+    };
+
+    int size = 64;
+
+    ygm::container::array<int> arr(world, size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        arr.async_set(i, i);
+      }
+    }
+
+    world.barrier();
+
+    for (int i = 0; i < size; ++i) {
+      arr.async_visit(i, visit_functor());
+    }
+  }
+
   // Test value-only for_all
   {
     int size = 64;

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -90,6 +90,30 @@ int main(int argc, char **argv) {
   }
 
   //
+  // Test async_visit with functor
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+
+    smap.async_insert("dog", "cat");
+    smap.async_insert("apple", "orange");
+
+    world.barrier();
+
+    smap.async_insert("dog", "dog");
+    smap.async_insert("red", "green");
+
+    world.barrier();
+
+    struct dog_check {
+      void operator()(const std::string &key, std::string &value) {
+        YGM_ASSERT_RELEASE(value == "cat");
+      }
+    };
+
+    smap.async_visit("dog", dog_check());
+  }
+
+  //
   // Test all ranks default & async_visit_if_contains
   {
     ygm::container::map<std::string, std::string> smap(world);


### PR DESCRIPTION
Adds `mutable` qualifier to wrapper lambdas taking user-provided functions in `async_` operations in order to call non-`const` methods on passed functions. This is necessary when using a hand-written functor with an `operator()` that is not `const`.