### PR TITLE
Feature/ci gcc versions

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -56,7 +56,7 @@ jobs:
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
         if: (matrix.gcc-version == '11' && matrix.os == 'ubuntu-24.04')
-        run: sudo apt-get install gcc-11
+        run: sudo apt-get install gcc-11 g++-11
       - name: Make
         run: |
           echo Run 'make'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -58,7 +58,7 @@ jobs:
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
         if: matrix.gcc-version == '13'
-        run: apt-get search gcc-13
+        run: apt search gcc-13
           #run: sudo apt-get install gcc-13
       - name: Make
         run: |

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -55,7 +55,7 @@ jobs:
         if: matrix.mpi-type == 'openmpi'
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
-        if: (matrix.gcc-version == '11' && matrix.os_version == 'ubuntu-24.04')
+        if: (matrix.gcc-version == '11' && matrix.os == 'ubuntu-24.04')
         run: sudo apt-get install gcc-11
       - name: Make
         run: |

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        - name: Update apt
+      - name: Update apt
         run: |
         sudo add-apt-repository universe
         sudo apt update

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update apt
         run: |
-        sudo add-apt-repository universe
-        sudo apt update
+          sudo add-apt-repository universe
+          sudo apt update
       - name: Cache boost
         uses: actions/cache@v4
         id: cache-boost

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -55,9 +55,9 @@ jobs:
         if: matrix.mpi-type == 'openmpi'
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
-        if: matrix.gcc-version == '13'
-        run: apt search gcc-13
-          #run: sudo apt-get install gcc-13
+        if: (matrix.gcc-version == '11' && matrix.os_version == 'ubuntu-24.04')
+        run: apt search gcc-11
+        run: sudo apt-get install gcc-11
       - name: Make
         run: |
           echo Run 'make'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -14,12 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         gcc-version: [11, 12, 13, 14]
         mpi-type: [mpich, openmpi]
         exclude:
-          - os: ubuntu-latest
-            gcc-version: 8
           - os: ubuntu-22.04
             gcc-version: 13
           - os: ubuntu-22.04

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -56,7 +56,6 @@ jobs:
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
         if: (matrix.gcc-version == '11' && matrix.os_version == 'ubuntu-24.04')
-        run: apt search gcc-11
         run: sudo apt-get install gcc-11
       - name: Make
         run: |

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -21,14 +21,16 @@ jobs:
           - os: ubuntu-latest
             gcc-version: 8
           - os: ubuntu-22.04
-            gcc-version: [13, 14]
+            gcc-version: 13
+          - os: ubuntu-22.04
+            gcc-version: 14
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        #- name: Update apt
-        #run: |
-        #sudo add-apt-repository universe
-        #sudo apt update
+        - name: Update apt
+        run: |
+        sudo add-apt-repository universe
+        sudo apt update
       - name: Cache boost
         uses: actions/cache@v4
         id: cache-boost
@@ -55,8 +57,8 @@ jobs:
         if: matrix.mpi-type == 'openmpi'
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
-        if: matrix.gcc-version == '8'
-        run: sudo apt-get install gcc-8 g++-8
+        if: matrix.gcc-version == '13'
+        run: sudo apt-get install gcc-13
       - name: Make
         run: |
           echo Run 'make'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -22,6 +22,8 @@ jobs:
             gcc-version: 13
           - os: ubuntu-22.04
             gcc-version: 14
+          - os: ubuntu-24.04
+            mpi-type: mpich
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -15,14 +15,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-22.04]
-        gcc-version: [11, 12]
+        gcc-version: [11, 12, 13, 14]
         mpi-type: [mpich, openmpi]
         exclude:
           - os: ubuntu-latest
             gcc-version: 8
+          - os: ubuntu-22.04
+            gcc-version: [13, 14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        #- name: Update apt
+        #run: |
+        #sudo add-apt-repository universe
+        #sudo apt update
       - name: Cache boost
         uses: actions/cache@v4
         id: cache-boost

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update apt
         run: |
-          sudo add-apt-repository universe
-          sudo apt update
+          sudo add-apt-repository -y universe
+          sudo apt-get update
       - name: Cache boost
         uses: actions/cache@v4
         id: cache-boost
@@ -58,7 +58,8 @@ jobs:
         run: sudo apt-get install openmpi-bin libopenmpi-dev
       - name: Install GCC-${{ matrix.gcc-version }}
         if: matrix.gcc-version == '13'
-        run: sudo apt-get install gcc-13
+        run: apt-get search gcc-13
+          #run: sudo apt-get install gcc-13
       - name: Make
         run: |
           echo Run 'make'

--- a/include/ygm/detail/ygm_traits.hpp
+++ b/include/ygm/detail/ygm_traits.hpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <algorithm>
 #include <type_traits>
 
 namespace ygm::detail {

--- a/test/test_collective.cpp
+++ b/test/test_collective.cpp
@@ -62,12 +62,16 @@ int main(int argc, char** argv) {
     string_set.insert("Aggs");
   }
 
-  YGM_ASSERT_RELEASE(not is_same(string_set, world));
+  if (world.size() > 1) {
+    YGM_ASSERT_RELEASE(not is_same(string_set, world));
+  }
   string_set.insert("Howdy");
   string_set.insert("Aggs");
   YGM_ASSERT_RELEASE(is_same(string_set, world));
 
-  YGM_ASSERT_RELEASE(not is_same(world.rank(), world));
+  if (world.size() > 1) {
+    YGM_ASSERT_RELEASE(not is_same(world.rank(), world));
+  }
 
   return 0;
 }


### PR DESCRIPTION
Explicitly testing ubuntu-24.04 since ubuntu-latest may or may not point to ubuntu-24.04 ([see here](https://github.com/actions/runner-images/issues/10636)).

In making this change, I discovered mpich is broken on Ubuntu 24.04 ([link](https://bugs.launchpad.net/ubuntu/+source/mpich/+bug/2072338)). Removing mpich tests on ubuntu-24.04 for the time being and will add them back in at a later date.

Adds tests for newer versions of GCC that are available on Ubuntu 24.04.