### PR TITLE
fixing likely typo in communicator

### DIFF
--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -968,7 +968,7 @@ inline bool comm::process_receive_queue() {
     }
   }
 
-  received_to_return != local_process_incoming();
+  received_to_return |= local_process_incoming();
 
   m_in_process_receive_queue = false;
   return received_to_return;


### PR DESCRIPTION
Small likely typo in https://github.com/LLNL/ygm/blob/v0.7-dev/include/ygm/detail/comm.ipp#L971
Likely meant to be: `received_to_return |= local_process_incoming();` to capture the return value of local_process_incoming, alternatively this could be just `local_process_incoming(); ` if the return value is not needed. The return value isn't stored or used but appears as it is. 