### PR TITLE
Adds clang to macOS CI jobs

### DIFF
--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15]
-        compiler: [g++-12, g++-13, g++-14, clang-15]
+        compiler: [g++-12, g++-13, g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -42,8 +42,8 @@ jobs:
       - name: Make
         run: |
           echo Run 'make'
-          if [ "${{ matrix.compiler }}" == "clang-15" ]; then
-            COMPILER="$(brew --prefix llvm@15)/bin/clang"
+          if [ "${{ matrix.compiler }}" == "clang-18" ]; then
+            COMPILER="$(brew --prefix llvm@18)/bin/clang"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -55,7 +55,7 @@ jobs:
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
           cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
-          make -j3
+          make 
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'
         run: |

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -44,7 +44,6 @@ jobs:
           echo Run 'make'
           if [ "${{ matrix.compiler }}" == "clang-15" ]; then
             COMPILER="$(brew --prefix llvm@15)/bin/clang++"
-            ls "$(brew --prefix llvm@15)/bin"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -48,13 +48,13 @@ jobs:
             COMPILER="${{ matrix.compiler }}"
           fi
           mpicc -show
+          mpicxx --show
           $COMPILER --version
           mkdir build
           cd build
           if [ "$ENABLE_PARQUET_TEST" ]; then
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
-          which mpicxx
           cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
           make 
       - name: Make test (mpich)

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        gcc-version: [12, 13, 14]
+        compiler: [g++-12, g++-13, g++-14, clang-15]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -43,24 +43,24 @@ jobs:
         run: |
           echo Run 'make'
           mpicc -show
-          g++-${{ matrix.gcc-version }} --version
+          ${{ matrix.compiler }} --version
           mkdir build
           cd build
           if [ "$ENABLE_PARQUET_TEST" ]; then
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
-          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc-version }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
+          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
           make -j3
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'
         run: |
-          echo Run 'make test' with mpich, gcc-${{ matrix.gcc-version }}
+          echo Run 'make test' with mpich, ${{ matrix.compiler }}
           cd build
           ctest -VV -C ${{ matrix.build-type }}
       - name: Make test (OpenMPI)
         if: matrix.mpi-type == 'openmpi'
         run: |
-          echo Run 'make test' with OpenMPI, gcc-${{ matrix.gcc-version }}
+          echo Run 'make test' with OpenMPI, ${{ matrix.compiler }}
           cd build
           export OMPI_MCA_rmaps_base_oversubscribe=1
           export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15]
-        compiler: [g++-12, g++-13, g++-14, clang-18]
+        compiler: [g++-13, g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -48,7 +48,6 @@ jobs:
             COMPILER="${{ matrix.compiler }}"
           fi
           mpicc -show
-          mpicxx --show
           $COMPILER --version
           mkdir build
           cd build

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-os]
+        os: [macos-15]
         compiler: [g++-12, g++-13, g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -44,6 +44,7 @@ jobs:
           echo Run 'make'
           if [ "${{ matrix.compiler }}" == "clang-18" ]; then
             COMPILER="$(brew --prefix llvm@18)/bin/clang++"
+            ls "$(brew --prefix llvm@18)/bin"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-15]
         compiler: [g++-12, g++-13, g++-14, clang-15]
         mpi-type: [openmpi]
         build-type: [Release, Debug]

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -55,7 +55,7 @@ jobs:
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
           cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
-          make 
+          make -j3
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'
         run: |

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        compiler: [g++-12, g++-13, g++-14, clang-15]
+        os: [macos-os]
+        compiler: [g++-12, g++-13, g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -42,8 +42,8 @@ jobs:
       - name: Make
         run: |
           echo Run 'make'
-          if [ "${{ matrix.compiler }}" == "clang-15" ]; then
-            COMPILER="$(brew --prefix llvm@15)/bin/clang++"
+          if [ "${{ matrix.compiler }}" == "clang-18" ]; then
+            COMPILER="$(brew --prefix llvm@18)/bin/clang++"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -54,6 +54,7 @@ jobs:
           if [ "$ENABLE_PARQUET_TEST" ]; then
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
+          which mpicxx
           cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
           make 
       - name: Make test (mpich)

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        compiler: [g++-12, g++-13, g++-14, clang-15]
+        os: [macos-15]
+        compiler: [g++-12, g++-13, g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -42,9 +42,9 @@ jobs:
       - name: Make
         run: |
           echo Run 'make'
-          if [ "${{ matrix.compiler }}" == "clang-15" ]; then
-            COMPILER="$(brew --prefix llvm@15)/bin/clang++"
-            ls "$(brew --prefix llvm@15)/bin"
+          if [ "${{ matrix.compiler }}" == "clang-18" ]; then
+            COMPILER="$(brew --prefix llvm@18)/bin/clang++"
+            ls "$(brew --prefix llvm@18)/bin"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15]
+        os: [macos-latest]
         compiler: [g++-12, g++-13, g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo Run 'make'
           if [ "${{ matrix.compiler }}" == "clang-18" ]; then
-            COMPILER="$(brew --prefix llvm@18)/bin/clang"
+            COMPILER="$(brew --prefix llvm@18)/bin/clang++"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        compiler: [g++-12, g++-13, g++-14, clang-18]
+        compiler: [g++-12, g++-13, g++-14, clang-15]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -42,9 +42,9 @@ jobs:
       - name: Make
         run: |
           echo Run 'make'
-          if [ "${{ matrix.compiler }}" == "clang-18" ]; then
-            COMPILER="$(brew --prefix llvm@18)/bin/clang++"
-            ls "$(brew --prefix llvm@18)/bin"
+          if [ "${{ matrix.compiler }}" == "clang-15" ]; then
+            COMPILER="$(brew --prefix llvm@15)/bin/clang++"
+            ls "$(brew --prefix llvm@15)/bin"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -42,14 +42,19 @@ jobs:
       - name: Make
         run: |
           echo Run 'make'
+          if [ "${{ matrix.compiler }}" == "clang-15" ]; then
+            COMPILER="$(brew --prefix llvm@15)/bin/clang"
+          else
+            COMPILER="${{ matrix.compiler }}"
+          fi
           mpicc -show
-          ${{ matrix.compiler }} --version
+          $COMPILER --version
           mkdir build
           cd build
           if [ "$ENABLE_PARQUET_TEST" ]; then
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
-          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
+          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
           make -j3
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15]
-        compiler: [g++-12, g++-13, g++-14, clang-18]
+        os: [macos-latest]
+        compiler: [g++-12, g++-13, g++-14, clang-15]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}
@@ -42,9 +42,9 @@ jobs:
       - name: Make
         run: |
           echo Run 'make'
