### PR TITLE
Brush up Parquet Reader

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -67,7 +67,7 @@ jobs:
           mkdir build
           cd build
           if [ "$ENABLE_PARQUET_TEST" ]; then
-            ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_ARROW_PARQUET=ON"
+            ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
           cmake ../ -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc-version }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
           make -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,8 @@ endif ()
 #
 #
 include(FindArrowParquet)
-option(YGM_REQUIRE_ARROW_PARQUET "YGM requires Apache Arrow Parquet." OFF)
+option(YGM_REQUIRE_PARQUET "YGM requires Arrow Parquet." OFF)
+option(YGM_INSTALL_PARQUET "YGM installs Arrow Parquet if it is not found." OFF)
 find_or_install_arrow_parquet()
 
 #

--- a/cmake/FindArrowParquet.cmake
+++ b/cmake/FindArrowParquet.cmake
@@ -172,19 +172,26 @@ endfunction()
 
 # Find Arrow and Parquet. If not found, install pyarrow using pip in a Python virtual environmental space.
 # Input:
-#   PIP_PYARROW_ROOT (option) The root directory of a pyarrow installed by pip.
-#   YGM_REQUIRE_ARROW_PARQUET (option) If TRUE, an fatal error is thrown when Arrow Parquet is not found.
+#   YGM_REQUIRE_PARQUET (option)
+#       If TRUE, a fatal error is thrown when Arrow Parquet is not found or not installed.
+#   YGM_INSTALL_PARQUET (option)
+#       If TRUE, install Arrow Parquet when it is not found.
+#   PIP_PYARROW_ROOT (option)
+#       The root directory of a pyarrow installed by pip. If given, search only the location.
+#       If Arrow Parquet is not found, A) return this function or B) throw a fatal error if YGM_REQUIRE_PARQUET is true.
+#       Ignore YGM_INSTALL_PARQUET --- no installation is performed even if Arrow Parquet is not found.
 # Output:
 #   Arrow_FOUND and Parquet_FOUND are defined and set to TRUE if Arrow and Parquet are found.
 function(find_or_install_arrow_parquet)
     if (PIP_PYARROW_ROOT)
         find_pip_installed_pyarrow()
         if (NOT Arrow_FOUND OR NOT Parquet_FOUND)
-            if (YGM_REQUIRE_ARROW_PARQUET)
+            if (YGM_REQUIRE_PARQUET)
                 message(FATAL_ERROR "${PROJECT_NAME} requires Arrow Parquet but Arrow Parquet was not found in ${PIP_PYARROW_ROOT}.")
             else ()
                 message(WARNING "${PROJECT_NAME} did not find Arrow Parquet in ${PIP_PYARROW_ROOT}. Building without Arrow Parquet.")
             endif ()
+            # If Arrow Parquet is not found, exit this function
             return()
         endif ()
     endif ()
@@ -203,16 +210,18 @@ function(find_or_install_arrow_parquet)
     endif ()
 
     if (NOT Arrow_FOUND OR NOT Parquet_FOUND)
-        install_pyarrow_in_venv()
-        if (PIP_PYARROW_ROOT)
-            find_pip_installed_pyarrow()
+        if (YGM_INSTALL_PARQUET)
+            install_pyarrow_in_venv()
+            if (PIP_PYARROW_ROOT)
+                find_pip_installed_pyarrow()
+            endif ()
         endif ()
     endif ()
 
     if (NOT Arrow_FOUND OR NOT Parquet_FOUND)
-        message(STATUS "${PROJECT_NAME} could not find Arrow Parquet.")
+        message(STATUS "${PROJECT_NAME} could not find or install Arrow Parquet.")
         message(STATUS "If this is an unexpected result, try the following command to install pyarrow: export Python3_ROOT_DIR=/path/to/python3; /path/to/python3 -m pip pyarrow")
-        if (YGM_REQUIRE_ARROW_PARQUET)
+        if (YGM_REQUIRE_PARQUET)
             message(FATAL_ERROR "${PROJECT_NAME} requires Arrow Parquet.")
         else ()
             message(WARNING "${PROJECT_NAME} keep the build process without Arrow Parquet.")

