### PR TITLE
YGM Container All-Gather

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -85,8 +85,19 @@ class comm {
   void async_bcast(AsyncFunction fn, const SendArgs &...args);
 
   template <typename AsyncFunction, typename... SendArgs>
+  void async_bcast(AsyncFunction fn, const SendArgs &...args) const {
+    const_cast<comm *>(this)->async_bcast(fn, args...);
+  }
+
+  template <typename AsyncFunction, typename... SendArgs>
   void async_mcast(const std::vector<int> &dests, AsyncFunction fn,
                    const SendArgs &...args);
+
+  template <typename AsyncFunction, typename... SendArgs>
+  void async_mcast(const std::vector<int> &dests, AsyncFunction fn,
+                   const SendArgs &...args) const {
+    const_cast<comm *>(this)->async_mcast(dests, fn, args...);
+  }
 
   //
   // Collective operations across all ranks.  Cannot be called inside OpenMP

--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -49,22 +49,31 @@ struct base_iteration_value {
   void gather(STLContainer& gto, int rank) const {
     static_assert(
         std::is_same_v<typename STLContainer::value_type, value_type>);
-    // TODO, make an all gather version that defaults to rank = -1 & uses a temp
-    // container.
     bool                 all_gather   = (rank == -1);
     static STLContainer* spgto        = &gto;
     const auto*          derived_this = static_cast<const derived_type*>(this);
     const ygm::comm&     mycomm       = derived_this->comm();
 
-    auto glambda = [&mycomm, rank](const auto& value) {
-      mycomm.async(
-          rank, [](const auto& value) { generic_insert(*spgto, value); },
-          value);
+    auto glambda = [&mycomm, rank, all_gather](const auto& value) {
+      auto insert_lambda = [](const auto& value) {
+        generic_insert(*spgto, value);
+      };
+
+      if (all_gather) {
+        mycomm.async_bcast(insert_lambda, value);
+      } else {
+        mycomm.async(rank, insert_lambda, value);
+      }
     };
 
     derived_this->for_all(glambda);
 
     derived_this->comm().barrier();
+  }
+
+  template <typename STLContainer>
+  void gather(STLContainer& gto) const {
+    gather(gto, -1);
   }
 
   template <typename Compare = std::greater<value_type>>
@@ -204,27 +213,35 @@ struct base_iteration_key_value {
   template <typename STLContainer>
   void gather(STLContainer& gto, int rank) const {
     static_assert(std::is_same_v<typename STLContainer::value_type,
-                                 std::pair<key_type, mapped_type>>);
-    // TODO, make an all gather version that defaults to rank = -1 & uses a temp
-    // container.
+                                 std::pair<key_type, mapped_type>> ||
+                  std::is_same_v<typename STLContainer::value_type,
+                                 std::pair<const key_type, mapped_type>>);
     bool                 all_gather   = (rank == -1);
     static STLContainer* spgto        = &gto;
     const derived_type*  derived_this = static_cast<const derived_type*>(this);
     const ygm::comm&     mycomm       = derived_this->comm();
 
-    auto glambda = [&mycomm, rank](const key_type&    key,
-                                   const mapped_type& value) {
-      mycomm.async(
-          rank,
-          [](const key_type& key, const mapped_type& value) {
-            generic_insert(*spgto, std::make_pair(key, value));
-          },
-          key, value);
+    auto glambda = [&mycomm, rank, all_gather](const key_type&    key,
+                                               const mapped_type& value) {
+      auto insert_lambda = [](const key_type& key, const mapped_type& value) {
+        generic_insert(*spgto, std::make_pair(key, value));
+      };
+
+      if (all_gather) {
+        mycomm.async_bcast(insert_lambda, key, value);
+      } else {
+        mycomm.async(rank, insert_lambda, key, value);
+      }
     };
 
     derived_this->for_all(glambda);
 
     derived_this->comm().barrier();
+  }
+
+  template <typename STLContainer>
+  void gather(STLContainer& gto) const {
+    gather(gto, -1);
   }
 
   template <typename Compare = std::greater<std::pair<key_type, mapped_type>>>
@@ -356,7 +373,6 @@ struct base_iteration_key_value {
 };
 
 }  // namespace ygm::container::detail
-
 #include <ygm/container/detail/filter_proxy.hpp>
 #include <ygm/container/detail/flatten_proxy.hpp>
 #include <ygm/container/detail/transform_proxy.hpp>

--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -50,9 +50,10 @@ struct base_iteration_value {
     static_assert(
         std::is_same_v<typename STLContainer::value_type, value_type>);
     bool                 all_gather   = (rank == -1);
-    static STLContainer* spgto        = &gto;
     const auto*          derived_this = static_cast<const derived_type*>(this);
     const ygm::comm&     mycomm       = derived_this->comm();
+    static STLContainer* spgto;
+    spgto = &gto;
 
     auto glambda = [&mycomm, rank, all_gather](const auto& value) {
       auto insert_lambda = [](const auto& value) {
@@ -217,9 +218,10 @@ struct base_iteration_key_value {
                   std::is_same_v<typename STLContainer::value_type,
                                  std::pair<const key_type, mapped_type>>);
     bool                 all_gather   = (rank == -1);
-    static STLContainer* spgto        = &gto;
     const derived_type*  derived_this = static_cast<const derived_type*>(this);
     const ygm::comm&     mycomm       = derived_this->comm();
+    static STLContainer* spgto;
+    spgto = &gto;
 
     auto glambda = [&mycomm, rank, all_gather](const key_type&    key,
                                                const mapped_type& value) {

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -799,8 +799,6 @@ inline void comm::pack_lambda_broadcast(Lambda l, const PackArgs &...args) {
   auto forward_remote_and_dispatch_lambda = [](comm                    *c,
                                                cereal::YGMInputArchive *bia,
                                                Lambda                   l) {
-    Lambda *pl = nullptr;
-
     std::tuple<PackArgs...> ta;
     if constexpr (!std::is_empty<std::tuple<PackArgs...>>::value) {
       (*bia)(ta);

--- a/test/test_bag.cpp
+++ b/test/test_bag.cpp
@@ -25,8 +25,6 @@ int main(int argc, char** argv) {
     static_assert(std::is_same_v<decltype(bbag)::for_all_args,
                                  std::tuple<decltype(bbag)::value_type>>);
   }
-  
-
 
   //
   // Test Rank 0 async_insert
@@ -116,10 +114,8 @@ int main(int argc, char** argv) {
 
     ygm::container::bag<std::string> bbag3 = std::move(bbag);
     YGM_ASSERT_RELEASE(bbag.size() == 0);
-    YGM_ASSERT_RELEASE(bbag3.size() == 3);  
+    YGM_ASSERT_RELEASE(bbag3.size() == 3);
   }
-
-
 
   //
   // Test all ranks async_insert
@@ -146,6 +142,16 @@ int main(int argc, char** argv) {
       if (world.rank0()) {
         YGM_ASSERT_RELEASE(all_data.size() == 3);
       }
+    }
+    {
+      std::vector<std::string> all_data;
+      bbag.gather(all_data);
+      YGM_ASSERT_RELEASE(all_data.size() == 3 * (size_t)world.size());
+    }
+    {
+      std::set<std::string> all_data;
+      bbag.gather(all_data);
+      YGM_ASSERT_RELEASE(all_data.size() == 3);
     }
   }
 
@@ -295,10 +301,10 @@ int main(int argc, char** argv) {
     bbag.gather(value_set, 0);
     if (world.rank0()) {
       YGM_ASSERT_RELEASE(value_set.size() == 200);
-      YGM_ASSERT_RELEASE(*std::min_element(value_set.begin(), value_set.end()) ==
-                     0);
-      YGM_ASSERT_RELEASE(*std::max_element(value_set.begin(), value_set.end()) ==
-                     199);
+      YGM_ASSERT_RELEASE(
+          *std::min_element(value_set.begin(), value_set.end()) == 0);
+      YGM_ASSERT_RELEASE(
+          *std::max_element(value_set.begin(), value_set.end()) == 199);
     }
   }
 
@@ -349,6 +355,4 @@ int main(int argc, char** argv) {
       YGM_ASSERT_RELEASE(vec_bags[bag_index].size() == world.size() * 2);
     }
   }
-
-
 }

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -488,5 +488,34 @@ int main(int argc, char **argv) {
     YGM_ASSERT_RELEASE(smap2.count("red") == 1);
   }
 
+  //
+  // Test gather
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+
+    smap.async_insert("dog", "cat");
+    smap.async_insert("apple", "orange");
+    smap.async_insert("red", "green");
+
+    {
+      std::map<std::string, std::string> local_map;
+      smap.gather(local_map, 0);
+      if (world.rank0()) {
+        YGM_ASSERT_RELEASE(local_map.size() == 3);
+        YGM_ASSERT_RELEASE(local_map["dog"] == "cat");
+        YGM_ASSERT_RELEASE(local_map["apple"] == "orange");
+        YGM_ASSERT_RELEASE(local_map["red"] == "green");
+      }
+    }
+    {
+      std::map<std::string, std::string> local_map;
+      smap.gather(local_map);
+      YGM_ASSERT_RELEASE(local_map.size() == 3);
+      YGM_ASSERT_RELEASE(local_map["dog"] == "cat");
+      YGM_ASSERT_RELEASE(local_map["apple"] == "orange");
+      YGM_ASSERT_RELEASE(local_map["red"] == "green");
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
Allows `ygm::container::detail::base_iteration::gather()` to gather values on all ranks using `async_bcast`. Makes this the default behavior when a rank to gather to is not provided.