-          if [ "${{ matrix.compiler }}" == "clang-18" ]; then
-            COMPILER="$(brew --prefix llvm@18)/bin/clang++"
-            ls "$(brew --prefix llvm@18)/bin"
+          if [ "${{ matrix.compiler }}" == "clang-15" ]; then
+            COMPILER="$(brew --prefix llvm@15)/bin/clang++"
+            ls "$(brew --prefix llvm@15)/bin"
           else
             COMPILER="${{ matrix.compiler }}"
           fi

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -69,7 +69,7 @@ jobs:
             ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
           fi
           cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_CXX_COMPILER=g++-${{ matrix.gcc-version }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
-          make -j
+          make -j4
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'
         run: |

--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -134,10 +134,9 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t)
-    requires detail::HasForAll<T> &&
-                 detail::SingleItemTuple<typename T::for_all_args> &&
-                 std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
+  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
+      detail::SingleItemTuple<typename T::for_all_args> &&
+      std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -154,19 +153,17 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t)
-    requires detail::HasForAll<T> &&
-                 detail::SingleItemTuple<typename T::for_all_args> &&
-                 detail::DoubleItemTuple<
-                     std::tuple_element_t<0, typename T::for_all_args>> &&
-                 std::convertible_to<
-                     std::tuple_element_t<
-                         0, std::tuple_element_t<0, typename T::for_all_args>>,
-                     key_type> &&
-                 std::convertible_to<
-                     std::tuple_element_t<
-                         1, std::tuple_element_t<0, typename T::for_all_args>>,
-                     mapped_type>
+  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
+      detail::SingleItemTuple<typename T::for_all_args> && detail::
+          DoubleItemTuple<std::tuple_element_t<0, typename T::for_all_args>> &&
+      std::convertible_to<
+          std::tuple_element_t<
+              0, std::tuple_element_t<0, typename T::for_all_args>>,
+          key_type> &&
+      std::convertible_to<
+          std::tuple_element_t<
+              1, std::tuple_element_t<0, typename T::for_all_args>>,
+          mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -188,15 +185,11 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t)
-    requires detail::HasForAll<T> &&
-                 detail::DoubleItemTuple<typename T::for_all_args> &&
-                 std::convertible_to<
-                     std::tuple_element_t<0, typename T::for_all_args>,
-                     key_type> &&
-                 std::convertible_to<
-                     std::tuple_element_t<0, typename T::for_all_args>,
-                     mapped_type>
+  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
+      detail::DoubleItemTuple<typename T::for_all_args> && std::convertible_to<
+          std::tuple_element_t<0, typename T::for_all_args>, key_type> &&
+      std::convertible_to<std::tuple_element_t<0, typename T::for_all_args>,
+                          mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -218,10 +211,9 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t)
-    requires detail::STLContainer<T> &&
-                 (not detail::SingleItemTuple<typename T::value_type>) &&
-                 std::convertible_to<typename T::value_type, mapped_type>
+  array(ygm::comm& comm, const T& t) requires detail::STLContainer<T> &&
+      (not detail::SingleItemTuple<typename T::value_type>)&&std::
+          convertible_to<typename T::value_type, mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -240,15 +232,11 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t)
-    requires detail::STLContainer<T> &&
-                 detail::DoubleItemTuple<typename T::value_type> &&
-                 std::convertible_to<
-                     std::tuple_element_t<0, typename T::value_type>,
-                     key_type> &&
-                 std::convertible_to<
-                     std::tuple_element_t<1, typename T::value_type>,
-                     mapped_type>
+  array(ygm::comm& comm, const T& t) requires detail::STLContainer<T> &&
+      detail::DoubleItemTuple<typename T::value_type> && std::convertible_to<
+          std::tuple_element_t<0, typename T::value_type>, key_type> &&
+      std::convertible_to<std::tuple_element_t<1, typename T::value_type>,
+                          mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -289,7 +277,7 @@ class array
           std::forward_as_tuple(
               index, m_local_vec[partitioner.local_index(index)], args...));
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "remote array lambda must be "
                     "invocable with (const "
                     "key_type, mapped_type &, ...) or "
