### PR TITLE
fixed template redefinition errors in build

### DIFF
--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -27,7 +27,7 @@ class flatten_proxy_value;
 template <typename derived_type>
 class flatten_proxy_key_value;
 
-template <typename derived_type, typename for_all_args>
+template <typename derived_type, SingleItemTuple for_all_args>
 struct base_iteration_value {
   using value_type = typename std::tuple_element<0, for_all_args>::type;
 
@@ -182,7 +182,7 @@ struct base_iteration_value {
 };
 
 // For Associative Containers
-template <typename derived_type, typename for_all_args>
+template <typename derived_type, DoubleItemTuple for_all_args>
 struct base_iteration_key_value {
   using key_type    = typename std::tuple_element<0, for_all_args>::type;
   using mapped_type = typename std::tuple_element<1, for_all_args>::type;


### PR DESCRIPTION
This minor change fixes the build errors I reported this morning. Built with gcc 13.2.0 and clang++ 17.0.6.

<details><summary>Test Results</summary>

```
Running tests...                                                                                                             
Test project /home/seth/dev/cpp/ygm/build                                                                                    
      Start  1: SEQ_test_cereal_archive                                                                                      
 1/34 Test  #1: SEQ_test_cereal_archive .............   Passed    0.01 sec                                                   
      Start  2: MPI_test_comm                                                                                                
 2/34 Test  #2: MPI_test_comm .......................   Passed    0.22 sec                                                   
      Start  3: MPI_test_comm_2                                                                                              
 3/34 Test  #3: MPI_test_comm_2 .....................   Passed    0.65 sec                                                   
      Start  4: MPI_test_barrier
 4/34 Test  #4: MPI_test_barrier ....................   Passed    0.17 sec
      Start  5: MPI_test_layout 
 5/34 Test  #5: MPI_test_layout .....................   Passed    0.20 sec
      Start  6: MPI_test_large_messages
 6/34 Test  #6: MPI_test_large_messages .............   Passed    0.27 sec
      Start  7: MPI_test_map
 7/34 Test  #7: MPI_test_map ........................   Passed    0.15 sec
      Start  8: MPI_test_multimap
 8/34 Test  #8: MPI_test_multimap ...................   Passed    0.19 sec
      Start  9: MPI_test_set
 9/34 Test  #9: MPI_test_set ........................   Passed    0.15 sec
      Start 10: MPI_test_bag
10/34 Test #10: MPI_test_bag ........................   Passed    0.19 sec
      Start 11: MPI_test_multiset
11/34 Test #11: MPI_test_multiset ...................   Passed    0.20 sec
      Start 12: MPI_test_array
12/34 Test #12: MPI_test_array ......................   Passed    0.20 sec
      Start 13: MPI_test_disjoint_set
13/34 Test #13: MPI_test_disjoint_set ...............   Passed    0.15 sec
      Start 14: MPI_test_line_parser
14/34 Test #14: MPI_test_line_parser ................   Passed    1.06 sec                                                   
      Start 15: MPI_test_csv_parser                                                                                          
15/34 Test #15: MPI_test_csv_parser .................   Passed    0.10 sec                                                   
      Start 16: MPI_test_csv_headers                                                                                         
16/34 Test #16: MPI_test_csv_headers ................   Passed    0.16 sec
      Start 17: MPI_test_multi_output
17/34 Test #17: MPI_test_multi_output ...............   Passed    0.20 sec
      Start 18: MPI_test_daily_output
18/34 Test #18: MPI_test_daily_output ...............   Passed    0.20 sec
      Start 19: MPI_test_interrupt_mask
19/34 Test #19: MPI_test_interrupt_mask .............   Passed    0.14 sec
      Start 20: MPI_test_random 
20/34 Test #20: MPI_test_random .....................   Passed    0.22 sec
      Start 21: MPI_test_container_traits
21/34 Test #21: MPI_test_container_traits ...........   Passed    0.16 sec
      Start 22: MPI_test_collective
22/34 Test #22: MPI_test_collective .................   Passed    0.18 sec
      Start 23: MPI_test_traits 
23/34 Test #23: MPI_test_traits .....................   Passed    0.19 sec
      Start 24: MPI_test_concepts
24/34 Test #24: MPI_test_concepts ...................   Passed    0.06 sec
      Start 25: MPI_test_recursion_large_messages
25/34 Test #25: MPI_test_recursion_large_messages ...   Passed    0.25 sec
      Start 26: MPI_test_recursion_progress
26/34 Test #26: MPI_test_recursion_progress .........   Passed    0.11 sec
      Start 27: MPI_test_gather_topk
27/34 Test #27: MPI_test_gather_topk ................   Passed    0.28 sec
      Start 28: MPI_test_reduce 
28/34 Test #28: MPI_test_reduce .....................   Passed    0.18 sec
      Start 29: MPI_test_transform
29/34 Test #29: MPI_test_transform ..................   Passed    0.19 sec
      Start 30: SEQ_test_cereal_boost_json
30/34 Test #30: SEQ_test_cereal_boost_json ..........   Passed    0.01 sec
      Start 31: SEQ_test_cereal_boost_container
31/34 Test #31: SEQ_test_cereal_boost_container .....   Passed    0.01 sec
      Start 32: MPI_test_ndjson_parser
32/34 Test #32: MPI_test_ndjson_parser ..............   Passed    0.18 sec
      Start 33: MPI_test_parquet_reader
33/34 Test #33: MPI_test_parquet_reader .............   Passed    0.20 sec
      Start 34: MPI_test_parquet_reader_json
34/34 Test #34: MPI_test_parquet_reader_json ........   Passed    0.22 sec

100% tests passed, 0 tests failed out of 34

Total Test time (real) =   7.08 sec
```

</details>