### PR TITLE
Use `derived_this->for_all()` in `gather` operations

### DIFF
--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -62,7 +62,7 @@ struct base_iteration_value {
           value);
     };
 
-    for_all(glambda);
+    derived_this->for_all(glambda);
 
     derived_this->comm().barrier();
   }
@@ -222,7 +222,7 @@ struct base_iteration_key_value {
           key, value);
     };
 
-    for_all(glambda);
+    derived_this->for_all(glambda);
 
     derived_this->comm().barrier();
   }


### PR DESCRIPTION
Calls derived_this->for_all() in ygm::container::base_iteration::gather() functions to properly use overloaded for_all() operations, such as when calling gather on the output of a filter().