### PR TITLE
Feature/macos runners

### DIFF
--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -20,10 +20,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Update apt
+      - name: Update brew
         run: |
-          sudo add-apt-repository -y universe
-          sudo apt-get update
+          brew update
       - name: Cache boost
         uses: actions/cache@v4
         id: cache-boost

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-latest]
+        os: [macos-latest]
         gcc-version: [12, 13, 14]
-        mpi-type: [mpich, openmpi]
+        mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -37,8 +37,8 @@ jobs:
           tar -xjf boost_1_77_0.tar.bz2
       - name: Install Apache Arrow
         run: |
-          # python -m pip install pyarrow==16.1.*
-          brew install apache-arrow
+          brew install apache-arrow@16.1.0
+          python -m pip install pyarrow==16.1.0
           PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
           echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
           echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -35,14 +35,6 @@ jobs:
           cd ~
           wget --no-verbose https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.bz2
           tar -xjf boost_1_77_0.tar.bz2
-      - name: Install Apache Arrow
-        run: |
-          brew search apache-arrow@
-          #brew install apache-arrow@16.1.0
-          #python -m pip install pyarrow==16.1.0
-          #PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
-          #echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
-          #echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV
       - name: Install mpich
         if: matrix.mpi-type == 'mpich'
         run: brew install mpich
@@ -73,4 +65,5 @@ jobs:
           echo Run 'make test' with OpenMPI, gcc-${{ matrix.gcc-version }}
           cd build
           export OMPI_MCA_rmaps_base_oversubscribe=1
+          export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
           ctest -VV -C ${{ env.BUILD_TYPE }}

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Apache Arrow
         run: |
           # python -m pip install pyarrow==16.1.*
-          brew install pyarrow
+          brew install apache-arrow
           PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
           echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
           echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -37,11 +37,12 @@ jobs:
           tar -xjf boost_1_77_0.tar.bz2
       - name: Install Apache Arrow
         run: |
-          brew install apache-arrow@16.1.0
-          python -m pip install pyarrow==16.1.0
-          PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
-          echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
-          echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV
+          brew search apache-arrow@
+          #brew install apache-arrow@16.1.0
+          #python -m pip install pyarrow==16.1.0
+          #PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
+          #echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
+          #echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV
       - name: Install mpich
         if: matrix.mpi-type == 'mpich'
         run: brew install mpich

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -1,0 +1,75 @@
+name: CI Test macOS
+
+on:
+  pull_request:
+    branches: [ master, '**-dev' ]
+  push:
+    branches: [ 'feature/**', 'hotfix/**']
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-latest]
+        gcc-version: [12, 13, 14]
+        mpi-type: [mpich, openmpi]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update apt
+        run: |
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+      - name: Cache boost
+        uses: actions/cache@v4
+        id: cache-boost
+        with:
+          path: "~/boost_1_77_0"
+          key: ${{ runner.os }}-libboost1.77
+      - name: Install boost
+        if: steps.cache-boost.outputs.cache-hit != 'true'
+        run: |
+          cd ~
+          wget --no-verbose https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.bz2
+          tar -xjf boost_1_77_0.tar.bz2
+      - name: Install Apache Arrow
+        run: |
+          python -m pip install pyarrow==16.1.*
+          PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
+          echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
+          echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV
+      - name: Install mpich
+        if: matrix.mpi-type == 'mpich'
+        run: brew install mpich
+      - name: Install OpenMPI
+        if: matrix.mpi-type == 'openmpi'
+        run: brew install open-mpi
+      - name: Make
+        run: |
+          echo Run 'make'
+          mpicc -show
+          g++-${{ matrix.gcc-version }} --version
+          mkdir build
+          cd build
+          if [ "$ENABLE_PARQUET_TEST" ]; then
+            ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
+          fi
+          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc-version }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
+          make -j
+      - name: Make test (mpich)
+        if: matrix.mpi-type == 'mpich'
+        run: |
+          echo Run 'make test' with mpich, gcc-${{ matrix.gcc-version }}
+          cd build
+          ctest -VV -C ${{ env.BUILD_TYPE }}
+      - name: Make test (OpenMPI)
+        if: matrix.mpi-type == 'openmpi'
+        run: |
+          echo Run 'make test' with OpenMPI, gcc-${{ matrix.gcc-version }}
+          cd build
+          export OMPI_MCA_rmaps_base_oversubscribe=1
+          ctest -VV -C ${{ env.BUILD_TYPE }}

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -37,7 +37,8 @@ jobs:
           tar -xjf boost_1_77_0.tar.bz2
       - name: Install Apache Arrow
         run: |
-          python -m pip install pyarrow==16.1.*
+          # python -m pip install pyarrow==16.1.*
+          brew install pyarrow
           PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
           echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
           echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -6,9 +6,6 @@ on:
   push:
     branches: [ 'feature/**', 'hotfix/**']
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   build-test:
     strategy:
@@ -17,6 +14,7 @@ jobs:
         os: [macos-14, macos-latest]
         gcc-version: [12, 13, 14]
         mpi-type: [mpich, openmpi]
+        build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -51,14 +49,14 @@ jobs:
           if [ "$ENABLE_PARQUET_TEST" ]; then
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
-          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc-version }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
-          make -j
+          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc-version }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
+          make -j3
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'
         run: |
           echo Run 'make test' with mpich, gcc-${{ matrix.gcc-version }}
           cd build
-          ctest -VV -C ${{ env.BUILD_TYPE }}
+          ctest -VV -C ${{ matrix.build-type }}
       - name: Make test (OpenMPI)
         if: matrix.mpi-type == 'openmpi'
         run: |
@@ -66,4 +64,4 @@ jobs:
           cd build
           export OMPI_MCA_rmaps_base_oversubscribe=1
           export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
-          ctest -VV -C ${{ env.BUILD_TYPE }}
+          ctest -VV -C ${{ matrix.build-type }}

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -44,7 +44,6 @@ jobs:
           wget --no-verbose https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.bz2
           tar -xjf boost_1_77_0.tar.bz2
       - name: Install Apache Arrow
-        if: ${{ matrix.os == 'ubuntu-latest'}} # Skip on ubuntu-20.04 due to pyarrow's ABI incompatibility issue
         run: |
           python -m pip install pyarrow==16.1.*
           PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")


### PR DESCRIPTION
This PR adds CI jobs that run on macOS runners. The current implementation tests GCC 12, 13, and 14 with OpenMPI using Release and Debug builds.