### PR TITLE
Logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,19 @@ if (NOT boost_POPULATED)
 endif ()
 
 #
+# spdlog
+#
+if (NOT spdlog_POPULATED)
+    set(SPDLOG_INSTALL On)
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog
+        GIT_TAG v1.15.1
+    )
+    FetchContent_MakeAvailable(spdlog)
+endif ()
+
+#
 # Arrow
 #
 include(FindArrowParquet)
@@ -119,7 +132,7 @@ target_include_directories(
 target_link_libraries(
     ygm
     PUBLIC
-    INTERFACE MPI::MPI_CXX Threads::Threads stdc++fs cereal
+    INTERFACE MPI::MPI_CXX Threads::Threads stdc++fs cereal spdlog_header_only
 )
 if (UNIX AND NOT APPLE)
     target_link_libraries(

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -197,7 +197,6 @@ class comm {
   template <typename StringType>
   void set_log_location(const StringType &s);
 
-  template <>
   void set_log_location(const std::filesystem::path &p);
 
   // Private member functions

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -194,8 +194,11 @@ class comm {
   void enable_comm_logging() { m_comm_logging_enabled = true; }
   void disable_comm_logging() { m_comm_logging_enabled = false; }
 
+  template <typename StringType>
+  void set_log_location(const StringType &s);
+
+  template <>
   void set_log_location(const std::filesystem::path &p);
-  void set_log_location(const std::string &s);
 
   // Private member functions
  private:

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -197,7 +197,7 @@ class comm {
   template <typename StringType>
   void set_log_location(const StringType &s);
 
-  void set_log_location(const std::filesystem::path &p);
+  void set_log_location(std::filesystem::path p);
 
   // Private member functions
  private:

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -181,18 +181,14 @@ class comm {
   template <typename... Args>
   void cerr0(Args &&...args) const;
 
-  template <typename... Args>
-  void log(Args &&...args) const {
-    if (m_logging_enabled) {
-      m_logger.log(args...);
-    }
+  void set_log_level(const ygm::log_level level) {
+    m_logger.set_log_level(level);
   }
 
-  void enable_logging() { m_logging_enabled = true; }
-  void disable_logging() { m_logging_enabled = false; }
-
-  void enable_comm_logging() { m_comm_logging_enabled = true; }
-  void disable_comm_logging() { m_comm_logging_enabled = false; }
+  template <typename... Args>
+  void log(const ygm::log_level level, Args &&...args) const {
+    m_logger.log(level, args...);
+  }
 
   template <typename StringType>
   void set_log_location(const StringType &s);
@@ -249,13 +245,6 @@ class comm {
   template <typename... Args>
   std::string outstr0(Args &&...args) const;
 
-  template <typename... Args>
-  void comm_log(Args &&...args) const {
-    if (m_comm_logging_enabled) {
-      m_logger.log(args...);
-    }
-  }
-
   comm() = delete;
 
   comm(const comm &c) = delete;
@@ -295,8 +284,6 @@ class comm {
   const detail::comm_environment config = detail::comm_environment(m_layout);
   detail::comm_router            m_router;
 
-  bool           m_logging_enabled      = true;
-  bool           m_comm_logging_enabled = false;
   detail::logger m_logger;
 
   detail::lambda_map<void (*)(comm *, cereal::YGMInputArchive *), uint16_t>

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -17,6 +17,7 @@
 #include <ygm/detail/comm_stats.hpp>
 #include <ygm/detail/lambda_map.hpp>
 #include <ygm/detail/layout.hpp>
+#include <ygm/detail/logger.hpp>
 #include <ygm/detail/meta/functional.hpp>
 #include <ygm/detail/mpi.hpp>
 #include <ygm/detail/ygm_cereal_archive.hpp>
@@ -180,6 +181,22 @@ class comm {
   template <typename... Args>
   void cerr0(Args &&...args) const;
 
+  template <typename... Args>
+  void log(Args &&...args) const {
+    if (m_logging_enabled) {
+      m_logger.log(args...);
+    }
+  }
+
+  void enable_logging() { m_logging_enabled = true; }
+  void disable_logging() { m_logging_enabled = false; }
+
+  void enable_comm_logging() { m_comm_logging_enabled = true; }
+  void disable_comm_logging() { m_comm_logging_enabled = false; }
+
+  void set_log_location(const std::filesystem::path &p);
+  void set_log_location(const std::string &s);
+
   // Private member functions
  private:
   void comm_setup(MPI_Comm comm);
@@ -190,7 +207,7 @@ class comm {
   std::pair<uint64_t, uint64_t> barrier_reduce_counts();
 
   void flush_next_send(std::deque<int> &dest_queue);
-  
+
   void flush_send_buffer(int dest);
 
   void handle_completed_send(mpi_isend_request &req_buffer);
@@ -216,11 +233,11 @@ class comm {
   size_t pack_lambda_generic(ygm::detail::byte_vector &packed, Lambda l,
                              RemoteLogicLambda rll, const PackArgs &...args);
 
-  void queue_message_bytes(const ygm::detail::byte_vector             &packed,
-                           const int                     dest);
+  void queue_message_bytes(const ygm::detail::byte_vector &packed,
+                           const int                       dest);
 
   void handle_next_receive(std::shared_ptr<ygm::detail::byte_vector> &buffer,
-                           const size_t                 buffer_size);
+                           const size_t buffer_size, const uint32_t from_rank);
 
   bool process_receive_queue();
 
@@ -229,6 +246,13 @@ class comm {
 
   template <typename... Args>
   std::string outstr0(Args &&...args) const;
+
+  template <typename... Args>
+  void comm_log(Args &&...args) const {
+    if (m_comm_logging_enabled) {
+      m_logger.log(args...);
+    }
+  }
 
   comm() = delete;
 
@@ -244,13 +268,13 @@ class comm {
 
   std::vector<ygm::detail::byte_vector> m_vec_send_buffers;
 
-  size_t                              m_send_local_buffer_bytes = 0;
-  std::deque<int>                     m_send_local_dest_queue;
-  size_t                              m_send_remote_buffer_bytes = 0;
-  std::deque<int>                     m_send_remote_dest_queue;
+  size_t          m_send_local_buffer_bytes = 0;
+  std::deque<int> m_send_local_dest_queue;
+  size_t          m_send_remote_buffer_bytes = 0;
+  std::deque<int> m_send_remote_dest_queue;
 
-  std::deque<mpi_irecv_request>                        m_recv_queue;
-  std::deque<mpi_isend_request>                        m_send_queue;
+  std::deque<mpi_irecv_request>                          m_recv_queue;
+  std::deque<mpi_isend_request>                          m_send_queue;
   std::vector<std::shared_ptr<ygm::detail::byte_vector>> m_free_send_buffers;
 
   size_t m_pending_isend_bytes = 0;
@@ -268,6 +292,10 @@ class comm {
   const detail::layout           m_layout;
   const detail::comm_environment config = detail::comm_environment(m_layout);
   detail::comm_router            m_router;
+
+  bool           m_logging_enabled      = true;
+  bool           m_comm_logging_enabled = false;
+  detail::logger m_logger;
 
   detail::lambda_map<void (*)(comm *, cereal::YGMInputArchive *), uint16_t>
       m_lambda_map;

--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -57,6 +57,7 @@ class array
         m_global_size(size),
         m_default_value{},
         partitioner(comm, size) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     resize(size);
@@ -68,6 +69,7 @@ class array
         m_global_size(size),
         m_default_value(default_value),
         partitioner(comm, size) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     resize(size);
@@ -80,6 +82,7 @@ class array
         m_default_value{},
         partitioner(comm, l.size()) {
     m_comm.cout0("initializer_list assumes all ranks are equal");
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     resize(l.size());
@@ -97,6 +100,7 @@ class array
         std::initializer_list<std::tuple<key_type, mapped_type>> l)
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.cout0("initializer_list assumes all ranks are equal");
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     key_type max_index{0};
@@ -124,6 +128,7 @@ class array
         m_default_value(rhs.m_default_value),
         m_local_vec(rhs.m_local_vec),
         partitioner(rhs.m_comm, rhs.m_global_size) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
     resize(m_global_size);
   }
@@ -134,6 +139,7 @@ class array
                  detail::SingleItemTuple<typename T::for_all_args> &&
                  std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     resize(t.size());
@@ -162,6 +168,7 @@ class array
                          1, std::tuple_element_t<0, typename T::for_all_args>>,
                      mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     key_type max_index{0};
@@ -191,6 +198,7 @@ class array
                      std::tuple_element_t<0, typename T::for_all_args>,
                      mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     key_type max_index{0};
@@ -215,6 +223,7 @@ class array
                  (not detail::SingleItemTuple<typename T::value_type>) &&
                  std::convertible_to<typename T::value_type, mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     auto global_size = sum(t.size(), m_comm);
@@ -241,6 +250,7 @@ class array
                      std::tuple_element_t<1, typename T::value_type>,
                      mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
     key_type max_index{0};
@@ -257,7 +267,10 @@ class array
     });
   }
 
-  ~array() { m_comm.barrier(); }
+  ~array() {
+    m_comm.barrier();
+    m_comm.log(log_level::info, "Destroying ygm::container::array");
+  }
 
   void local_insert(const key_type& key, const mapped_type& value) {
     m_local_vec[partitioner.local_index(key)] = value;

--- a/include/ygm/container/bag.hpp
+++ b/include/ygm/container/bag.hpp
@@ -32,11 +32,13 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   using container_type = ygm::container::bag_tag;
 
   bag(ygm::comm &comm) : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
   }
 
   bag(ygm::comm &comm, std::initializer_list<Item> l)
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
       for (const Item &i : l) {
@@ -47,10 +49,11 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   }
 
   template <typename STLContainer>
-  bag(ygm::comm          &comm,
-      const STLContainer &cont) requires detail::STLContainer<STLContainer> &&
-      std::convertible_to<typename STLContainer::value_type, Item>
+  bag(ygm::comm &comm, const STLContainer &cont)
+    requires detail::STLContainer<STLContainer> &&
+                 std::convertible_to<typename STLContainer::value_type, Item>
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
 
     for (const Item &i : cont) {
@@ -60,10 +63,11 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   }
 
   template <typename YGMContainer>
-  bag(ygm::comm          &comm,
-      const YGMContainer &yc) requires detail::HasForAll<YGMContainer> &&
-      detail::SingleItemTuple<typename YGMContainer::for_all_args>
+  bag(ygm::comm &comm, const YGMContainer &yc)
+    requires detail::HasForAll<YGMContainer> &&
+                 detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
 
     yc.for_all([this](const Item &value) { this->async_insert(value); });
@@ -71,10 +75,14 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
     m_comm.barrier();
   }
 
-  ~bag() { m_comm.barrier(); }
+  ~bag() {
+    m_comm.log(log_level::info, "Destroying ygm::container::bag");
+    m_comm.barrier();
+  }
 
   bag(const self_type &other)  // If I remove const it compiles
       : m_comm(other.comm()), pthis(this), partitioner(other.comm()) {
+    m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
   }
 
@@ -83,6 +91,7 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
         pthis(this),
         partitioner(other.comm()),
         m_local_bag(std::move(other.m_local_bag)) {
+    m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
   }
 

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -131,10 +131,14 @@ class disjoint_set_impl {
 
   disjoint_set_impl(ygm::comm &comm, const size_t cache_size)
       : m_comm(comm), pthis(this), m_cache(cache_size) {
+    m_comm.log(log_level::info, "Creating ygm::container::disjoint_set");
     pthis.check(m_comm);
   }
 
-  ~disjoint_set_impl() { m_comm.barrier(); }
+  ~disjoint_set_impl() {
+    m_comm.log(log_level::info, "Destroying ygm::container::disjoint_set");
+    m_comm.barrier();
+  }
 
   typename ygm::ygm_ptr<self_type> get_ygm_ptr() const { return pthis; }
 

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -54,6 +54,7 @@ class map
 
   map(ygm::comm& comm)
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
   }
 
@@ -62,11 +63,13 @@ class map
         pthis(this),
         partitioner(comm),
         m_default_value(default_value) {
+    m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
   }
 
   map(ygm::comm& comm, std::initializer_list<std::pair<Key, Value>> l)
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
       for (const std::pair<Key, Value>& i : l) {
@@ -81,6 +84,7 @@ class map
                  std::convertible_to<typename STLContainer::value_type,
                                      std::pair<Key, Value>>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
 
     for (const std::pair<Key, Value>& i : cont) {
@@ -94,6 +98,7 @@ class map
     requires detail::HasForAll<YGMContainer> &&
                  detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
 
     yc.for_all([this](const std::pair<Key, Value>& value) {
@@ -103,7 +108,10 @@ class map
     m_comm.barrier();
   }
 
-  ~map() { m_comm.barrier(); }
+  ~map() {
+    m_comm.log(log_level::info, "Destroying ygm::container::map");
+    m_comm.barrier();
+  }
 
   using detail::base_async_erase_key<map<Key, Value>,
                                      for_all_args>::async_erase;
@@ -380,6 +388,7 @@ class multimap
 
   multimap(ygm::comm& comm)
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
   }
 
@@ -388,11 +397,13 @@ class multimap
         pthis(this),
         partitioner(comm),
         m_default_value(default_value) {
+    m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
   }
 
   multimap(ygm::comm& comm, std::initializer_list<std::pair<Key, Value>> l)
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
       for (const std::pair<Key, Value>& i : l) {
@@ -407,6 +418,7 @@ class multimap
                  std::convertible_to<typename STLContainer::value_type,
                                      std::pair<Key, Value>>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
 
     for (const std::pair<Key, Value>& i : cont) {
@@ -420,6 +432,7 @@ class multimap
     requires detail::HasForAll<YGMContainer> &&
                  detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
+    m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
 
     yc.for_all([this](const std::pair<Key, Value>& value) {
@@ -429,7 +442,10 @@ class multimap
     m_comm.barrier();
   }
 
-  ~multimap() { m_comm.barrier(); }
+  ~multimap() {
+    m_comm.log(log_level::info, "Destroying ygm::container::multimap");
+    m_comm.barrier();
+  }
 
   void local_insert(const key_type& key) {
     if (m_local_map.count(key) == 0) {

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -42,6 +42,7 @@ class multiset
 
   multiset(ygm::comm &comm)
       : m_comm(comm), pthis(this), partitioner(comm, std::hash<value_type>()) {
+    m_comm.log(log_level::info, "Creating ygm::container::multiset");
     pthis.check(m_comm);
   }
 
@@ -49,6 +50,7 @@ class multiset
       : m_comm(other.comm()),
         pthis(this),
         partitioner(other.comm, other.partitioner) {
+    m_comm.log(log_level::info, "Creating ygm::container::multiset");
     pthis.check(m_comm);
   }
 
@@ -57,11 +59,13 @@ class multiset
         pthis(this),
         partitioner(other.partitioner),
         m_local_set(std::move(other.m_local_set)) {
+    m_comm.log(log_level::info, "Creating ygm::container::multiset");
     pthis.check(m_comm);
   }
 
   multiset(ygm::comm &comm, std::initializer_list<Value> l)
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::multiset");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
       for (const Value &i : l) {
@@ -73,10 +77,11 @@ class multiset
   }
 
   template <typename STLContainer>
-  multiset(ygm::comm &comm, const STLContainer &cont) requires
-      detail::STLContainer<STLContainer> &&
-      std::convertible_to<typename STLContainer::value_type, Value>
+  multiset(ygm::comm &comm, const STLContainer &cont)
+    requires detail::STLContainer<STLContainer> &&
+                 std::convertible_to<typename STLContainer::value_type, Value>
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::multiset");
     pthis.check(m_comm);
 
     for (const Value &i : cont) {
@@ -88,10 +93,13 @@ class multiset
 
   template <typename YGMContainer>
   multiset(ygm::comm          &comm,
-           const YGMContainer &yc) requires detail::HasForAll<YGMContainer> &&
-      detail::SingleItemTuple<typename YGMContainer::for_all_args>  //&&
+           const YGMContainer &yc)
+    requires detail::HasForAll<YGMContainer> &&
+                 detail::SingleItemTuple<
+                     typename YGMContainer::for_all_args>  //&&
       // std::same_as<typename TYGMContainer::for_all_args, std::tuple<Value>>
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::multiset");
     pthis.check(m_comm);
 
     yc.for_all([this](const Value &value) { this->async_insert(value); });
@@ -99,7 +107,10 @@ class multiset
     m_comm.barrier();
   }
 
-  ~multiset() { m_comm.barrier(); }
+  ~multiset() {
+    m_comm.log(log_level::info, "Destroying ygm::container::multiset");
+    m_comm.barrier();
+  }
 
   multiset() = delete;
 
@@ -169,6 +180,7 @@ class set
 
   set(ygm::comm &comm)
       : m_comm(comm), pthis(this), partitioner(comm, std::hash<value_type>()) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
   }
 
@@ -176,6 +188,7 @@ class set
       : m_comm(other.comm()),
         pthis(this),
         partitioner(other.comm, other.partitioner) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
   }
 
@@ -184,11 +197,13 @@ class set
         pthis(this),
         partitioner(other.partitioner),
         m_local_set(std::move(other.m_local_set)) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
   }
 
   set(ygm::comm &comm, std::initializer_list<Value> l)
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
       for (const Value &i : l) {
@@ -199,10 +214,11 @@ class set
   }
 
   template <typename STLContainer>
-  set(ygm::comm          &comm,
-      const STLContainer &cont) requires detail::STLContainer<STLContainer> &&
-      std::convertible_to<typename STLContainer::value_type, Value>
+  set(ygm::comm &comm, const STLContainer &cont)
+    requires detail::STLContainer<STLContainer> &&
+                 std::convertible_to<typename STLContainer::value_type, Value>
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
 
     for (const Value &i : cont) {
@@ -213,10 +229,13 @@ class set
 
   template <typename YGMContainer>
   set(ygm::comm          &comm,
-      const YGMContainer &yc) requires detail::HasForAll<YGMContainer> &&
-      detail::SingleItemTuple<typename YGMContainer::for_all_args>  //&&
+      const YGMContainer &yc)
+    requires detail::HasForAll<YGMContainer> &&
+                 detail::SingleItemTuple<
+                     typename YGMContainer::for_all_args>  //&&
       // std::same_as<typename TYGMContainer::for_all_args, std::tuple<Value>>
       : m_comm(comm), pthis(this), partitioner(comm) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
 
     yc.for_all([this](const Value &value) { this->async_insert(value); });
@@ -224,7 +243,10 @@ class set
     m_comm.barrier();
   }
 
-  ~set() { m_comm.barrier(); }
+  ~set() {
+    m_comm.log(log_level::info, "Destroying ygm::container::set");
+    m_comm.barrier();
+  }
 
   set() = delete;
 

--- a/include/ygm/container/tagged_bag.hpp
+++ b/include/ygm/container/tagged_bag.hpp
@@ -29,8 +29,14 @@ class tagged_bag {
   tagged_bag(ygm::comm &comm)
       : m_next_tag(tag_type(comm.rank()) << TAG_BITS),
         m_tagged_bag(ygm::container::map<tag_type, value_type>(comm)),
-        pthis(this) {}
-  ~tagged_bag() = default;
+        pthis(this) {
+    m_tagged_bag.comm().log(log_level::info,
+                            "Creating ygm::container::tagged_bag");
+  }
+  ~tagged_bag() {
+    m_tagged_bag.comm().log(log_level::info,
+                            "Creating ygm::container::tagged_bag");
+  }
 
   tag_type async_insert(const value_type &item) {
     tag_type tag = m_next_tag++;
@@ -103,7 +109,8 @@ class tagged_bag {
   //   return m_tagged_bag.all_gather(tags);
   // }
 
-  std::map<tag_type, value_type> gather_keys(const std::vector<tag_type> &tags) {
+  std::map<tag_type, value_type> gather_keys(
+      const std::vector<tag_type> &tags) {
     return m_tagged_bag.gather_keys(tags);
   }
   template <typename Function>

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -1107,8 +1107,7 @@ inline void comm::set_log_location(const StringType &s) {
   set_log_location(std::filesystem::path(s));
 }
 
-template <>
-inline void comm::set_log_location<>(const std::filesystem::path &p) {
+inline void comm::set_log_location(const std::filesystem::path &p) {
   // p will be treated as a desired directory location to store all logs. The
   // full name of the individual loggers on each rank will be determined by the
   // ygm::detail::logger objects.

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -46,6 +46,10 @@ inline comm::comm(MPI_Comm mcomm)
 }
 
 inline void comm::comm_setup(MPI_Comm c) {
+  m_logger.set_path(config.default_log_path + std::to_string(rank()));
+  m_logger.set_log_level(config.default_log_level);
+  m_logger.log(log_level::info, "Setting up ygm::comm");
+
   YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_async));
   YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_barrier));
   YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_other));
@@ -61,8 +65,6 @@ inline void comm::comm_setup(MPI_Comm c) {
         new ygm::detail::byte_vector(config.irecv_size)};
     post_new_irecv(recv_buffer);
   }
-
-  m_logger.set_path("./log/ygm_logs" + std::to_string(rank()));
 }
 
 inline void comm::welcome(std::ostream &os) {
@@ -129,6 +131,8 @@ inline void comm::stats_print(const std::string &name, std::ostream &os) {
 
 inline comm::~comm() {
   barrier();
+
+  m_logger.log(log_level::info, "Destroying ygm::comm");
 
   YGM_ASSERT_RELEASE(MPI_Barrier(m_comm_async) == MPI_SUCCESS);
 

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -1102,7 +1102,13 @@ inline bool comm::local_process_incoming() {
   return received_to_return;
 }
 
-inline void comm::set_log_location(const std::filesystem::path &p) {
+template <typename StringType>
+inline void comm::set_log_location(const StringType &s) {
+  set_log_location(std::filesystem::path(s));
+}
+
+template <>
+inline void comm::set_log_location<>(const std::filesystem::path &p) {
   // p will be treated as a desired directory location to store all logs. The
   // full name of the individual loggers on each rank will be determined by the
   // ygm::detail::logger objects.
@@ -1112,7 +1118,4 @@ inline void comm::set_log_location(const std::filesystem::path &p) {
   std::filesystem::create_directories(p);
 }
 
-inline void comm::set_log_location(const std::string &s) {
-  set_log_location(std::filesystem::path(s));
-}
 };  // namespace ygm

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -1107,7 +1107,7 @@ inline void comm::set_log_location(const StringType &s) {
   set_log_location(std::filesystem::path(s));
 }
 
-inline void comm::set_log_location(const std::filesystem::path p) {
+inline void comm::set_log_location(std::filesystem::path p) {
   // p will be treated as a desired directory location to store all logs. The
   // full name of the individual loggers on each rank will be determined by the
   // ygm::detail::logger objects.

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -1107,7 +1107,7 @@ inline void comm::set_log_location(const StringType &s) {
   set_log_location(std::filesystem::path(s));
 }
 
-inline void comm::set_log_location(const std::filesystem::path &p) {
+inline void comm::set_log_location(const std::filesystem::path p) {
   // p will be treated as a desired directory location to store all logs. The
   // full name of the individual loggers on each rank will be determined by the
   // ygm::detail::logger objects.
@@ -1116,9 +1116,8 @@ inline void comm::set_log_location(const std::filesystem::path &p) {
   }
   std::filesystem::create_directories(p);
 
-  std::filesystem::path rank_log_path =
-      p + std::filesystem::path("ygm_logs" + std::to_string(rank()));
-  m_logger.set_path(rank_log_path);
+  p /= ("ygm_logs" + std::to_string(rank()));
+  m_logger.set_path(p);
 }
 
 };  // namespace ygm

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -1115,6 +1115,10 @@ inline void comm::set_log_location(const std::filesystem::path &p) {
     cout0("Cannot set log location: ", p, " exists and is not a directory");
   }
   std::filesystem::create_directories(p);
+
+  std::filesystem::path rank_log_path =
+      p + std::filesystem::path("ygm_logs" + std::to_string(rank()));
+  m_logger.set_path(rank_log_path);
 }
 
 };  // namespace ygm

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -254,7 +254,7 @@ inline MPI_Comm comm::get_mpi_comm() const { return m_comm_other; }
  *
  */
 inline void comm::barrier() {
-  comm_log("Entering YGM barrier");
+  log(log_level::debug, "Entering YGM barrier");
   flush_all_local_and_process_incoming();
   std::pair<uint64_t, uint64_t> previous_counts{1, 2};
   std::pair<uint64_t, uint64_t> current_counts{3, 4};
@@ -271,7 +271,7 @@ inline void comm::barrier() {
   YGM_ASSERT_RELEASE(m_send_remote_dest_queue.empty());
 
   cf_barrier();
-  comm_log("Exiting YGM barrier");
+  log(log_level::debug, "Exiting YGM barrier");
 }
 
 /**
@@ -280,9 +280,9 @@ inline void comm::barrier() {
  * called it. See:  MPI_Barrier()
  */
 inline void comm::cf_barrier() const {
-  comm_log("Entering YGM cf_barrier");
+  log(log_level::debug, "Entering YGM cf_barrier");
   YGM_ASSERT_MPI(MPI_Barrier(m_comm_barrier));
-  comm_log("Exiting YGM cf_barrier");
+  log(log_level::debug, "Exiting YGM cf_barrier");
 }
 
 template <typename T>
@@ -558,14 +558,16 @@ inline void comm::flush_send_buffer(int dest) {
     }
     request.buffer->swap(m_vec_send_buffers[dest]);
     if (config.freq_issend > 0 && counter++ % config.freq_issend == 0) {
-      comm_log("MPI_Issend " + std::to_string(request.buffer->size()) +
-               " bytes to rank " + std::to_string(dest));
+      log(log_level::debug, "MPI_Issend " +
+                                std::to_string(request.buffer->size()) +
+                                " bytes to rank " + std::to_string(dest));
       YGM_ASSERT_MPI(MPI_Issend(request.buffer->data(), request.buffer->size(),
                                 MPI_BYTE, dest, 0, m_comm_async,
                                 &(request.request)));
     } else {
-      comm_log("MPI_Isend " + std::to_string(request.buffer->size()) +
-               " bytes to rank " + std::to_string(dest));
+      log(log_level::debug, "MPI_Isend " +
+                                std::to_string(request.buffer->size()) +
+                                " bytes to rank " + std::to_string(dest));
       YGM_ASSERT_MPI(MPI_Isend(request.buffer->data(), request.buffer->size(),
                                MPI_BYTE, dest, 0, m_comm_async,
                                &(request.request)));
@@ -600,8 +602,9 @@ inline void comm::flush_next_send(std::deque<int> &dest_queue) {
  */
 inline void comm::handle_completed_send(mpi_isend_request &req_buffer) {
   m_pending_isend_bytes -= req_buffer.buffer->size();
-  comm_log("Completed send of " + std::to_string(req_buffer.buffer->size()) +
-           " bytes");
+  log(log_level::debug, "Completed send of " +
+                            std::to_string(req_buffer.buffer->size()) +
+                            " bytes");
   if (m_free_send_buffers.size() < config.send_buffer_free_list_len) {
     req_buffer.buffer->clear();
     m_free_send_buffers.push_back(req_buffer.buffer);
@@ -965,8 +968,8 @@ inline void comm::queue_message_bytes(const ygm::detail::byte_vector &packed,
 inline void comm::handle_next_receive(
     std::shared_ptr<ygm::detail::byte_vector> &buffer, const size_t buffer_size,
     const uint32_t from_rank) {
-  comm_log("Received " + std::to_string(buffer_size) + " bytes from rank " +
-           std::to_string(from_rank));
+  log(log_level::debug, "Received " + std::to_string(buffer_size) +
+                            " bytes from rank " + std::to_string(from_rank));
   cereal::YGMInputArchive iarchive(buffer.get()->data(), buffer_size);
   while (!iarchive.empty()) {
     if (config.routing != detail::routing_type::NONE) {

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -13,12 +13,12 @@ namespace ygm {
 
 struct comm::mpi_irecv_request {
   std::shared_ptr<ygm::detail::byte_vector> buffer;
-  MPI_Request                             request;
+  MPI_Request                               request;
 };
 
 struct comm::mpi_isend_request {
   std::shared_ptr<ygm::detail::byte_vector> buffer;
-  MPI_Request                             request;
+  MPI_Request                               request;
 };
 
 struct comm::header_t {
@@ -57,9 +57,12 @@ inline void comm::comm_setup(MPI_Comm c) {
   }
 
   for (size_t i = 0; i < config.num_irecvs; ++i) {
-    std::shared_ptr<ygm::detail::byte_vector> recv_buffer{new ygm::detail::byte_vector(config.irecv_size)};
+    std::shared_ptr<ygm::detail::byte_vector> recv_buffer{
+        new ygm::detail::byte_vector(config.irecv_size)};
     post_new_irecv(recv_buffer);
   }
+
+  m_logger.set_path("./log/ygm_logs" + std::to_string(rank()));
 }
 
 inline void comm::welcome(std::ostream &os) {
@@ -251,6 +254,7 @@ inline MPI_Comm comm::get_mpi_comm() const { return m_comm_other; }
  *
  */
 inline void comm::barrier() {
+  comm_log("Entering YGM barrier");
   flush_all_local_and_process_incoming();
   std::pair<uint64_t, uint64_t> previous_counts{1, 2};
   std::pair<uint64_t, uint64_t> current_counts{3, 4};
@@ -267,6 +271,7 @@ inline void comm::barrier() {
   YGM_ASSERT_RELEASE(m_send_remote_dest_queue.empty());
 
   cf_barrier();
+  comm_log("Exiting YGM barrier");
 }
 
 /**
@@ -275,7 +280,9 @@ inline void comm::barrier() {
  * called it. See:  MPI_Barrier()
  */
 inline void comm::cf_barrier() const {
+  comm_log("Entering YGM cf_barrier");
   YGM_ASSERT_MPI(MPI_Barrier(m_comm_barrier));
+  comm_log("Exiting YGM cf_barrier");
 }
 
 template <typename T>
@@ -353,7 +360,7 @@ inline T comm::all_reduce(const T &in, MergeFunction merge) const {
 template <typename T>
 inline void comm::mpi_send(const T &data, int dest, int tag,
                            MPI_Comm comm) const {
-  ygm::detail::byte_vector        packed;
+  ygm::detail::byte_vector packed;
   cereal::YGMOutputArchive oarchive(packed);
   oarchive(data);
   size_t packed_size = packed.size();
@@ -382,7 +389,7 @@ inline T comm::mpi_recv(int source, int tag, MPI_Comm comm) const {
 
 template <typename T>
 inline T comm::mpi_bcast(const T &to_bcast, int root, MPI_Comm comm) const {
-  ygm::detail::byte_vector        packed;
+  ygm::detail::byte_vector packed;
   cereal::YGMOutputArchive oarchive(packed);
   if (rank() == root) {
     oarchive(to_bcast);
@@ -468,8 +475,8 @@ inline std::string comm::outstr(Args &&...args) const {
   return ss.str();
 }
 
-inline size_t comm::pack_header(ygm::detail::byte_vector &packed, const int dest,
-                                size_t size) {
+inline size_t comm::pack_header(ygm::detail::byte_vector &packed,
+                                const int dest, size_t size) {
   size_t size_before = packed.size();
 
   header_t h;
@@ -524,7 +531,8 @@ inline std::pair<uint64_t, uint64_t> comm::barrier_reduce_counts() {
         int buffer_size{0};
         YGM_ASSERT_MPI(MPI_Get_count(&twin_status[i], MPI_BYTE, &buffer_size));
         stats.irecv(twin_status[i].MPI_SOURCE, buffer_size);
-        handle_next_receive(req_buffer.buffer, buffer_size);
+        handle_next_receive(req_buffer.buffer, buffer_size,
+                            twin_status[i].MPI_SOURCE);
         flush_all_local_and_process_incoming();
       }
     }
@@ -550,10 +558,14 @@ inline void comm::flush_send_buffer(int dest) {
     }
     request.buffer->swap(m_vec_send_buffers[dest]);
     if (config.freq_issend > 0 && counter++ % config.freq_issend == 0) {
+      comm_log("MPI_Issend " + std::to_string(request.buffer->size()) +
+               " bytes to rank " + std::to_string(dest));
       YGM_ASSERT_MPI(MPI_Issend(request.buffer->data(), request.buffer->size(),
                                 MPI_BYTE, dest, 0, m_comm_async,
                                 &(request.request)));
     } else {
+      comm_log("MPI_Isend " + std::to_string(request.buffer->size()) +
+               " bytes to rank " + std::to_string(dest));
       YGM_ASSERT_MPI(MPI_Isend(request.buffer->data(), request.buffer->size(),
                                MPI_BYTE, dest, 0, m_comm_async,
                                &(request.request)));
@@ -566,14 +578,13 @@ inline void comm::flush_send_buffer(int dest) {
     } else {
       m_send_remote_buffer_bytes -= request.buffer->size();
     }
-    
+
     m_send_queue.push_back(request);
     if (!m_in_process_receive_queue) {
       process_receive_queue();
     }
   }
 }
-
 
 inline void comm::flush_next_send(std::deque<int> &dest_queue) {
   if (!dest_queue.empty()) {
@@ -589,6 +600,8 @@ inline void comm::flush_next_send(std::deque<int> &dest_queue) {
  */
 inline void comm::handle_completed_send(mpi_isend_request &req_buffer) {
   m_pending_isend_bytes -= req_buffer.buffer->size();
+  comm_log("Completed send of " + std::to_string(req_buffer.buffer->size()) +
+           " bytes");
   if (m_free_send_buffers.size() < config.send_buffer_free_list_len) {
     req_buffer.buffer->clear();
     m_free_send_buffers.push_back(req_buffer.buffer);
@@ -615,7 +628,8 @@ inline void comm::check_completed_sends() {
 
 inline void comm::check_if_production_halt_required() {
   while (m_enable_interrupts && !m_in_process_receive_queue &&
-         m_pending_isend_bytes > (config.local_buffer_size + config.remote_buffer_size)) {
+         m_pending_isend_bytes >
+             (config.local_buffer_size + config.remote_buffer_size)) {
     process_receive_queue();
   }
 }
@@ -703,15 +717,16 @@ inline void comm::flush_to_capacity() {
   }
 }
 
-inline void comm::post_new_irecv(std::shared_ptr<ygm::detail::byte_vector> &recv_buffer) {
+inline void comm::post_new_irecv(
+    std::shared_ptr<ygm::detail::byte_vector> &recv_buffer) {
   recv_buffer->clear();
   mpi_irecv_request recv_req;
   recv_req.buffer = recv_buffer;
 
   //::madvise(recv_req.buffer.get(), config.irecv_size, MADV_DONTNEED);
-  YGM_ASSERT_MPI(MPI_Irecv(recv_req.buffer.get()->data(), config.irecv_size, MPI_BYTE,
-                       MPI_ANY_SOURCE, MPI_ANY_TAG, m_comm_async,
-                       &(recv_req.request)));
+  YGM_ASSERT_MPI(MPI_Irecv(recv_req.buffer.get()->data(), config.irecv_size,
+                           MPI_BYTE, MPI_ANY_SOURCE, MPI_ANY_TAG, m_comm_async,
+                           &(recv_req.request)));
   m_recv_queue.push_back(recv_req);
 }
 
@@ -886,9 +901,7 @@ inline size_t comm::pack_lambda_generic(ygm::detail::byte_vector &packed,
 
   uint16_t lid = m_lambda_map.register_lambda(remote_dispatch_lambda);
 
-  {
-    packed.push_bytes(&lid, sizeof(lid));
-  }
+  { packed.push_bytes(&lid, sizeof(lid)); }
 
   if constexpr (!std::is_empty<Lambda>::value) {
     // oarchive.saveBinary(&l, sizeof(Lambda));
@@ -909,8 +922,8 @@ inline size_t comm::pack_lambda_generic(ygm::detail::byte_vector &packed,
  * destination. Does not modify packed message to add headers for routing.
  *
  */
-inline void comm::queue_message_bytes(const ygm::detail::byte_vector            &packed,
-                                      const int                    dest) {
+inline void comm::queue_message_bytes(const ygm::detail::byte_vector &packed,
+                                      const int                       dest) {
   m_send_count++;
   bool local = m_layout.is_local(dest);
   //
@@ -949,8 +962,11 @@ inline void comm::queue_message_bytes(const ygm::detail::byte_vector            
   }
 }
 
-inline void comm::handle_next_receive(std::shared_ptr<ygm::detail::byte_vector> &buffer,
-                                      const size_t buffer_size) {
+inline void comm::handle_next_receive(
+    std::shared_ptr<ygm::detail::byte_vector> &buffer, const size_t buffer_size,
+    const uint32_t from_rank) {
+  comm_log("Received " + std::to_string(buffer_size) + " bytes from rank " +
+           std::to_string(from_rank));
   cereal::YGMInputArchive iarchive(buffer.get()->data(), buffer_size);
   while (!iarchive.empty()) {
     if (config.routing != detail::routing_type::NONE) {
@@ -963,8 +979,8 @@ inline void comm::handle_next_receive(std::shared_ptr<ygm::detail::byte_vector> 
         m_recv_count++;
         stats.rpc_execute();
       } else {
-        int next_dest = m_router.next_hop(h.dest);
-        bool local = m_layout.is_local(next_dest);
+        int  next_dest = m_router.next_hop(h.dest);
+        bool local     = m_layout.is_local(next_dest);
 
         if (m_vec_send_buffers[next_dest].empty()) {
           if (local) {
@@ -1049,7 +1065,8 @@ inline bool comm::process_receive_queue() {
         int buffer_size{0};
         YGM_ASSERT_MPI(MPI_Get_count(&twin_status[i], MPI_BYTE, &buffer_size));
         stats.irecv(twin_status[i].MPI_SOURCE, buffer_size);
-        handle_next_receive(req_buffer.buffer, buffer_size);
+        handle_next_receive(req_buffer.buffer, buffer_size,
+                            twin_status[i].MPI_SOURCE);
       }
     }
   } else {
@@ -1077,11 +1094,25 @@ inline bool comm::local_process_incoming() {
       int buffer_size{0};
       YGM_ASSERT_MPI(MPI_Get_count(&status, MPI_BYTE, &buffer_size));
       stats.irecv(status.MPI_SOURCE, buffer_size);
-      handle_next_receive(req_buffer.buffer, buffer_size);
+      handle_next_receive(req_buffer.buffer, buffer_size, status.MPI_SOURCE);
     } else {
       break;  // not ready yet
     }
   }
   return received_to_return;
+}
+
+inline void comm::set_log_location(const std::filesystem::path &p) {
+  // p will be treated as a desired directory location to store all logs. The
+  // full name of the individual loggers on each rank will be determined by the
+  // ygm::detail::logger objects.
+  if (std::filesystem::exists(p) && not std::filesystem::is_directory(p)) {
+    cout0("Cannot set log location: ", p, " exists and is not a directory");
+  }
+  std::filesystem::create_directories(p);
+}
+
+inline void comm::set_log_location(const std::string &s) {
+  set_log_location(std::filesystem::path(s));
 }
 };  // namespace ygm

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <string>
 #include <ygm/detail/layout.hpp>
+#include <ygm/detail/logger.hpp>
 
 namespace ygm {
 
@@ -119,6 +120,28 @@ class comm_environment {
     if (const char* cc = std::getenv("YGM_COMM_SEND_BUFFER_FREE_LIST_LEN")) {
       send_buffer_free_list_len = convert<size_t>(cc);
     }
+    if (const char* cc = std::getenv("YGM_DEFAULT_LOG_PATH")) {
+      default_log_path = std::string(cc);
+    }
+    if (const char* cc = std::getenv("YGM_DEFAULT_LOG_LEVEL")) {
+      std::string level_str(cc);
+      if (level_str == "off") {
+        default_log_level = log_level::off;
+      } else if (level_str == "critical") {
+        default_log_level = log_level::critical;
+      } else if (level_str == "error") {
+        default_log_level = log_level::error;
+      } else if (level_str == "warn") {
+        default_log_level = log_level::warn;
+      } else if (level_str == "info") {
+        default_log_level = log_level::info;
+      } else if (level_str == "debug") {
+        default_log_level = log_level::debug;
+      } else {
+        throw(std::runtime_error(
+            "comm_environment -- unknown default logging level: " + level_str));
+      }
+    }
   }
 
   void print(std::ostream& os = std::cout) const {
@@ -143,6 +166,28 @@ class comm_environment {
         os << "NLNR\n";
         break;
     }
+    os << "YGM_DEFAULT_LOG_PATH             = " << default_log_path << "\n"
+       << "YGM_DEFAULT_LOG_LEVEL            = ";
+    switch (default_log_level) {
+      case log_level::off:
+        os << "off\n";
+        break;
+      case log_level::critical:
+        os << "critical\n";
+        break;
+      case log_level::error:
+        os << "error\n";
+        break;
+      case log_level::warn:
+        os << "warn\n";
+        break;
+      case log_level::info:
+        os << "info\n";
+        break;
+      case log_level::debug:
+        os << "debug\n";
+        break;
+    }
     os << "======================================\n";
   }
 
@@ -160,6 +205,9 @@ class comm_environment {
   size_t send_buffer_free_list_len = 32;
 
   routing_type routing = routing_type::NONE;
+
+  std::string default_log_path  = "./log/ygm_logs_";
+  log_level   default_log_level = log_level::off;
 
   bool welcome = false;
 };

--- a/include/ygm/detail/logger.hpp
+++ b/include/ygm/detail/logger.hpp
@@ -11,8 +11,6 @@
 
 namespace ygm {
 
-class comm;
-
 enum class log_level {
   off      = 0,
   critical = 1,

--- a/include/ygm/detail/logger.hpp
+++ b/include/ygm/detail/logger.hpp
@@ -1,0 +1,60 @@
+// Copyright 2019-2021 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <ygm/comm.hpp>
+
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/spdlog.h"
+
+#include <filesystem>
+
+namespace ygm {
+
+class comm;
+
+namespace detail {
+
+/**
+ * @brief Simple logger for applications using YGM
+ */
+class logger {
+ public:
+  logger() : logger(std::filesystem::path("./log/")) {}
+
+  logger(const std::filesystem::path &path) : m_path(path) {
+    if (std::filesystem::is_directory(path)) {
+      m_path += "/ygm_logs";
+    }
+  }
+
+  void set_path(const std::filesystem::path p) {
+    m_path = p;
+
+    if (m_logger_ptr) {
+      m_logger_ptr.reset();
+    }
+  }
+
+  template <typename... Args>
+  void log(Args &&...args) const {
+    if (not m_logger_ptr) {
+      std::filesystem::create_directories(m_path.parent_path());
+
+      m_logger_ptr =
+          spdlog::basic_logger_mt("ygm_logger", m_path.c_str(), true);
+    }
+    m_logger_ptr->info(args...);
+  }
+
+ private:
+  mutable std::shared_ptr<spdlog::logger> m_logger_ptr;
+
+  std::filesystem::path m_path;
+};
+
+}  // namespace detail
+}  // namespace ygm

--- a/include/ygm/detail/logger.hpp
+++ b/include/ygm/detail/logger.hpp
@@ -5,16 +5,22 @@
 
 #pragma once
 
-#include <ygm/comm.hpp>
-
 #include "spdlog/sinks/basic_file_sink.h"
-#include "spdlog/spdlog.h"
 
 #include <filesystem>
 
 namespace ygm {
 
 class comm;
+
+enum class log_level {
+  off      = 0,
+  critical = 1,
+  error    = 2,
+  warn     = 3,
+  info     = 4,
+  debug    = 5
+};
 
 namespace detail {
 
@@ -23,6 +29,9 @@ namespace detail {
  */
 class logger {
  public:
+  using rank_logger_t    = spdlog::logger;
+  using rank_file_sink_t = spdlog::sinks::basic_file_sink_st;
+
   logger() : logger(std::filesystem::path("./log/")) {}
 
   logger(const std::filesystem::path &path) : m_path(path) {
@@ -39,19 +48,32 @@ class logger {
     }
   }
 
+  std::filesystem::path get_path() { return m_path; }
+
+  void set_log_level(const log_level level) { m_log_level = level; }
+
+  log_level get_log_level() { return m_log_level; }
+
   template <typename... Args>
-  void log(Args &&...args) const {
+  void log(const log_level level, Args &&...args) const {
+    if (level > m_log_level) {
+      return;
+    }
+
     if (not m_logger_ptr) {
       std::filesystem::create_directories(m_path.parent_path());
 
-      m_logger_ptr =
-          spdlog::basic_logger_mt("ygm_logger", m_path.c_str(), true);
+      m_logger_ptr = std::make_unique<spdlog::logger>(
+          "ygm_logger",
+          std::make_shared<rank_file_sink_t>(m_path.c_str(), false));
     }
     m_logger_ptr->info(args...);
   }
 
  private:
-  mutable std::shared_ptr<spdlog::logger> m_logger_ptr;
+  mutable std::unique_ptr<rank_logger_t> m_logger_ptr;
+
+  log_level m_log_level = log_level::off;
 
   std::filesystem::path m_path;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ endfunction ()
 
 add_ygm_seq_test(test_cereal_archive)
 add_ygm_seq_test(test_byte_vector)
+add_ygm_seq_test(test_logger)
 
 add_ygm_test(test_comm)
 add_ygm_test(test_comm_2)

--- a/test/test_logger.cpp
+++ b/test/test_logger.cpp
@@ -1,0 +1,113 @@
+
+#include <filesystem>
+#include <ygm/detail/assert.hpp>
+#include <ygm/detail/logger.hpp>
+
+class file_cleanup {
+ public:
+  file_cleanup(std::filesystem::path &p) : m_p(p) {
+    // Only use this for files that do not currently exist
+    YGM_ASSERT_RELEASE(std::filesystem::exists(m_p) == false);
+  }
+
+  ~file_cleanup() { std::filesystem::remove(m_p); }
+
+ private:
+  std::filesystem::path m_p;
+};
+
+int main(int argc, char **argv) {
+  // Test files are not created until necessary
+  {
+    std::filesystem::path p("./test_log");
+    file_cleanup          c(p);
+
+    ygm::detail::logger l(p);
+
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::off);
+    l.log(ygm::log_level::info, "Do not log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::info);
+    l.log(ygm::log_level::info, "Do log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == true);
+  }
+
+  // Test logging level ordering
+  {
+    std::filesystem::path p("./test_log");
+    file_cleanup          c(p);
+
+    ygm::detail::logger l(p);
+
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::warn);
+    l.log(ygm::log_level::info, "Do not log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::debug);
+    l.log(ygm::log_level::info, "Do log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == true);
+  }
+
+  // Test setting new log file
+  {
+    std::filesystem::path p("./test_log");
+    file_cleanup          c(p);
+
+    ygm::detail::logger l(p);
+
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::warn);
+    l.log(ygm::log_level::info, "Do not log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    std::filesystem::path p2("./test_log2");
+    file_cleanup          c2(p2);
+
+    l.set_path(p2);
+    YGM_ASSERT_RELEASE(l.get_path() == p2);
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.log(ygm::log_level::info, "Do not log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::debug);
+    l.log(ygm::log_level::info, "Do log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == true);
+  }
+
+  // Test logs do not get overwritten when opening existing file
+  {
+    std::filesystem::path p("./test_log");
+    file_cleanup          c(p);
+
+    ygm::detail::logger l(p);
+
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::warn);
+    l.log(ygm::log_level::info, "Do not log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_log_level(ygm::log_level::debug);
+    l.log(ygm::log_level::info, "Do log");
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == true);
+
+    std::filesystem::path p2("./test_log2");
+    file_cleanup          c2(p2);
+
+    l.set_path(p2);
+    YGM_ASSERT_RELEASE(l.get_path() == p2);
+    YGM_ASSERT_RELEASE(std::filesystem::exists(l.get_path()) == false);
+
+    l.set_path(p);
+    YGM_ASSERT_RELEASE(std::filesystem::is_empty(p) == false);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds a `ygm::detail::logger` that can be accessed from a `comm`. Debugging messages are added to log communicators at the level of MPI sends and receives. This feature adds a dependency on [spdlog](https://github.com/gabime/spdlog).