--- a/examples/io/parquet_stream_reader_json.cpp
+++ b/examples/io/parquet_stream_reader_json.cpp
@@ -19,7 +19,7 @@
 
 #include <ygm/comm.hpp>
 #include <ygm/detail/cereal_boost_json.hpp>
-#include <ygm/io/detail/parquet2json.hpp>
+#include <ygm/io/parquet2json.hpp>
 
 int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
@@ -42,8 +42,7 @@ int main(int argc, char** argv) {
   const auto& schema = parquetp.schema();
   parquetp.for_all([&schema, &world](auto& stream_reader, const auto&) {
     // obj's type is boost::json::object
-    const auto obj =
-        ygm::io::detail::read_parquet_as_json(stream_reader, schema);
+    const auto obj = ygm::io::read_parquet_as_json(stream_reader, schema);
 
     world.async(
         0, [](auto, const auto& obj) { std::cout << obj << std::endl; }, obj);

--- a/examples/io/parquet_stream_reader_variant.cpp
+++ b/examples/io/parquet_stream_reader_variant.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
 
   world.cout0()
-      << "Arrow Parquet file parser example (reads data as JSON objects)"
+      << "Arrow Parquet file parser example (reads data as std::variant objects)"
       << std::endl;
 
   // assuming the build directory is inside the YGM root directory

--- a/examples/io/parquet_stream_reader_variant.cpp
+++ b/examples/io/parquet_stream_reader_variant.cpp
@@ -17,14 +17,14 @@
 #include <vector>
 
 #include <ygm/comm.hpp>
-#include <ygm/io/detail/parquet2variant.hpp>
+#include <ygm/io/parquet2variant.hpp>
 
 int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
 
-  world.cout0()
-      << "Arrow Parquet file parser example (reads data as std::variant objects)"
-      << std::endl;
+  world.cout0() << "Arrow Parquet file parser example (reads data as "
+                   "std::variant objects)"
+                << std::endl;
 
   // assuming the build directory is inside the YGM root directory
   std::string dir_name = "../test/data/parquet_files_json/";
@@ -52,8 +52,8 @@ int main(int argc, char** argv) {
   std::size_t num_invalids = 0;
   parquetp.for_all([&schema, &num_valids, &num_invalids, &num_rows](
                        auto& stream_reader, const auto&) {
-    const std::vector<ygm::io::detail::parquet_type_variant> row =
-        ygm::io::detail::read_parquet_as_variant(stream_reader, schema);
+    const std::vector<ygm::io::parquet_type_variant> row =
+        ygm::io::read_parquet_as_variant(stream_reader, schema);
     ++num_rows;
     for (const auto& field : row) {
       if (std::holds_alternative<std::monostate>(field)) {

--- a/examples/io/parquet_stream_reader_variant.cpp
+++ b/examples/io/parquet_stream_reader_variant.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
   // Print column name
   world.cout0() << "Column names:" << std::endl;
   for (size_t i = 0; i < schema.size(); ++i) {
-    world.cout0() << std::get<1>(schema[i]);
+    world.cout0() << "[" << std::get<1>(schema[i]) << "]";
     if (i < schema.size() - 1) {
       world.cout0() << "\t";
     }

--- a/include/ygm/io/parquet2json.hpp
+++ b/include/ygm/io/parquet2json.hpp
@@ -94,6 +94,12 @@ inline boost::json::object read_parquet_as_json_helper(
     if (!read_all &&
         std::find(std::begin(include_columns), std::end(include_columns),
                   colum_name) == std::end(include_columns)) {
+      reader.SkipColumns(1);
+      continue;
+    }
+    if (data_type.unsupported) {
+      // Skip unsupported columns instead of throwing an exception
+      reader.SkipColumns(1);
       continue;
     }
     object[colum_name] = read_parquet_element_as_json_value(data_type, reader);

--- a/include/ygm/io/parquet2json.hpp
+++ b/include/ygm/io/parquet2json.hpp
@@ -24,6 +24,8 @@
 #include <ygm/io/parquet_parser.hpp>
 
 namespace ygm::io {
+
+namespace detail {
 inline boost::json::value read_parquet_element_as_json_value(
     const ygm::io::detail::parquet_data_type& type_holder,
     parquet_parser::parquet_stream_reader&    stream) {
@@ -100,6 +102,7 @@ inline boost::json::object read_parquet_as_json_helper(
   reader.EndRow();
   return object;
 }
+}  // namespace detail
 
 /**
  * @brief Reads a row data from a Parquet StreamReader and returns the read row
@@ -110,7 +113,7 @@ inline boost::json::object read_parquet_as_json_helper(
 inline boost::json::object read_parquet_as_json(
     parquet_parser::parquet_stream_reader&       reader,
     const parquet_parser::file_schema_container& schema) {
-  return read_parquet_as_json_helper<std::unordered_set<std::string>>(
+  return detail::read_parquet_as_json_helper<std::unordered_set<std::string>>(
       reader, schema, true);
 }
 
@@ -123,6 +126,7 @@ inline boost::json::object read_parquet_as_json(
     parquet_parser::parquet_stream_reader&       reader,
     const parquet_parser::file_schema_container& schema,
     const key_container&                         include_columns) {
-  return read_parquet_as_json_helper(reader, schema, false, include_columns);
+  return detail::read_parquet_as_json_helper(reader, schema, false,
+                                             include_columns);
 }
 }  // namespace ygm::io

--- a/include/ygm/io/parquet2json.hpp
+++ b/include/ygm/io/parquet2json.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other YGM
+// Copyright 2019-2025 Lawrence Livermore National Security, LLC and other YGM
 // Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: MIT
@@ -23,10 +23,10 @@
 
 #include <ygm/io/parquet_parser.hpp>
 
-namespace ygm::io::detail {
+namespace ygm::io {
 inline boost::json::value read_parquet_element_as_json_value(
-    const ygm::io::parquet_data_type&            type_holder,
-    parquet_parser::parquet_stream_reader& stream) {
+    const ygm::io::detail::parquet_data_type& type_holder,
+    parquet_parser::parquet_stream_reader&    stream) {
   boost::json::value out_value;
   out_value.emplace_null();
 
@@ -83,8 +83,7 @@ inline boost::json::value read_parquet_element_as_json_value(
 template <typename key_container>
 inline boost::json::object read_parquet_as_json_helper(
     parquet_parser::parquet_stream_reader&       reader,
-    const parquet_parser::file_schema_container& schema,
-    const bool                                         read_all,
+    const parquet_parser::file_schema_container& schema, const bool read_all,
     const key_container& include_columns = key_container()) {
   boost::json::object object;
   for (size_t i = 0; i < schema.size(); ++i) {
@@ -123,7 +122,7 @@ template <typename key_container>
 inline boost::json::object read_parquet_as_json(
     parquet_parser::parquet_stream_reader&       reader,
     const parquet_parser::file_schema_container& schema,
-    const key_container&                               include_columns) {
+    const key_container&                         include_columns) {
   return read_parquet_as_json_helper(reader, schema, false, include_columns);
 }
-}  // namespace ygm::io::detail
+}  // namespace ygm::io

--- a/include/ygm/io/parquet2variant.hpp
+++ b/include/ygm/io/parquet2variant.hpp
@@ -23,6 +23,7 @@ namespace ygm::io {
 using parquet_type_variant = std::variant<std::monostate, bool, int32_t,
                                           int64_t, float, double, std::string>;
 
+namespace detail {
 inline parquet_type_variant read_parquet_element_as_variant(
     const ygm::io::detail::parquet_data_type& type_holder,
     parquet_parser::parquet_stream_reader&    stream) {
@@ -96,6 +97,7 @@ inline std::vector<parquet_type_variant> read_parquet_as_variant_helper(
   reader.EndRow();
   return row;
 }
+}  // namespace detail
 
 /**
  * @brief Reads a row data from a Parquet StreamReader and returns the read row
@@ -106,7 +108,7 @@ inline std::vector<parquet_type_variant> read_parquet_as_variant_helper(
 inline std::vector<parquet_type_variant> read_parquet_as_variant(
     parquet_parser::parquet_stream_reader&       reader,
     const parquet_parser::file_schema_container& schema) {
-  return read_parquet_as_variant_helper(reader, schema);
+  return detail::read_parquet_as_variant_helper(reader, schema);
 }
 
 /**
@@ -117,6 +119,6 @@ inline std::vector<parquet_type_variant> read_parquet_as_variant(
     parquet_parser::parquet_stream_reader&       reader,
     const parquet_parser::file_schema_container& schema,
     const std::unordered_set<std::string>&       include_columns) {
-  return read_parquet_as_variant_helper(reader, schema, include_columns);
+  return detail::read_parquet_as_variant_helper(reader, schema, include_columns);
 }
 }  // namespace ygm::io

--- a/include/ygm/io/parquet2variant.hpp
+++ b/include/ygm/io/parquet2variant.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other YGM
+// Copyright 2019-2025 Lawrence Livermore National Security, LLC and other YGM
 // Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: MIT
@@ -18,14 +18,14 @@
 
 #include <ygm/io/parquet_parser.hpp>
 
-namespace ygm::io::detail {
+namespace ygm::io {
 
 using parquet_type_variant = std::variant<std::monostate, bool, int32_t,
                                           int64_t, float, double, std::string>;
 
 inline parquet_type_variant read_parquet_element_as_variant(
-    const ygm::io::parquet_data_type&            type_holder,
-    parquet_parser::parquet_stream_reader& stream) {
+    const ygm::io::detail::parquet_data_type& type_holder,
+    parquet_parser::parquet_stream_reader&    stream) {
   parquet_type_variant out_value = std::monostate{};
 
   // Note: there is no uint types in Parquet
@@ -77,8 +77,8 @@ inline parquet_type_variant read_parquet_element_as_variant(
 }
 
 inline std::vector<parquet_type_variant> read_parquet_as_variant_helper(
-    parquet_parser::parquet_stream_reader&          reader,
-    const parquet_parser::file_schema_container&    schema,
+    parquet_parser::parquet_stream_reader&                reader,
+    const parquet_parser::file_schema_container&          schema,
     const std::optional<std::unordered_set<std::string>>& include_columns =
         std::nullopt) {
   std::vector<parquet_type_variant> row;
@@ -116,7 +116,7 @@ inline std::vector<parquet_type_variant> read_parquet_as_variant(
 inline std::vector<parquet_type_variant> read_parquet_as_variant(
     parquet_parser::parquet_stream_reader&       reader,
     const parquet_parser::file_schema_container& schema,
-    const std::unordered_set<std::string>&             include_columns) {
+    const std::unordered_set<std::string>&       include_columns) {
   return read_parquet_as_variant_helper(reader, schema, include_columns);
 }
-}  // namespace ygm::io::detail
+}  // namespace ygm::io

--- a/include/ygm/io/parquet2variant.hpp
+++ b/include/ygm/io/parquet2variant.hpp
@@ -89,6 +89,12 @@ inline std::vector<parquet_type_variant> read_parquet_as_variant_helper(
     if (include_columns &&
         std::find(std::begin(*include_columns), std::end(*include_columns),
                   colum_name) == std::end(*include_columns)) {
+      reader.SkipColumns(1);
+      continue;
+    }
+    if (data_type.unsupported) {
+      // Skip unsupported columns instead of throwing an exception
+      reader.SkipColumns(1);
       continue;
     }
     row.emplace_back(read_parquet_element_as_variant(data_type, reader));

--- a/include/ygm/io/parquet_parser.hpp
+++ b/include/ygm/io/parquet_parser.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other YGM
+// Copyright 2019-2025 Lawrence Livermore National Security, LLC and other YGM
 // Project Developers. See the top-level COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: MIT
@@ -30,6 +30,7 @@ namespace stdfs = std::filesystem;
 
 namespace ygm::io {
 
+namespace detail {
 struct parquet_data_type {
   parquet::Type::type type;
 
@@ -44,6 +45,7 @@ std::ostream& operator<<(std::ostream& os, const parquet_data_type& t) {
   os << parquet::TypeToString(t.type);
   return os;
 }
+}  // namespace detail
 
 // Parquet file parser
 // Only supports the plain encoding.
@@ -53,7 +55,7 @@ class parquet_parser {
   using self_type = parquet_parser;
   // 0: a column type, 1: column name
   using file_schema_container =
-      std::vector<std::tuple<parquet_data_type, std::string>>;
+      std::vector<std::tuple<detail::parquet_data_type, std::string>>;
   using parquet_stream_reader = parquet::StreamReader;
 
   parquet_parser(ygm::comm& _comm) : m_comm(_comm), pthis(this) {
@@ -262,7 +264,7 @@ class parquet_parser {
     for (size_t i = 0; i < field_count; ++i) {
       parquet::ColumnDescriptor const* const column = file_schema->Column(i);
       m_schema.emplace_back(std::forward_as_tuple(
-          parquet_data_type{column->physical_type()}, column->name()));
+          detail::parquet_data_type{column->physical_type()}, column->name()));
     }
     m_schema_string = file_schema->ToString();
   }

--- a/include/ygm/io/parquet_parser.hpp
+++ b/include/ygm/io/parquet_parser.hpp
@@ -32,7 +32,10 @@ namespace ygm::io {
 
 namespace detail {
 struct parquet_data_type {
-  parquet::Type::type type;
+  parquet::Type::type type{parquet::Type::type::UNDEFINED};
+
+  // If true, the data type is not supported by this parser.
+  bool unsupported{false};
 
   bool equal(const parquet::Type::type other_type) const {
     return other_type == type;
@@ -122,9 +125,12 @@ class parquet_parser {
       const stdfs::path& input_filename) {
     // Open the Parquet file
     std::shared_ptr<arrow::io::ReadableFile> input_file;
-    PARQUET_ASSIGN_OR_THROW(input_file,
-                            arrow::io::ReadableFile::Open(input_filename));
-
+    try {
+      PARQUET_ASSIGN_OR_THROW(input_file,
+                              arrow::io::ReadableFile::Open(input_filename));
+    } catch (...) {
+      return nullptr;
+    }
     // Create a ParquetFileReader object
     return parquet::ParquetFileReader::Open(input_file);
   }
@@ -227,7 +233,6 @@ class parquet_parser {
   template <typename Function>
   void read_files(Function fn) {
     m_comm.barrier();
-
     if (ARROW_VERSION_MAJOR < 14) {
       // Due to a bug in parquet::StreamReader::SkipRows() in < v14,
       // we can not read a single file using multiple ranks.
@@ -238,12 +243,10 @@ class parquet_parser {
       }
     } else {
       assign_read_range();
-
       // If n is 0, fno and offset could contain invalid values
       ssize_t n      = ssize_t(m_read_range.num_rows);
       size_t  fno    = m_read_range.begin_file_no;
       size_t  offset = m_read_range.begin_row_offset;
-
       while (n > 0) {
         n -= read_parquet_stream(m_paths[fno], fn, offset, n);
         assert(n >= 0);
@@ -255,6 +258,10 @@ class parquet_parser {
 
   void read_file_schema() {
     auto reader = open_file(m_paths[0]);
+    if (reader == nullptr) {
+      throw std::runtime_error("Failed to open the file: " +
+                               m_paths[0].string());
+    }
 
     // Get the file schema
     parquet::SchemaDescriptor const* const file_schema =
@@ -263,8 +270,15 @@ class parquet_parser {
     const size_t field_count = file_schema->num_columns();
     for (size_t i = 0; i < field_count; ++i) {
       parquet::ColumnDescriptor const* const column = file_schema->Column(i);
-      m_schema.emplace_back(std::forward_as_tuple(
-          detail::parquet_data_type{column->physical_type()}, column->name()));
+      auto ptype = detail::parquet_data_type{column->physical_type()};
+      if (column->max_definition_level() != 1 ||
+          column->max_repetition_level() != 0) {
+        // The column is not flat, which is not supported by this parser.
+        ptype.unsupported = true;
+        // Memo: for definition and repetition levels, see
+        // https://blog.x.com/engineering/en_us/a/2013/dremel-made-simple-with-parquet
+      }
+      m_schema.emplace_back(std::forward_as_tuple(ptype, column->name()));
     }
     m_schema_string = file_schema->ToString();
   }
@@ -278,9 +292,12 @@ class parquet_parser {
   size_t read_parquet_stream(const stdfs::path& input_filename, Function fn,
                              const size_t  offset           = 0,
                              const ssize_t num_rows_to_read = -1) {
-    auto                  reader = open_file(input_filename);
+    auto reader = open_file(input_filename);
+    if (reader == nullptr) {
+      throw std::runtime_error("Failed to open the file: " +
+                               input_filename.string());
+    }
     parquet_stream_reader stream{std::move(reader)};
-
     if (offset > 0) {
       // SkipRows() has a bug in < v14
       assert(ARROW_VERSION_MAJOR >= 14);
@@ -311,7 +328,7 @@ class parquet_parser {
 
       const size_t total_num_rows =
           std::accumulate(num_rows.begin(), num_rows.end(), size_t(0));
-      // std::cout << total_num_rows << std::endl; //DB
+      // std::cerr << total_num_rows << std::endl; //DB
 
       size_t file_no           = 0;
       size_t row_no_offset     = 0;

--- a/test/test_parquet_reader_json.cpp
+++ b/test/test_parquet_reader_json.cpp
@@ -8,7 +8,7 @@
 #include <filesystem>
 #include <ygm/comm.hpp>
 #include <ygm/detail/cereal_boost_json.hpp>
-#include <ygm/io/detail/parquet2json.hpp>
+#include <ygm/io/parquet2json.hpp>
 #include <ygm/io/parquet_parser.hpp>
 
 int main(int argc, char** argv) {
@@ -22,12 +22,12 @@ int main(int argc, char** argv) {
   static size_t cnt2 = 0;
   static size_t cnt3 = 0;
 
-  // Test if ygm::io::detail::read_parquet_as_json can read all supported data
+  // Test if ygm::io::read_parquet_as_json can read all supported data
   // types correctly
   const auto& schema = parquetp.schema();
   parquetp.for_all([&schema, &world](auto& stream_reader, const auto&) {
     const auto obj =
-        ygm::io::detail::read_parquet_as_json(stream_reader, schema);
+        ygm::io::read_parquet_as_json(stream_reader, schema);
 
     world.async(
         0,

--- a/tools/parquet_tools.cpp
+++ b/tools/parquet_tools.cpp
@@ -16,8 +16,8 @@
 
 #include <ygm/comm.hpp>
 #include <ygm/io/csv_parser.hpp>
-#include <ygm/io/detail/parquet2json.hpp>
-#include <ygm/io/detail/parquet2variant.hpp>
+#include <ygm/io/parquet2json.hpp>
+#include <ygm/io/parquet2variant.hpp>
 #include <ygm/io/parquet_parser.hpp>
 #include <ygm/utility.hpp>
 
@@ -207,13 +207,13 @@ void count_rows(const options_t& opt, ygm::comm& world) {
                          auto& stream_reader, const auto&) {
       if (opt.variant) {
         try {
-          ygm::io::detail::read_parquet_as_variant(stream_reader, schema);
+          ygm::io::read_parquet_as_variant(stream_reader, schema);
         } catch (...) {
           ++num_error_lines;
         }
       } else if (opt.json) {
         try {
-          ygm::io::detail::read_parquet_as_json(stream_reader, schema);
+          ygm::io::read_parquet_as_json(stream_reader, schema);
         } catch (...) {
           ++num_error_lines;
         }
@@ -264,15 +264,13 @@ void dump(const options_t& opt, ygm::comm& world) {
                        auto& stream_reader, const auto&) {
     if (opt.json) {
       try {
-        const auto row =
-            ygm::io::detail::read_parquet_as_json(stream_reader, schema);
+        const auto row = ygm::io::read_parquet_as_json(stream_reader, schema);
         ofs << row << std::endl;
       } catch (...) {
         ++num_error_lines;
       }
     } else {
-      auto row =
-          ygm::io::detail::read_parquet_as_variant(stream_reader, schema);
+      auto row = ygm::io::read_parquet_as_variant(stream_reader, schema);
       for (const auto& v : row) {
         std::visit(
             [&ofs](auto&& arg) {


### PR DESCRIPTION
Code brush up on Parquet Reader.

Major changes are:

- Set CMake option `YGM_INSTALL_PARQUET` to ON to install Parquet when it is not found.

- Change option name: `YGM_REQUIRE_ARROW_PARQUET` -> `YGM_REQUIRE_PARQUET`