### PR TITLE
Default construct lambdas instead of dereferencing null pointers

### DIFF
--- a/include/ygm/container/detail/base_async_contains.hpp
+++ b/include/ygm/container/detail/base_async_contains.hpp
@@ -24,10 +24,11 @@ struct base_async_contains {
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [fn](auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) mutable {
-      bool contains = static_cast<bool>(pcont->local_count(value));
+    auto lambda = [](auto                                             pcont,
+                     const std::tuple_element<0, for_all_args>::type& value,
+                     const FuncArgs&... args) mutable {
+      Function fn{};
+      bool     contains = static_cast<bool>(pcont->local_count(value));
       ygm::meta::apply_optional(
           fn, std::make_tuple(pcont),
           std::forward_as_tuple(contains, value, args...));

--- a/include/ygm/container/detail/base_async_insert_contains.hpp
+++ b/include/ygm/container/detail/base_async_insert_contains.hpp
@@ -25,9 +25,11 @@ struct base_async_insert_contains {
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [fn](auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) mutable {
+    auto lambda = [](auto                                             pcont,
+                     const std::tuple_element<0, for_all_args>::type& value,
+                     const FuncArgs&... args) mutable {
+      Function fn{};
+
       bool contains = static_cast<bool>(pcont->local_count(value));
       if (!contains) {
         pcont->local_insert(value);

--- a/include/ygm/container/detail/base_async_reduce.hpp
+++ b/include/ygm/container/detail/base_async_reduce.hpp
@@ -27,9 +27,9 @@ struct base_async_reduce {
     int dest = derived_this->partitioner.owner(key);
 
     auto rlambda =
-        [reducer](
-            auto pcont, const std::tuple_element<0, for_all_args>::type& key,
-            const std::tuple_element<1, for_all_args>::type& value) mutable {
+        [](auto pcont, const std::tuple_element<0, for_all_args>::type& key,
+           const std::tuple_element<1, for_all_args>::type& value) mutable {
+          ReductionOp reducer{};
           pcont->local_reduce(key, value, reducer);
         };
 

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -26,10 +26,10 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
-                       auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) mutable {
+    auto vlambda = [](auto                                             pcont,
+                      const std::tuple_element<0, for_all_args>::type& key,
+                      const VisitorArgs&... args) mutable {
+      Visitor visitor{};
       pcont->local_visit(key, visitor, args...);
     };
 
@@ -50,10 +50,10 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
-                       auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) mutable {
+    auto vlambda = [](auto                                             pcont,
+                      const std::tuple_element<0, for_all_args>::type& key,
+                      const VisitorArgs&... args) mutable {
+      Visitor visitor{};
       pcont->local_visit_if_contains(key, visitor, args...);
     };
 
@@ -74,10 +74,10 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
-                       const auto                                       pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) mutable {
+    auto vlambda = [](const auto                                       pcont,
+                      const std::tuple_element<0, for_all_args>::type& key,
+                      const VisitorArgs&... args) mutable {
+      Visitor visitor{};
       pcont->local_visit_if_contains(key, visitor, args...);
     };
 

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -878,10 +878,7 @@ inline size_t comm::pack_lambda_generic(ygm::detail::byte_vector &packed,
       std::forward<const PackArgs>(args)...);
 
   auto remote_dispatch_lambda = [](comm *c, cereal::YGMInputArchive *bia) {
-    RemoteLogicLambda *rll = nullptr;
-    Lambda            *pl  = nullptr;
-
-    (*rll)(c, bia, *pl);
+    RemoteLogicLambda{}.operator()(c, bia, Lambda{});
   };
 
   uint16_t lid = m_lambda_map.register_lambda(remote_dispatch_lambda);


### PR DESCRIPTION
I ran into crashes on my machines where the following lines segfaulted.

```
RemoteLogicLambda *rll = nullptr;
Lambda            *pl  = nullptr;

(*rll)(c, bia, *pl);
```

This patch changes these lines to the following which relies on the change in c++20 that lambdas with no captures can be default constructed.

```
RemoteLogicLambda{}.operator()(c, bia, Lambda{});
```

This required fixes in some containers that were capturing lambda types, these were fixed by default constructing these lambdas as well.

This approach to accepting lambda types as input and default constructing them gives an extra compile time sanity check that the user is not passing in a capturing lambda.