### PR TITLE
Support node-local path in parquet reader

### DIFF
--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -51,10 +51,7 @@ jobs:
           $COMPILER --version
           mkdir build
           cd build
-          if [ "$ENABLE_PARQUET_TEST" ]; then
-            ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
-          fi
-          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
+          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=~/boost_1_77_0 -DYGM_INSTALL_PARQUET=OFF
           make -j3
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -45,12 +45,6 @@ jobs:
           cd ~
           wget --no-verbose https://archives.boost.io/release/1.77.0/source/boost_1_77_0.tar.bz2
           tar -xjf boost_1_77_0.tar.bz2
-      - name: Install Apache Arrow
-        run: |
-          python -m pip install pyarrow==16.1.*
-          PIP_PYARROW_ROOT=$(python -c "import pyarrow as pa; print(pa.get_library_dirs()[0])")
-          echo "PIP_PYARROW_ROOT=${PIP_PYARROW_ROOT}" >> $GITHUB_ENV
-          echo "ENABLE_PARQUET_TEST=true" >> $GITHUB_ENV
       - name: Install mpich
         if: matrix.mpi-type == 'mpich'
         run: sudo apt-get install mpich
@@ -67,10 +61,7 @@ jobs:
           ${{ matrix.compiler }} --version
           mkdir build
           cd build
-          if [ "$ENABLE_PARQUET_TEST" ]; then
-            ARROW_CMAKE_OPTION="-DPIP_PYARROW_ROOT=$PIP_PYARROW_ROOT -DYGM_REQUIRE_PARQUET=ON"
-          fi
-          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DBOOST_ROOT=~/boost_1_77_0 ${ARROW_CMAKE_OPTION}
+          cmake ../ -DYGM_BUILD_TESTS=On -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DBOOST_ROOT=~/boost_1_77_0 -DYGM_INSTALL_PARQUET=ON
           make -j4
       - name: Make test (mpich)
         if: matrix.mpi-type == 'mpich'


### PR DESCRIPTION
I was able to confirm the new node-local path support by manually checking. I still need to implement some tests for local path patterns.