### PR TITLE
Adding back in documentation generation to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,16 @@ if (JUST_INSTALL_YGM_HEADERS)
   return()
 endif ()
 
+#
+# Doxygen and Read the Docs (RTD) Documentation
+#
+if (YGM_DOXYGEN OR YGM_RTD_ONLY)
+    add_subdirectory(docs)
+    if (YGM_RTD_ONLY)
+        return()
+    endif ()
+endif ()
+
 # Require out-of-source builds
 file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
 if (EXISTS "${LOC_PATH}")


### PR DESCRIPTION
Recent changes to CMake accidentally removed the checks to allow ReadTheDocs to build our documentation successfully. This adds those necessary changes back in.