@@ -432,7 +420,7 @@ class array
     } else if constexpr (std::is_invocable<decltype(fn), mapped_type&>()) {
       std::for_each(std::begin(m_local_vec), std::end(m_local_vec), fn);
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "local array lambda must be "
                     "invocable with (const "
                     "key_type, mapped_type &) or "

--- a/include/ygm/container/detail/base_async_contains.hpp
+++ b/include/ygm/container/detail/base_async_contains.hpp
@@ -15,8 +15,9 @@ namespace ygm::container::detail {
 template <typename derived_type, typename for_all_args>
 struct base_async_contains {
   template <typename Function, typename... FuncArgs>
-  void async_contains(const std::tuple_element<0, for_all_args>::type& value,
-                      Function fn, const FuncArgs&... args) {
+  void async_contains(
+      const typename std::tuple_element<0, for_all_args>::type& value,
+      Function fn, const FuncArgs&... args) {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Function,
                                       "ygm::container::async_contains()");
 
@@ -24,14 +25,15 @@ struct base_async_contains {
 
     int dest = derived_this->partitioner.owner(value);
 
-    auto lambda = [fn](auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& value,
-                       const FuncArgs&... args) mutable {
-      bool contains = static_cast<bool>(pcont->local_count(value));
-      ygm::meta::apply_optional(
-          fn, std::make_tuple(pcont),
-          std::forward_as_tuple(contains, value, args...));
-    };
+    auto lambda =
+        [fn](auto                                                      pcont,
+             const typename std::tuple_element<0, for_all_args>::type& value,
+             const FuncArgs&... args) mutable {
+          bool contains = static_cast<bool>(pcont->local_count(value));
+          ygm::meta::apply_optional(
+              fn, std::make_tuple(pcont),
+              std::forward_as_tuple(contains, value, args...));
+        };
 
     derived_this->comm().async(dest, lambda, derived_this->get_ygm_ptr(), value,
                                args...);

--- a/include/ygm/container/detail/base_async_erase.hpp
+++ b/include/ygm/container/detail/base_async_erase.hpp
@@ -13,19 +13,19 @@ namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
 struct base_async_erase_key {
-  void async_erase(
-      const typename std::tuple_element<0, for_all_args>::type& key)
-    requires AtLeastOneItemTuple<for_all_args>
+  void async_erase(const typename std::tuple_element<0, for_all_args>::type&
+                       key) requires AtLeastOneItemTuple<for_all_args>
 
   {
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto updater = [](auto                                             pcont,
-                      const std::tuple_element<0, for_all_args>::type& key) {
-      pcont->local_erase(key);
-    };
+    auto updater =
+        [](auto                                                      pcont,
+           const typename std::tuple_element<0, for_all_args>::type& key) {
+          pcont->local_erase(key);
+        };
 
     derived_this->comm().async(dest, updater, derived_this->get_ygm_ptr(), key);
   }
@@ -35,18 +35,18 @@ template <typename derived_type, typename for_all_args>
 struct base_async_erase_key_value {
   void async_erase(
       const typename std::tuple_element<0, for_all_args>::type& key,
-      const typename std::tuple_element<1, for_all_args>::type& value)
-    requires DoubleItemTuple<for_all_args>
-  {
+      const typename std::tuple_element<1, for_all_args>::type& value) requires
+      DoubleItemTuple<for_all_args> {
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto updater = [](auto                                             pcont,
-                      const std::tuple_element<0, for_all_args>::type& key,
-                      const std::tuple_element<1, for_all_args>::type& value) {
-      pcont->local_erase(key, value);
-    };
+    auto updater =
+        [](auto                                                      pcont,
+           const typename std::tuple_element<0, for_all_args>::type& key,
+           const typename std::tuple_element<1, for_all_args>::type& value) {
+          pcont->local_erase(key, value);
+        };
 
     derived_this->comm().async(dest, updater, derived_this->get_ygm_ptr(), key,
                                value);

--- a/include/ygm/container/detail/base_async_insert.hpp
+++ b/include/ygm/container/detail/base_async_insert.hpp
@@ -13,10 +13,8 @@ namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
 struct base_async_insert_value {
-  void async_insert(
-      const typename std::tuple_element<0, for_all_args>::type& value)
-    requires SingleItemTuple<for_all_args>
-  {
+  void async_insert(const typename std::tuple_element<0, for_all_args>::type&
+                        value) requires SingleItemTuple<for_all_args> {
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(value);
@@ -36,18 +34,18 @@ template <typename derived_type, typename for_all_args>
 struct base_async_insert_key_value {
   void async_insert(
       const typename std::tuple_element<0, for_all_args>::type& key,
-      const typename std::tuple_element<1, for_all_args>::type& value)
-    requires DoubleItemTuple<for_all_args>
-  {
+      const typename std::tuple_element<1, for_all_args>::type& value) requires
+      DoubleItemTuple<for_all_args> {
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto inserter = [](auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const std::tuple_element<1, for_all_args>::type& value) {
-      pcont->local_insert(key, value);
-    };
+    auto inserter =
+        [](auto                                                      pcont,
+           const typename std::tuple_element<0, for_all_args>::type& key,
+           const typename std::tuple_element<1, for_all_args>::type& value) {
+          pcont->local_insert(key, value);
+        };
 
     derived_this->comm().async(dest, inserter, derived_this->get_ygm_ptr(), key,
                                value);
@@ -55,9 +53,8 @@ struct base_async_insert_key_value {
 
   void async_insert(
       const std::pair<const typename std::tuple_element<0, for_all_args>::type,
-                      typename std::tuple_element<1, for_all_args>::type>& kvp)
-    requires DoubleItemTuple<for_all_args>
-  {
+                      typename std::tuple_element<1, for_all_args>::type>&
+          kvp) requires DoubleItemTuple<for_all_args> {
     async_insert(kvp.first, kvp.second);
   }
 };

--- a/include/ygm/container/detail/base_async_insert_or_assign.hpp
+++ b/include/ygm/container/detail/base_async_insert_or_assign.hpp
@@ -14,19 +14,19 @@ namespace ygm::container::detail {
 template <typename derived_type, typename for_all_args>
 struct base_async_insert_or_assign {
   void async_insert_or_assign(
-      const std::tuple_element<0, for_all_args>::type& key,
-      const std::tuple_element<1, for_all_args>::type& value)
-    requires DoubleItemTuple<for_all_args>
-  {
+      const typename std::tuple_element<0, for_all_args>::type& key,
+      const typename std::tuple_element<1, for_all_args>::type& value) requires
+      DoubleItemTuple<for_all_args> {
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto updater = [](auto                                             pcont,
-                      const std::tuple_element<0, for_all_args>::type& key,
-                      const std::tuple_element<1, for_all_args>::type& value) {
-      pcont->local_insert_or_assign(key, value);
-    };
+    auto updater =
+        [](auto                                                      pcont,
+           const typename std::tuple_element<0, for_all_args>::type& key,
+           const typename std::tuple_element<1, for_all_args>::type& value) {
+          pcont->local_insert_or_assign(key, value);
+        };
 
     derived_this->comm().async(dest, updater, derived_this->get_ygm_ptr(), key,
                                value);
@@ -34,9 +34,8 @@ struct base_async_insert_or_assign {
 
   void async_insert_or_assign(
       const std::pair<typename std::tuple_element<0, for_all_args>::type,
-                      typename std::tuple_element<1, for_all_args>::type>& kvp)
-    requires DoubleItemTuple<for_all_args>
-  {
+                      typename std::tuple_element<1, for_all_args>::type>&
+          kvp) requires DoubleItemTuple<for_all_args> {
     async_insert_or_assign(kvp.first, kvp.second);
   }
 };

--- a/include/ygm/container/detail/base_async_reduce.hpp
+++ b/include/ygm/container/detail/base_async_reduce.hpp
@@ -27,9 +27,10 @@ struct base_async_reduce {
     int dest = derived_this->partitioner.owner(key);
 
     auto rlambda =
-        [reducer](
-            auto pcont, const std::tuple_element<0, for_all_args>::type& key,
-            const std::tuple_element<1, for_all_args>::type& value) mutable {
+        [reducer](auto pcont,
+                  const typename std::tuple_element<0, for_all_args>::type& key,
+                  const typename std::tuple_element<1, for_all_args>::type&
+                      value) mutable {
           pcont->local_reduce(key, value, reducer);
         };
 

--- a/include/ygm/container/detail/base_async_visit.hpp
+++ b/include/ygm/container/detail/base_async_visit.hpp
@@ -16,22 +16,22 @@ namespace ygm::container::detail {
 template <typename derived_type, typename for_all_args>
 struct base_async_visit {
   template <typename Visitor, typename... VisitorArgs>
-  void async_visit(const std::tuple_element<0, for_all_args>::type& key,
-                   Visitor visitor, const VisitorArgs&... args)
-    requires DoubleItemTuple<for_all_args>
-  {
+  void async_visit(
+      const typename std::tuple_element<0, for_all_args>::type& key,
+      Visitor                                                   visitor,
+      const VisitorArgs&... args) requires DoubleItemTuple<for_all_args> {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(Visitor, "ygm::container::async_visit()");
 
     derived_type* derived_this = static_cast<derived_type*>(this);
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
-                       auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) mutable {
-      pcont->local_visit(key, visitor, args...);
-    };
+    auto vlambda =
+        [visitor](auto pcont,
+                  const typename std::tuple_element<0, for_all_args>::type& key,
+                  const VisitorArgs&... args) mutable {
+          pcont->local_visit(key, visitor, args...);
+        };
 
     derived_this->comm().async(dest, vlambda, derived_this->get_ygm_ptr(), key,
                                args...);
@@ -39,10 +39,9 @@ struct base_async_visit {
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
-      const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args)
-    requires DoubleItemTuple<for_all_args>
-  {
+      const typename std::tuple_element<0, for_all_args>::type& key,
+      Visitor                                                   visitor,
+      const VisitorArgs&... args) requires DoubleItemTuple<for_all_args> {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
         Visitor, "ygm::container::async_visit_if_contains()");
 
@@ -50,12 +49,12 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
-                       auto                                             pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) mutable {
-      pcont->local_visit_if_contains(key, visitor, args...);
-    };
+    auto vlambda =
+        [visitor](auto pcont,
+                  const typename std::tuple_element<0, for_all_args>::type& key,
+                  const VisitorArgs&... args) mutable {
+          pcont->local_visit_if_contains(key, visitor, args...);
+        };
 
     derived_this->comm().async(dest, vlambda, derived_this->get_ygm_ptr(), key,
                                args...);
@@ -63,10 +62,9 @@ struct base_async_visit {
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit_if_contains(
-      const std::tuple_element<0, for_all_args>::type& key, Visitor visitor,
-      const VisitorArgs&... args) const
-    requires DoubleItemTuple<for_all_args>
-  {
+      const typename std::tuple_element<0, for_all_args>::type& key,
+      Visitor                                                   visitor,
+      const VisitorArgs&... args) const requires DoubleItemTuple<for_all_args> {
     YGM_CHECK_ASYNC_LAMBDA_COMPLIANCE(
         Visitor, "ygm::container::async_visit_if_contains()");
 
@@ -74,12 +72,12 @@ struct base_async_visit {
 
     int dest = derived_this->partitioner.owner(key);
 
-    auto vlambda = [visitor](
-                       const auto                                       pcont,
-                       const std::tuple_element<0, for_all_args>::type& key,
-                       const VisitorArgs&... args) mutable {
-      pcont->local_visit_if_contains(key, visitor, args...);
-    };
+    auto vlambda =
+        [visitor](const auto pcont,
+                  const typename std::tuple_element<0, for_all_args>::type& key,
+                  const VisitorArgs&... args) mutable {
+          pcont->local_visit_if_contains(key, visitor, args...);
+        };
 
     derived_this->comm().async(dest, vlambda, derived_this->get_ygm_ptr(), key,
                                args...);

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -13,12 +13,13 @@ namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
 struct base_batch_erase_key {
-  using key_type = std::tuple_element_t<0, for_all_args>;
+  using key_type = typename std::tuple_element_t<0, for_all_args>;
 
   template <typename Container>
   void erase(const Container &cont) requires detail::HasForAll<Container> &&
       SingleItemTuple<typename Container::for_all_args> && std::convertible_to<
-          std::tuple_element_t<0, typename Container::for_all_args>, key_type> {
+          typename std::tuple_element_t<0, typename Container::for_all_args>,
+          key_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
     cont.for_all(
@@ -43,16 +44,16 @@ struct base_batch_erase_key {
 
 template <typename derived_type, typename for_all_args>
 struct base_batch_erase_key_value {
-  using key_type    = std::tuple_element_t<0, for_all_args>;
-  using mapped_type = std::tuple_element_t<1, for_all_args>;
+  using key_type    = typename std::tuple_element_t<0, for_all_args>;
+  using mapped_type = typename std::tuple_element_t<1, for_all_args>;
 
   template <typename Container>
   void erase(const Container &cont) requires HasForAll<Container> &&
       DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
-          std::tuple_element_t<0, typename Container::for_all_args>,
+          typename std::tuple_element_t<0, typename Container::for_all_args>,
           key_type> &&
       std::convertible_to<
-          std::tuple_element_t<1, typename Container::for_all_args>,
+          typename std::tuple_element_t<1, typename Container::for_all_args>,
           mapped_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
@@ -66,15 +67,15 @@ struct base_batch_erase_key_value {
   template <typename Container>
   void erase(const Container &cont) requires HasForAll<Container> &&
       SingleItemTuple<typename Container::for_all_args> && DoubleItemTuple<
-          std::tuple_element_t<0, typename Container::for_all_args>> &&
-      std::convertible_to<
-          std::tuple_element_t<
-              0, std::tuple_element_t<0, typename Container::for_all_args>>,
-          key_type> &&
-      std::convertible_to<
-          std::tuple_element_t<
-              1, std::tuple_element_t<0, typename Container::for_all_args>>,
-          mapped_type> {
+          typename std::tuple_element_t<0, typename Container::for_all_args>> &&
+      std::convertible_to<typename std::tuple_element_t<
+                              0, typename std::tuple_element_t<
+                                     0, typename Container::for_all_args>>,
+                          key_type> &&
+      std::convertible_to<typename std::tuple_element_t<
+                              1, typename std::tuple_element_t<
+                                     0, typename Container::for_all_args>>,
+                          mapped_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
     cont.for_all([derived_this](const auto &key_value) {
@@ -89,9 +90,10 @@ struct base_batch_erase_key_value {
   template <typename Container>
   void erase(const Container &cont) requires STLContainer<Container> &&
       DoubleItemTuple<typename Container::value_type> && std::convertible_to<
-          std::tuple_element_t<0, typename Container::value_type>, key_type> &&
+          typename std::tuple_element_t<0, typename Container::value_type>,
+          key_type> &&
       std::convertible_to<
-          std::tuple_element_t<1, typename Container::value_type>,
+          typename std::tuple_element_t<1, typename Container::value_type>,
           mapped_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
@@ -109,7 +111,8 @@ struct base_batch_erase_key_value {
   template <typename Container>
   void erase(const Container &cont) requires detail::HasForAll<Container> &&
       SingleItemTuple<typename Container::for_all_args> && std::convertible_to<
-          std::tuple_element_t<0, typename Container::for_all_args>, key_type> {
+          typename std::tuple_element_t<0, typename Container::for_all_args>,
+          key_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
     cont.for_all(

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -42,17 +42,27 @@ struct base_batch_erase_key {
   }
 };
 
+template <typename Container, typename KeyType, typename MappedType>
+concept ContainerofErasableTuples = HasForAll<Container> &&
+    DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
+        typename std::tuple_element_t<0, typename Container::for_all_args>,
+        KeyType> &&
+    std::convertible_to<
+        typename std::tuple_element_t<1, typename Container::for_all_args>,
+        MappedType>;
+
 template <typename derived_type, typename for_all_args>
 struct base_batch_erase_key_value {
   using key_type    = typename std::tuple_element_t<0, for_all_args>;
   using mapped_type = typename std::tuple_element_t<1, for_all_args>;
 
   template <typename Container>
-  void erase(const Container &cont) requires HasForAll<Container> &&
-      DoubleItemTuple<typename Container::for_all_args> /*&&
-      std::convertible_to< typename std::tuple_element_t<0, typename
-      Container::for_all_args>, key_type> && std::convertible_to< typename
-      std::tuple_element_t<1, typename Container::for_all_args>, mapped_type>*/
+  void erase(const Container &cont) requires ContainerofErasableTuples<
+      Container, key_type, mapped_type> /* HasForAll<Container> &&
+DoubleItemTuple<typename Container::for_all_args> &&
+std::convertible_to< typename std::tuple_element_t<0, typename
+Container::for_all_args>, key_type> && std::convertible_to< typename
+std::tuple_element_t<1, typename Container::for_all_args>, mapped_type>*/
   {
     derived_type *derived_this = static_cast<derived_type *>(this);
 

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -57,13 +57,15 @@ struct base_batch_erase_key_value {
   using mapped_type = typename std::tuple_element_t<1, for_all_args>;
 
   template <typename Container>
-  void erase(const Container &cont) requires ContainerofErasableTuples<
-      Container, key_type, mapped_type> /* HasForAll<Container> &&
-DoubleItemTuple<typename Container::for_all_args> &&
-std::convertible_to< typename std::tuple_element_t<0, typename
-Container::for_all_args>, key_type> && std::convertible_to< typename
-std::tuple_element_t<1, typename Container::for_all_args>, mapped_type>*/
-  {
+  void erase(const Container &cont) requires /* ContainerofErasableTuples<
+      Container, key_type, mapped_type> */
+      HasForAll<Container> &&
+      DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
+          typename std::tuple_element_t<0, typename Container::for_all_args>,
+          key_type> &&
+      std::convertible_to<
+          typename std::tuple_element_t<1, typename Container::for_all_args>,
+          mapped_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
     cont.for_all([derived_this](const auto &key, const auto &value) {

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -44,20 +44,16 @@ struct base_batch_erase_key {
 
 template <typename derived_type, typename for_all_args>
 struct base_batch_erase_key_value {
-  using key_type =
-      typename std::remove_cvref_t<std::tuple_element_t<0, for_all_args>>;
-  using mapped_type =
-      typename std::remove_cvref_t<std::tuple_element_t<1, for_all_args>>;
+  using key_type    = typename std::tuple_element_t<0, for_all_args>;
+  using mapped_type = typename std::tuple_element_t<1, for_all_args>;
 
   template <typename Container>
   void erase(const Container &cont) requires HasForAll<Container> &&
       DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
-          typename std::tuple_element_t<
-              0, std::remove_cvref_t<typename Container::for_all_args>>,
+          typename std::tuple_element_t<0, typename Container::for_all_args>,
           key_type> &&
       std::convertible_to<
-          typename std::tuple_element_t<
-              1, std::remove_cvref_t<typename Container::for_all_args>>,
+          typename std::tuple_element_t<1, typename Container::for_all_args>,
           mapped_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -52,10 +52,12 @@ struct base_batch_erase_key_value {
   template <typename Container>
   void erase(const Container &cont) requires HasForAll<Container> &&
       DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
-          typename std::tuple_element_t<0, typename Container::for_all_args>,
+          typename std::tuple_element_t<
+              0, std::remove_cvref_t<typename Container::for_all_args>>,
           key_type> &&
       std::convertible_to<
-          typename std::tuple_element_t<1, typename Container::for_all_args>,
+          typename std::tuple_element_t<
+              1, std::remove_cvref_t<typename Container::for_all_args>>,
           mapped_type> {
     derived_type *derived_this = static_cast<derived_type *>(this);
 

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -49,12 +49,11 @@ struct base_batch_erase_key_value {
 
   template <typename Container>
   void erase(const Container &cont) requires HasForAll<Container> &&
-      DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
-          typename std::tuple_element_t<0, typename Container::for_all_args>,
-          key_type> &&
-      std::convertible_to<
-          typename std::tuple_element_t<1, typename Container::for_all_args>,
-          mapped_type> {
+      DoubleItemTuple<typename Container::for_all_args> /*&&
+      std::convertible_to< typename std::tuple_element_t<0, typename
+      Container::for_all_args>, key_type> && std::convertible_to< typename
+      std::tuple_element_t<1, typename Container::for_all_args>, mapped_type>*/
+  {
     derived_type *derived_this = static_cast<derived_type *>(this);
 
     cont.for_all([derived_this](const auto &key, const auto &value) {

--- a/include/ygm/container/detail/base_batch_erase.hpp
+++ b/include/ygm/container/detail/base_batch_erase.hpp
@@ -42,24 +42,15 @@ struct base_batch_erase_key {
   }
 };
 
-template <typename Container, typename KeyType, typename MappedType>
-concept ContainerofErasableTuples = HasForAll<Container> &&
-    DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
-        typename std::tuple_element_t<0, typename Container::for_all_args>,
-        KeyType> &&
-    std::convertible_to<
-        typename std::tuple_element_t<1, typename Container::for_all_args>,
-        MappedType>;
-
 template <typename derived_type, typename for_all_args>
 struct base_batch_erase_key_value {
-  using key_type    = typename std::tuple_element_t<0, for_all_args>;
-  using mapped_type = typename std::tuple_element_t<1, for_all_args>;
+  using key_type =
+      typename std::remove_cvref_t<std::tuple_element_t<0, for_all_args>>;
+  using mapped_type =
+      typename std::remove_cvref_t<std::tuple_element_t<1, for_all_args>>;
 
   template <typename Container>
-  void erase(const Container &cont) requires /* ContainerofErasableTuples<
-      Container, key_type, mapped_type> */
-      HasForAll<Container> &&
+  void erase(const Container &cont) requires HasForAll<Container> &&
       DoubleItemTuple<typename Container::for_all_args> && std::convertible_to<
           typename std::tuple_element_t<0, typename Container::for_all_args>,
           key_type> &&

--- a/include/ygm/container/detail/base_count.hpp
+++ b/include/ygm/container/detail/base_count.hpp
@@ -13,7 +13,8 @@ namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
 struct base_count {
-  size_t count(const std::tuple_element<0, for_all_args>::type& value) const {
+  size_t count(
+      const typename std::tuple_element<0, for_all_args>::type& value) const {
     const derived_type* derived_this = static_cast<const derived_type*>(this);
     derived_this->comm().barrier();
     return ygm::sum(derived_this->local_count(value), derived_this->comm());

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -420,7 +420,7 @@ class disjoint_set_impl {
                   std::forward_as_tuple(orig_a, orig_b, true, args...));
             } else {
               static_assert(
-                  ygm::detail::always_false<>,
+                  ygm::detail::always_false<Function>,
                   "remote disjoint_set lambda signature must be invocable "
                   "with (const value_type &, const value_type &, const bool) "
                   "signature");
@@ -464,7 +464,7 @@ class disjoint_set_impl {
                     std::forward_as_tuple(orig_a, orig_b, true, args...));
               } else {
                 static_assert(
-                    ygm::detail::always_false<>,
+                    ygm::detail::always_false<Function>,
                     "remote disjoint_set lambda signature must be invocable "
                     "with (const value_type &, const value_type &, const bool) "
                     "signature");
@@ -621,7 +621,7 @@ class disjoint_set_impl {
         fn(item, item_data.get_parent());
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "local disjoint_set lambda signature must be invocable "
                     "with (const value_type &, const value_type &) signature");
     }

--- a/include/ygm/container/detail/flatten_proxy.hpp
+++ b/include/ygm/container/detail/flatten_proxy.hpp
@@ -10,18 +10,18 @@ namespace ygm::container::detail {
 template <typename Container>
 class flatten_proxy_value
     : public base_iteration_value<flatten_proxy_value<Container>,
-                                  std::tuple<std::tuple_element_t<
+                                  std::tuple<typename std::tuple_element_t<
                                       0, typename Container::for_all_args>>> {
  public:
-  using for_all_args =
-      std::tuple<std::tuple_element_t<0, typename Container::for_all_args>>;
+  using for_all_args = std::tuple<
+      typename std::tuple_element_t<0, typename Container::for_all_args>>;
 
   flatten_proxy_value(Container& rc) : m_rcontainer(rc) {}
 
   template <typename Function>
   void for_all(Function fn) {
     auto flambda =
-        [fn](std::tuple_element_t<0, typename Container::for_all_args>&
+        [fn](typename std::tuple_element_t<0, typename Container::for_all_args>&
                  stlcont) {
           for (auto& v : stlcont) {
             fn(v);
@@ -34,7 +34,7 @@ class flatten_proxy_value
   template <typename Function>
   void for_all(Function fn) const {
     auto flambda =
-        [fn](std::tuple_element_t<0, typename Container::for_all_args>&
+        [fn](typename std::tuple_element_t<0, typename Container::for_all_args>&
                  stlcont) {
           for (const auto& v : stlcont) {
             fn(v);
@@ -53,21 +53,20 @@ class flatten_proxy_value
 };
 
 template <typename Container>
-class flatten_proxy_key_value
-    : public base_iteration_key_value<
-          flatten_proxy_value<Container>,
-          std::tuple<
-              std::tuple_element_t<0, typename Container::for_all_args>>> {
+class flatten_proxy_key_value : public base_iteration_key_value<
+                                    flatten_proxy_value<Container>,
+                                    std::tuple<typename std::tuple_element_t<
+                                        0, typename Container::for_all_args>>> {
  public:
-  using for_all_args =
-      std::tuple<std::tuple_element_t<0, typename Container::for_all_args>>;
+  using for_all_args = std::tuple<
+      typename std::tuple_element_t<0, typename Container::for_all_args>>;
 
   flatten_proxy_key_value(Container& rc) : m_rcontainer(rc) {}
 
   template <typename Function>
   void for_all(Function fn) {
     auto flambda =
-        [fn](std::tuple_element_t<0, typename Container::for_all_args>&
+        [fn](typename std::tuple_element_t<0, typename Container::for_all_args>&
                  stlcont) {
           for (auto& v : stlcont) {
             fn(v);
@@ -80,7 +79,7 @@ class flatten_proxy_key_value
   template <typename Function>
   void for_all(Function fn) const {
     auto flambda =
-        [fn](std::tuple_element_t<0, typename Container::for_all_args>&
+        [fn](typename std::tuple_element_t<0, typename Container::for_all_args>&
                  stlcont) {
           for (const auto& v : stlcont) {
             fn(v);

--- a/include/ygm/container/detail/reducing_adapter.hpp
+++ b/include/ygm/container/detail/reducing_adapter.hpp
@@ -105,7 +105,7 @@ class reducing_adapter {
                              Container, ygm::container::array_tag>()) {
       m_container.async_binary_op_update_value(key, value, m_reducer);
     } else {
-      static_assert(ygm::detail::always_false<Function>,
+      static_assert(ygm::detail::always_false<ReductionOp>,
                     "Container unsuitable for reducing_adapter");
     }
   }

--- a/include/ygm/container/detail/reducing_adapter.hpp
+++ b/include/ygm/container/detail/reducing_adapter.hpp
@@ -105,7 +105,7 @@ class reducing_adapter {
                              Container, ygm::container::array_tag>()) {
       m_container.async_binary_op_update_value(key, value, m_reducer);
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "Container unsuitable for reducing_adapter");
     }
   }

--- a/include/ygm/container/detail/transform_proxy.hpp
+++ b/include/ygm/container/detail/transform_proxy.hpp
@@ -25,7 +25,8 @@ class transform_proxy_value
                           std::declval<typename Container::for_all_args>()));
 
  public:
-  using for_all_args = type_traits::tuple_wrapper<map_function_ret>::type;
+  using for_all_args =
+      typename type_traits::tuple_wrapper<map_function_ret>::type;
 
   transform_proxy_value(Container& rc, MapFunction filter)
       : m_rcontainer(rc), m_map_fn(filter) {}
@@ -80,7 +81,8 @@ class transform_proxy_key_value
                           std::declval<typename Container::for_all_args>()));
 
  public:
-  using for_all_args = type_traits::tuple_wrapper<map_function_ret>::type;
+  using for_all_args =
+      typename type_traits::tuple_wrapper<map_function_ret>::type;
 
   transform_proxy_key_value(Container& rc, MapFunction filter)
       : m_rcontainer(rc), m_map_fn(filter) {}

--- a/include/ygm/container/detail/type_traits.hpp
+++ b/include/ygm/container/detail/type_traits.hpp
@@ -25,8 +25,8 @@ struct is_tuple
     : is_specialization_of<std::tuple, typename std::decay<T>::type> {};
 
 template <typename T>
-struct is_pair
-    : is_specialization_of<std::pair, typename std::decay<T>::type> {};
+struct is_pair : is_specialization_of<std::pair, typename std::decay<T>::type> {
+};
 
 template <class T, bool isTuple>
 struct tuple_wrapper_helper  // T is not a tuple
@@ -43,6 +43,6 @@ struct tuple_wrapper_helper<T, true>  // T is a tuple
 template <class T>
 struct tuple_wrapper  // T is a tuple
 {
-  using type = tuple_wrapper_helper<T, is_tuple<T>::value>::type;
+  using type = typename tuple_wrapper_helper<T, is_tuple<T>::value>::type;
 };
 }  // namespace ygm::container::detail::type_traits

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -578,7 +578,7 @@ class multimap
         fn(kv.first, kv.second);
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "local map lambda signature must be invocable with (const "
                     "&key_type, mapped_type&) signature");
     }
@@ -592,7 +592,7 @@ class multimap
         fn(kv.first, kv.second);
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "local map lambda signature must be invocable with (const "
                     "&key_type, mapped_type&) signature");
     }

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -79,10 +79,10 @@ class map
   }
 
   template <typename STLContainer>
-  map(ygm::comm& comm, const STLContainer& cont)
-    requires detail::STLContainer<STLContainer> &&
-                 std::convertible_to<typename STLContainer::value_type,
-                                     std::pair<Key, Value>>
+  map(ygm::comm&          comm,
+      const STLContainer& cont) requires detail::STLContainer<STLContainer> &&
+      std::convertible_to<typename STLContainer::value_type,
+                          std::pair<Key, Value>>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
@@ -94,9 +94,9 @@ class map
   }
 
   template <typename YGMContainer>
-  map(ygm::comm& comm, const YGMContainer& yc)
-    requires detail::HasForAll<YGMContainer> &&
-                 detail::SingleItemTuple<typename YGMContainer::for_all_args>
+  map(ygm::comm&          comm,
+      const YGMContainer& yc) requires detail::HasForAll<YGMContainer> &&
+      detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
@@ -181,7 +181,7 @@ class map
             std::forward_as_tuple(itr->first, itr->second, args...));
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "remote map lambda signature must be invocable with (const "
                     "&key_type, mapped_type&, ...) or (ptr_type, const "
                     "&key_type, mapped_type&, ...) signatures");
@@ -203,7 +203,7 @@ class map
             std::forward_as_tuple(itr->first, itr->second, args...));
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "remote map lambda signature must be invocable with (const "
                     "&key_type, mapped_type&, ...) or (ptr_type, const "
                     "&key_type, mapped_type&, ...) signatures");
@@ -254,7 +254,7 @@ class map
         fn(kv.first, kv.second);
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "local map lambda signature must be invocable with (const "
                     "key_type&, mapped_type&) signature");
     }
@@ -268,7 +268,7 @@ class map
         fn(kv.first, kv.second);
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "local map lambda signature must be invocable with (const "
                     "key_type&, const mapped_type&) signature");
     }
@@ -413,10 +413,9 @@ class multimap
   }
 
   template <typename STLContainer>
-  multimap(ygm::comm& comm, const STLContainer& cont)
-    requires detail::STLContainer<STLContainer> &&
-                 std::convertible_to<typename STLContainer::value_type,
-                                     std::pair<Key, Value>>
+  multimap(ygm::comm& comm, const STLContainer& cont) requires
+      detail::STLContainer<STLContainer> && std::convertible_to<
+          typename STLContainer::value_type, std::pair<Key, Value>>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
@@ -428,9 +427,9 @@ class multimap
   }
 
   template <typename YGMContainer>
-  multimap(ygm::comm& comm, const YGMContainer& yc)
-    requires detail::HasForAll<YGMContainer> &&
-                 detail::SingleItemTuple<typename YGMContainer::for_all_args>
+  multimap(ygm::comm&          comm,
+           const YGMContainer& yc) requires detail::HasForAll<YGMContainer> &&
+      detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
@@ -506,7 +505,7 @@ class multimap
             std::forward_as_tuple(itr->first, itr->second, args...));
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "remote map lambda signature must be invocable with (const "
                     "&key_type, mapped_type&, ...) or (ptr_type, const "
                     "&key_type, mapped_type&, ...) signatures");
@@ -528,7 +527,7 @@ class multimap
             std::forward_as_tuple(itr->first, itr->second, args...));
       }
     } else {
-      static_assert(ygm::detail::always_false<>,
+      static_assert(ygm::detail::always_false<Function>,
                     "remote map lambda signature must be invocable with (const "
                     "&key_type, mapped_type&, ...) or (ptr_type, const "
                     "&key_type, mapped_type&, ...) signatures");

--- a/include/ygm/detail/mpi.hpp
+++ b/include/ygm/detail/mpi.hpp
@@ -26,7 +26,7 @@ class mpi_init_finalize {
 
 template <typename T>
 inline MPI_Datatype mpi_typeof(T) {
-  static_assert(always_false<>, "Unknown MPI Type");
+  static_assert(always_false<T>, "Unknown MPI Type");
   return 0;
 }
 
@@ -50,7 +50,8 @@ inline MPI_Datatype mpi_typeof(std::signed_integral auto t) {
   } else if constexpr (sizeof(t) == 8) {
     return MPI_INT64_T;
   } else {
-    static_assert(always_false<>, "Invalid integer size for MPI Type");
+    static_assert(always_false<decltype(t)>,
+                  "Invalid integer size for MPI Type");
   }
 }
 
@@ -64,7 +65,8 @@ inline MPI_Datatype mpi_typeof(std::unsigned_integral auto t) {
   } else if constexpr (sizeof(t) == 8) {
     return MPI_UINT64_T;
   } else {
-    static_assert(always_false<>, "Invalid integer size for MPI Type");
+    static_assert(always_false<decltype(t)>,
+                  "Invalid integer size for MPI Type");
   }
 }
 


### PR DESCRIPTION
Requires switching to `macos-15` runners to get YGM to compile. CMake is unable to get a working `mpicxx` when using `g++-12` on these runners, so it has been removed for now.