### PR TITLE
Feature/async union and execute api

### DIFF
--- a/examples/container/disjoint_set_async_union_and_execute.cpp
+++ b/examples/container/disjoint_set_async_union_and_execute.cpp
@@ -13,9 +13,12 @@ int main(int argc, char **argv) {
 
   ygm::container::disjoint_set<int> dset(world);
 
-  auto union_lambda = [](const int a, const int b, const int originator) {
-    std::cout << a << " and " << b << " union occurred originating from "
-              << originator << std::endl;
+  auto union_lambda = [](const int a, const int b, const bool union_result,
+                         const int originator) {
+    if (union_result) {
+      std::cout << a << " and " << b << " union occurred originating from "
+                << originator << std::endl;
+    }
   };
 
   if (world.rank() % 2) {

--- a/examples/container/disjoint_set_spanning_tree.cpp
+++ b/examples/container/disjoint_set_spanning_tree.cpp
@@ -23,8 +23,11 @@ int main(int argc, char **argv) {
 
   ygm::container::disjoint_set<int> dset(world);
 
-  auto add_spanning_tree_edges_lambda = [](const int u, const int v) {
-    local_spanning_tree_edges.push_back(std::make_pair(u, v));
+  auto add_spanning_tree_edges_lambda = [](const int u, const int v,
+                                           const bool union_result) {
+    if (union_result) {
+      local_spanning_tree_edges.push_back(std::make_pair(u, v));
+    }
   };
 
   for (const auto &[u, v] : graph_edges) {

--- a/test/test_disjoint_set.cpp
+++ b/test/test_disjoint_set.cpp
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
           if (union_result) {
             successful_counter++;
           } else {
-            ++unsuccessful_counter;
+            unsuccessful_counter++;
           }
         });
     dset.async_union_and_execute(
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
           if (union_result) {
             successful_counter++;
           } else {
-            ++unsuccessful_counter;
+            unsuccessful_counter++;
           }
         });
     dset.async_union_and_execute(
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
           if (union_result) {
             successful_counter++;
           } else {
-            ++unsuccessful_counter;
+            unsuccessful_counter++;
           }
         });
     dset.async_union_and_execute(
@@ -245,7 +245,7 @@ int main(int argc, char** argv) {
           if (union_result) {
             successful_counter++;
           } else {
-            ++unsuccessful_counter;
+            unsuccessful_counter++;
           }
         },
         0);
@@ -253,6 +253,7 @@ int main(int argc, char** argv) {
     world.barrier();
 
     YGM_ASSERT_RELEASE(ygm::sum(successful_counter, world) == 3);
-    YGM_ASSERT_RELEASE(ygm::sum(unsuccessful_counter, world) == 1);
+    YGM_ASSERT_RELEASE(ygm::sum(unsuccessful_counter, world) ==
+                       world.size() * 4 - 3);
   }
 }


### PR DESCRIPTION
This PR adds a 3rd required argument to the `ygm::container::disjoint_set::async_union_and_execute` lambda signature that is a boolean denoting whether the union was successful or not. With this change, user lambdas are executed at the end of all unions that are started, not just the successful ones.