### PR TITLE
Feature split local and remote buffer tracking

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -189,6 +189,8 @@ class comm {
 
   std::pair<uint64_t, uint64_t> barrier_reduce_counts();
 
+  void queue_next_send(std::deque<int> &dest_queue);
+  
   void flush_send_buffer(int dest);
 
   void handle_completed_send(mpi_isend_request &req_buffer);
@@ -241,8 +243,11 @@ class comm {
   MPI_Comm m_comm_other;
 
   std::vector<ygm::detail::byte_vector> m_vec_send_buffers;
-  size_t                              m_send_buffer_bytes = 0;
-  std::deque<int>                     m_send_dest_queue;
+
+  size_t                              m_send_local_buffer_bytes = 0;
+  std::deque<int>                     m_send_local_dest_queue;
+  size_t                              m_send_remote_buffer_bytes = 0;
+  std::deque<int>                     m_send_remote_dest_queue;
 
   std::deque<mpi_irecv_request>                        m_recv_queue;
   std::deque<mpi_isend_request>                        m_send_queue;

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -265,8 +265,8 @@ class comm {
   bool m_in_process_receive_queue = false;
 
   detail::comm_stats             stats;
-  const detail::comm_environment config;
   const detail::layout           m_layout;
+  const detail::comm_environment config = detail::comm_environment(m_layout.node_size());
   detail::comm_router            m_router;
 
   detail::lambda_map<void (*)(comm *, cereal::YGMInputArchive *), uint16_t>

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -189,7 +189,7 @@ class comm {
 
   std::pair<uint64_t, uint64_t> barrier_reduce_counts();
 
-  void queue_next_send(std::deque<int> &dest_queue);
+  void flush_next_send(std::deque<int> &dest_queue);
   
   void flush_send_buffer(int dest);
 
@@ -266,7 +266,7 @@ class comm {
 
   detail::comm_stats             stats;
   const detail::layout           m_layout;
-  const detail::comm_environment config = detail::comm_environment(m_layout.node_size());
+  const detail::comm_environment config = detail::comm_environment(m_layout);
   detail::comm_router            m_router;
 
   detail::lambda_map<void (*)(comm *, cereal::YGMInputArchive *), uint16_t>

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -579,7 +579,7 @@ inline void comm::flush_send_buffer(int dest) {
 }
 
 
-inline void comm::queue_next_send(std::deque<int> &dest_queue) {
+inline void comm::flush_next_send(std::deque<int> &dest_queue) {
   if (!dest_queue.empty()) {
     int dest = dest_queue.front();
     dest_queue.pop_front();
@@ -633,10 +633,10 @@ inline void comm::local_progress() {
     process_receive_queue();
   }
   if (not m_send_local_dest_queue.empty()) {
-    queue_next_send(m_send_local_dest_queue);
+    flush_next_send(m_send_local_dest_queue);
   }
   if (not m_send_remote_dest_queue.empty()) {
-    queue_next_send(m_send_remote_dest_queue);
+    flush_next_send(m_send_remote_dest_queue);
   }
 }
 
@@ -675,12 +675,12 @@ inline void comm::flush_all_local_and_process_incoming() {
     //  Flush each send buffer
     while (!m_send_local_dest_queue.empty()) {
       did_something = true;
-      queue_next_send(m_send_local_dest_queue);
+      flush_next_send(m_send_local_dest_queue);
       process_receive_queue();
     }
     while (!m_send_remote_dest_queue.empty()) {
       did_something = true;
-      queue_next_send(m_send_remote_dest_queue);
+      flush_next_send(m_send_remote_dest_queue);
       process_receive_queue();
     }
 
@@ -699,11 +699,11 @@ inline void comm::flush_all_local_and_process_incoming() {
 inline void comm::flush_to_capacity() {
   while (m_send_local_buffer_bytes > config.local_buffer_size) {
     YGM_ASSERT_DEBUG(!m_send_local_dest_queue.empty());
-    queue_next_send(m_send_local_dest_queue);
+    flush_next_send(m_send_local_dest_queue);
   }
   while (m_send_remote_buffer_bytes > config.remote_buffer_size) {
     YGM_ASSERT_DEBUG(!m_send_remote_dest_queue.empty());
-    queue_next_send(m_send_remote_dest_queue);
+    flush_next_send(m_send_remote_dest_queue);
   }
 }
 

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -619,7 +619,7 @@ inline void comm::check_completed_sends() {
 
 inline void comm::check_if_production_halt_required() {
   while (m_enable_interrupts && !m_in_process_receive_queue &&
-         m_pending_isend_bytes > config.remote_buffer_size) {
+         m_pending_isend_bytes > (config.local_buffer_size + config.remote_buffer_size)) {
     process_receive_queue();
   }
 }

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -27,7 +27,7 @@ struct comm::header_t {
 };
 
 inline comm::comm(int *argc, char ***argv)
-    : pimpl_if(std::make_shared<detail::mpi_init_finalize>(argc, argv)),
+    : pimpl_if (std::make_shared<detail::mpi_init_finalize>(argc, argv)),
       m_layout(MPI_COMM_WORLD),
       m_router(m_layout, config.routing) {
   // pimpl_if = std::make_shared<detail::mpi_init_finalize>(argc, argv);
@@ -938,7 +938,7 @@ inline void comm::queue_message_bytes(const ygm::detail::byte_vector            
   // forwarded in a bcast
   if (config.routing != detail::routing_type::NONE) {
     size_t header_bytes = pack_header(send_buff, -1, 0);
-    if(local) {
+    if (local) {
       m_send_local_buffer_bytes += header_bytes;
     } else {
       m_send_remote_buffer_bytes += header_bytes;
@@ -946,7 +946,7 @@ inline void comm::queue_message_bytes(const ygm::detail::byte_vector            
   }
 
   send_buff.push_bytes(packed.data(), packed.size());
-  if(local) {
+  if (local) {
     m_send_local_buffer_bytes += packed.size();
   } else {
     m_send_remote_buffer_bytes += packed.size();

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -27,7 +27,7 @@ struct comm::header_t {
 };
 
 inline comm::comm(int *argc, char ***argv)
-    : pimpl_if (std::make_shared<detail::mpi_init_finalize>(argc, argv)),
+    : pimpl_if(std::make_shared<detail::mpi_init_finalize>(argc, argv)),
       m_layout(MPI_COMM_WORLD),
       m_router(m_layout, config.routing) {
   // pimpl_if = std::make_shared<detail::mpi_init_finalize>(argc, argv);

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <string>
 #include <cmath>
+#include <ygm/detail/layout.hpp>
 
 namespace ygm {
 
@@ -17,8 +18,8 @@ namespace detail {
 
 enum class routing_type { NONE, NR, NLNR };
 
-  size_t round_to_nearest_kb(size_t number) {
-    return std::ceil(static_cast<double>(number) / 1024) * 1024;
+  size_t round_to_nearest_kb(float number) {
+    return std::ceil(static_cast<float>(number) / 1024) * 1024;
   }
   
 /**
@@ -40,7 +41,8 @@ class comm_environment {
   }
 
  public:
-  comm_environment(size_t nodes) {
+  comm_environment(const ygm::detail::layout& layout) {
+    size_t nodes = layout.node_size();
     if (const char* cc = std::getenv("YGM_COMM_ROUTING")) {
       if (std::string(cc) == "NONE") {
         routing = routing_type::NONE;
@@ -57,27 +59,27 @@ class comm_environment {
     }
     switch (routing) {
       case routing_type::NONE :
-        local_buffer_size  = round_to_nearest_kb(total_buffer_size / nodes);
+        local_buffer_size  = round_to_nearest_kb((float) total_buffer_size / nodes);
         remote_buffer_size = total_buffer_size - local_buffer_size;
         break;
       case routing_type::NR :
-        local_buffer_size  = round_to_nearest_kb(total_buffer_size / 2);
+        local_buffer_size  = round_to_nearest_kb((float) total_buffer_size / 2);
         remote_buffer_size = local_buffer_size;
         break;
       case routing_type::NLNR :
-        local_buffer_size  = round_to_nearest_kb(2 * total_buffer_size / 3);
-        remote_buffer_size = round_to_nearest_kb(total_buffer_size / 3);
+        local_buffer_size  = round_to_nearest_kb(2 * (float) total_buffer_size / 3);
+        remote_buffer_size = round_to_nearest_kb((float) total_buffer_size / 3);
         break;
     }
     if (const char* cc = std::getenv("YGM_COMM_LOCAL_BUFFER_SIZE_KB")) {
       local_buffer_size = convert<size_t>(cc) * 1024;
       if (std::getenv("YGM_COMM_REMOTE_BUFFER_SIZE_KB") == nullptr)
-        std::cerr << "YGM_COMM_REMOTE_BUFFER_SIZE_KB not set, using default  of" << remote_buffer_size << "\n";
+        std::cerr << "YGM_COMM_REMOTE_BUFFER_SIZE_KB not set, using recommended value of" << remote_buffer_size << "\n";
     }
     if (const char* cc = std::getenv("YGM_COMM_REMOTE_BUFFER_SIZE_KB")) {
       remote_buffer_size = convert<size_t>(cc) * 1024;
       if (std::getenv("YGM_COMM_LOCAL_BUFFER_SIZE_KB") == nullptr)
-        std::cerr << "YGM_COMM_LOCAL_BUFFER_SIZE_KB not set, using default  of" << local_buffer_size << "\n";
+        std::cerr << "YGM_COMM_LOCAL_BUFFER_SIZE_KB not set, using recommended value of" << local_buffer_size << "\n";
     }
     if (const char* cc = std::getenv("YGM_COMM_NUM_IRECVS")) {
       num_irecvs = convert<size_t>(cc);

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -56,7 +56,13 @@ class comm_environment {
       }
     }
 
-    // Now we can calculate the buffere sizes based off of the expected traffic from the routing scheme
+    // Calculate local and remote buffer sizes based on heuristics for the routing scheme being used 
+    // assuming a uniform communication pattern.
+    // NONE - All messages are sent directly, so the fraction of local messages is 1/(num_nodes)
+    // NR - Most remote messages generate a single remote message followed by a single local message.
+    //      In high-node count situations, this will give roughly equal local and remote communication.
+    // NLNR - Most remote messages generate one remote message and two local messages. In high node-count
+    //      situations, this will give roughly 1/3 of communication as remote and 2/3 as local.
     if (const char* cc = std::getenv("YGM_COM_BUFFER_SIZE_KB")) {
       total_buffer_size = convert<size_t>(cc) * 1024;
     }

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -43,6 +43,7 @@ class comm_environment {
  public:
   comm_environment(const ygm::detail::layout& layout) {
     size_t nodes = layout.node_size();
+    // We have to determine the routing type first as it changes the ratio between local and remote buffers
     if (const char* cc = std::getenv("YGM_COMM_ROUTING")) {
       if (std::string(cc) == "NONE") {
         routing = routing_type::NONE;
@@ -54,6 +55,8 @@ class comm_environment {
         throw std::runtime_error("comm_enviornment -- unknown routing type");
       }
     }
+
+    // Now we can calculate the buffere sizes based off of the expected traffic from the routing scheme
     if (const char* cc = std::getenv("YGM_COM_BUFFER_SIZE_KB")) {
       total_buffer_size = convert<size_t>(cc) * 1024;
     }

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -36,8 +36,11 @@ class comm_environment {
 
  public:
   comm_environment() {
-    if (const char* cc = std::getenv("YGM_COMM_BUFFER_SIZE_KB")) {
-      buffer_size = convert<size_t>(cc) * 1024;
+    if (const char* cc = std::getenv("YGM_COMM_LOCAL_BUFFER_SIZE_KB")) {
+      local_buffer_size = convert<size_t>(cc) * 1024;
+    }
+    if (const char* cc = std::getenv("YGM_COMM_REMOTE_BUFFER_SIZE_KB")) {
+      remote_buffer_size = convert<size_t>(cc) * 1024;
     }
     if (const char* cc = std::getenv("YGM_COMM_NUM_IRECVS")) {
       num_irecvs = convert<size_t>(cc);
@@ -72,12 +75,13 @@ class comm_environment {
 
   void print(std::ostream& os = std::cout) const {
     os << "======== ENVIRONMENT SETTINGS ========\n"
-       << "YGM_COMM_BUFFER_SIZE_KB  = " << buffer_size / 1024 << "\n"
-       << "YGM_COMM_NUM_IRECVS      = " << num_irecvs << "\n"
-       << "YGM_COMM_IRECVS_SIZE_KB  = " << irecv_size / 1024 << "\n"
-       << "YGM_COMM_NUM_ISENDS_WAIT = " << num_isends_wait << "\n"
-       << "YGM_COMM_ISSEND_FREQ     = " << freq_issend << "\n"
-       << "YGM_COMM_ROUTING         = ";
+       << "YGM_COMM_LOCAL_BUFFER_SIZE_KB   = " << local_buffer_size / 1024 << "\n"
+       << "YGM_COMM_REMOTE_BUFFER_SIZE_KB  = " << remote_buffer_size / 1024 << "\n"
+       << "YGM_COMM_NUM_IRECVS             = " << num_irecvs << "\n"
+       << "YGM_COMM_IRECVS_SIZE_KB         = " << irecv_size / 1024 << "\n"
+       << "YGM_COMM_NUM_ISENDS_WAIT        = " << num_isends_wait << "\n"
+       << "YGM_COMM_ISSEND_FREQ            = " << freq_issend << "\n"
+       << "YGM_COMM_ROUTING                = ";
     switch (routing) {
       case routing_type::NONE:
         os << "NONE\n";
@@ -94,7 +98,8 @@ class comm_environment {
 
   //
   // variables with their default values
-  size_t buffer_size = 16 * 1024 * 1024;
+  size_t local_buffer_size  = 16 * 1024 * 1024;
+  size_t remote_buffer_size = 16 * 1024 * 1024;
 
   size_t irecv_size = 1024 * 1024 * 1024;
   size_t num_irecvs = 8;


### PR DESCRIPTION
## Summary
This feature aims to split how the comm buffer handles local and remote communications separately. This should allow for more fine-tuning in our environment parameters as we can set the node local and node remote target msg size separately. 

## Description of Changes
- Split m_send_buffer_bytes and m_send_dest_queue into local and remote counterparts
- Added a comm function queue_next_send to reduce repeated code since we have two dest queues now
- Updated several places in the comm to check if the next dest is local and handled appropriately

## Unfinished items / Todo
- More testing, especially on large node scales. I've tested locally, and on a few nodes with my SHM version of this but haven't extensively tested this branch
- There's likely a cleaner way to implement some if(local) checks.
- Check `comm::check_if_production_halt_required`. I have this as the pending isend_bytes being less than the sum of the two buffers. In my SHM version, this is just the remote_send_bytes, as we would expect the majority of communication to be through shared memory.