### PR TITLE
Feature/copy constructors

### DIFF
--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -267,7 +267,7 @@ class array
         m_default_value(other.m_default_value),
         m_local_vec(other.m_local_vec),
         partitioner(other.m_comm, other.m_global_size) {
-    m_comm.log(log_level::info, "Creating ygm::container::array");
+    m_comm.log(log_level::info, "Copying ygm::container::array");
     pthis.check(m_comm);
   }
 
@@ -278,7 +278,7 @@ class array
         m_default_value(other.m_default_value),
         m_local_vec(std::move(other.m_local_vec)),
         partitioner(other.comm(), other.m_global_size) {
-    m_comm.log(log_level::info, "Creating ygm::container::array");
+    m_comm.log(log_level::info, "Moving ygm::container::array");
     pthis.check(m_comm);
 
     other.m_global_size = 0;

--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -121,22 +121,11 @@ class array
     m_comm.barrier();
   }
 
-  array(const self_type& rhs)
-      : m_comm(rhs.m_comm),
-        pthis(this),
-        m_global_size(rhs.m_global_size),
-        m_default_value(rhs.m_default_value),
-        m_local_vec(rhs.m_local_vec),
-        partitioner(rhs.m_comm, rhs.m_global_size) {
-    m_comm.log(log_level::info, "Creating ygm::container::array");
-    pthis.check(m_comm);
-    resize(m_global_size);
-  }
-
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
-      detail::SingleItemTuple<typename T::for_all_args> &&
-      std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
+  array(ygm::comm& comm, const T& t)
+    requires detail::HasForAll<T> &&
+                 detail::SingleItemTuple<typename T::for_all_args> &&
+                 std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -153,17 +142,19 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
-      detail::SingleItemTuple<typename T::for_all_args> && detail::
-          DoubleItemTuple<std::tuple_element_t<0, typename T::for_all_args>> &&
-      std::convertible_to<
-          std::tuple_element_t<
-              0, std::tuple_element_t<0, typename T::for_all_args>>,
-          key_type> &&
-      std::convertible_to<
-          std::tuple_element_t<
-              1, std::tuple_element_t<0, typename T::for_all_args>>,
-          mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::HasForAll<T> &&
+                 detail::SingleItemTuple<typename T::for_all_args> &&
+                 detail::DoubleItemTuple<
+                     std::tuple_element_t<0, typename T::for_all_args>> &&
+                 std::convertible_to<
+                     std::tuple_element_t<
+                         0, std::tuple_element_t<0, typename T::for_all_args>>,
+                     key_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<
+                         1, std::tuple_element_t<0, typename T::for_all_args>>,
+                     mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -185,11 +176,15 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::HasForAll<T> &&
-      detail::DoubleItemTuple<typename T::for_all_args> && std::convertible_to<
-          std::tuple_element_t<0, typename T::for_all_args>, key_type> &&
-      std::convertible_to<std::tuple_element_t<0, typename T::for_all_args>,
-                          mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::HasForAll<T> &&
+                 detail::DoubleItemTuple<typename T::for_all_args> &&
+                 std::convertible_to<
+                     std::tuple_element_t<0, typename T::for_all_args>,
+                     key_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<0, typename T::for_all_args>,
+                     mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -211,9 +206,10 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::STLContainer<T> &&
-      (not detail::SingleItemTuple<typename T::value_type>)&&std::
-          convertible_to<typename T::value_type, mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::STLContainer<T> &&
+                 (not detail::SingleItemTuple<typename T::value_type>) &&
+                 std::convertible_to<typename T::value_type, mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -232,11 +228,15 @@ class array
   }
 
   template <typename T>
-  array(ygm::comm& comm, const T& t) requires detail::STLContainer<T> &&
-      detail::DoubleItemTuple<typename T::value_type> && std::convertible_to<
-          std::tuple_element_t<0, typename T::value_type>, key_type> &&
-      std::convertible_to<std::tuple_element_t<1, typename T::value_type>,
-                          mapped_type>
+  array(ygm::comm& comm, const T& t)
+    requires detail::STLContainer<T> &&
+                 detail::DoubleItemTuple<typename T::value_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<0, typename T::value_type>,
+                     key_type> &&
+                 std::convertible_to<
+                     std::tuple_element_t<1, typename T::value_type>,
+                     mapped_type>
       : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -258,6 +258,57 @@ class array
   ~array() {
     m_comm.barrier();
     m_comm.log(log_level::info, "Destroying ygm::container::array");
+  }
+
+  array(const self_type& other)
+      : m_comm(other.comm()),
+        pthis(this),
+        m_global_size(other.m_global_size),
+        m_default_value(other.m_default_value),
+        m_local_vec(other.m_local_vec),
+        partitioner(other.m_comm, other.m_global_size) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
+    pthis.check(m_comm);
+  }
+
+  array(self_type&& other) noexcept
+      : m_comm(other.comm()),
+        pthis(this),
+        m_global_size(other.m_global_size),
+        m_default_value(other.m_default_value),
+        m_local_vec(std::move(other.m_local_vec)),
+        partitioner(other.comm(), other.m_global_size) {
+    m_comm.log(log_level::info, "Creating ygm::container::array");
+    pthis.check(m_comm);
+
+    other.m_global_size = 0;
+  }
+
+  array& operator=(const self_type& other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::array copy assignment operator");
+    resize(other.m_global_size);
+    m_default_value = other.m_default_value;
+    m_local_vec     = other.m_local_vec;
+
+    return *this;
+  }
+
+  array& operator=(self_type&& other) noexcept {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::array move assignment operator");
+    m_global_size   = other.m_global_size;
+    m_default_value = other.m_default_value;
+    partitioner = detail::block_partitioner<key_type>(m_comm, m_global_size);
+
+    std::swap(m_local_vec, other.m_local_vec);
+
+    if (other.m_local_vec.size() > 0) {
+      other.m_local_vec.clear();
+    }
+    other.m_global_size = 0;
+
+    return *this;
   }
 
   void local_insert(const key_type& key, const mapped_type& value) {

--- a/include/ygm/container/bag.hpp
+++ b/include/ygm/container/bag.hpp
@@ -82,7 +82,7 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
     m_comm.barrier();
   }
 
-  bag(const self_type &other)  // If I remove const it compiles
+  bag(const self_type &other)
       : m_comm(other.comm()), pthis(this), partitioner(other.comm()) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);

--- a/include/ygm/container/bag.hpp
+++ b/include/ygm/container/bag.hpp
@@ -83,7 +83,10 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   }
 
   bag(const self_type &other)
-      : m_comm(other.comm()), pthis(this), partitioner(other.comm()) {
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_local_bag(other.m_local_bag) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
   }

--- a/include/ygm/container/counting_set.hpp
+++ b/include/ygm/container/counting_set.hpp
@@ -87,6 +87,40 @@ class counting_set
     m_comm.log(log_level::info, "Destroying ygm::container::counting_set");
   }
 
+  counting_set(const self_type &other)
+      : m_comm(other.comm()),
+        pthis(this),
+        m_count_cache(other.m_count_cache),
+        m_cache_empty(other.m_cache_empty),
+        m_map(other.m_map) {
+    m_comm.log(log_level::info, "Copying ygm::container::counting_set");
+    pthis.check(m_comm);
+  }
+
+  counting_set(self_type &&other)
+      : m_comm(other.comm()),
+        pthis(this),
+        m_count_cache(std::move(other.m_count_cache)),
+        m_cache_empty(other.m_cache_empty),
+        m_map(std::move(other.m_map)) {
+    m_comm.log(log_level::info, "Moving ygm::container::counting_set");
+    pthis.check(m_comm);
+  }
+
+  counting_set &operator=(const self_type &other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::counting_set copy assignment operator");
+    return *this = counting_set(other);
+  }
+
+  counting_set &operator=(self_type &&other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::counting_set move assignment operator");
+    std::swap(m_count_cache, other.m_count_cache);
+    m_map = std::move(other.m_map);
+    return *this;
+  }
+
   void async_insert(const key_type &key) { cache_insert(key); }
 
   template <typename Function>

--- a/include/ygm/container/detail/base_misc.hpp
+++ b/include/ygm/container/detail/base_misc.hpp
@@ -29,9 +29,7 @@ struct base_misc {
     derived_this->local_swap(other);
   }
 
-  ygm::comm& comm() { return static_cast<derived_type*>(this)->m_comm; }
-
-  const ygm::comm& comm() const {
+  ygm::comm& comm() const {
     return static_cast<const derived_type*>(this)->m_comm;
   }
 

--- a/include/ygm/container/detail/round_robin_partitioner.hpp
+++ b/include/ygm/container/detail/round_robin_partitioner.hpp
@@ -8,7 +8,7 @@
 namespace ygm::container::detail {
 
 struct round_robin_partitioner {
-  round_robin_partitioner(ygm::comm &comm)
+  round_robin_partitioner(const ygm::comm &comm)
       : m_next(comm.rank()), m_comm_size(comm.size()) {}
   template <typename Item>
   int owner(const Item &) {

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -481,6 +481,40 @@ class multimap
     m_comm.barrier();
   }
 
+  multimap(const self_type& other)
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_default_value(other.m_default_value),
+        m_local_map(other.m_local_map) {
+    m_comm.log(log_level::info, "Copying ygm::container::map");
+    pthis.check(m_comm);
+  }
+
+  multimap(self_type&& other) noexcept
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_default_value(other.m_default_value),
+        m_local_map(std::move(other.m_local_map)) {
+    m_comm.log(log_level::info, "Moving ygm::container::map");
+    pthis.check(m_comm);
+  }
+
+  multimap& operator=(const self_type& other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::map copy assignment operator");
+    return *this = multimap(other);
+  }
+
+  multimap& operator=(self_type&& other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::map move assignment operator");
+    std::swap(m_local_map, other.m_local_map);
+    std::swap(m_default_value, other.m_default_value);
+    return *this;
+  }
+
   void local_insert(const key_type& key) {
     if (m_local_map.count(key) == 0) {
       m_local_map.insert({key, m_default_value});

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -79,10 +79,10 @@ class map
   }
 
   template <typename STLContainer>
-  map(ygm::comm&          comm,
-      const STLContainer& cont) requires detail::STLContainer<STLContainer> &&
-      std::convertible_to<typename STLContainer::value_type,
-                          std::pair<Key, Value>>
+  map(ygm::comm& comm, const STLContainer& cont)
+    requires detail::STLContainer<STLContainer> &&
+                 std::convertible_to<typename STLContainer::value_type,
+                                     std::pair<Key, Value>>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
@@ -94,9 +94,9 @@ class map
   }
 
   template <typename YGMContainer>
-  map(ygm::comm&          comm,
-      const YGMContainer& yc) requires detail::HasForAll<YGMContainer> &&
-      detail::SingleItemTuple<typename YGMContainer::for_all_args>
+  map(ygm::comm& comm, const YGMContainer& yc)
+    requires detail::HasForAll<YGMContainer> &&
+                 detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
@@ -111,6 +111,46 @@ class map
   ~map() {
     m_comm.log(log_level::info, "Destroying ygm::container::map");
     m_comm.barrier();
+  }
+
+  map(const self_type& other)
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_default_value(other.m_default_value),
+        m_local_map(other.m_local_map) {
+    m_comm.log(log_level::info, "Copying ygm::container::map");
+    pthis.check(m_comm);
+  }
+
+  map(self_type&& other) noexcept
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_default_value(other.m_default_value),
+        m_local_map(std::move(other.m_local_map)) {
+    m_comm.log(log_level::info, "Moving ygm::container::map");
+    pthis.check(m_comm);
+  }
+
+  map& operator=(const self_type& other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::map copy assignment operator");
+    partitioner     = detail::hash_partitioner<std::hash<key_type>>(m_comm);
+    m_default_value = other.m_default_value;
+    m_local_map     = other.m_local_map;
+
+    return *this;
+  }
+
+  map& operator=(self_type&& other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::map move assignment operator");
+    partitioner     = detail::hash_partitioner<std::hash<key_type>>(m_comm);
+    m_default_value = std::move(other.m_default_value);
+    m_local_map     = std::move(other.m_local_map);
+
+    return *this;
   }
 
   using detail::base_async_erase_key<map<Key, Value>,
@@ -413,9 +453,10 @@ class multimap
   }
 
   template <typename STLContainer>
-  multimap(ygm::comm& comm, const STLContainer& cont) requires
-      detail::STLContainer<STLContainer> && std::convertible_to<
-          typename STLContainer::value_type, std::pair<Key, Value>>
+  multimap(ygm::comm& comm, const STLContainer& cont)
+    requires detail::STLContainer<STLContainer> &&
+                 std::convertible_to<typename STLContainer::value_type,
+                                     std::pair<Key, Value>>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);
@@ -427,9 +468,9 @@ class multimap
   }
 
   template <typename YGMContainer>
-  multimap(ygm::comm&          comm,
-           const YGMContainer& yc) requires detail::HasForAll<YGMContainer> &&
-      detail::SingleItemTuple<typename YGMContainer::for_all_args>
+  multimap(ygm::comm& comm, const YGMContainer& yc)
+    requires detail::HasForAll<YGMContainer> &&
+                 detail::SingleItemTuple<typename YGMContainer::for_all_args>
       : m_comm(comm), pthis(this), partitioner(comm), m_default_value() {
     m_comm.log(log_level::info, "Creating ygm::container::multimap");
     pthis.check(m_comm);

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -136,20 +136,14 @@ class map
   map& operator=(const self_type& other) {
     m_comm.log(log_level::info,
                "Calling ygm::container::map copy assignment operator");
-    partitioner     = detail::hash_partitioner<std::hash<key_type>>(m_comm);
-    m_default_value = other.m_default_value;
-    m_local_map     = other.m_local_map;
-
-    return *this;
+    return *this = map(other);
   }
 
   map& operator=(self_type&& other) {
     m_comm.log(log_level::info,
                "Calling ygm::container::map move assignment operator");
-    partitioner     = detail::hash_partitioner<std::hash<key_type>>(m_comm);
-    m_default_value = std::move(other.m_default_value);
-    m_local_map     = std::move(other.m_local_map);
-
+    std::swap(m_local_map, other.m_local_map);
+    std::swap(m_default_value, other.m_default_value);
     return *this;
   }
 

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -116,10 +116,14 @@ class multiset
   }
 
   multiset &operator=(const self_type &other) {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::multiset copy assignment operator");
     return *this = multiset(other);
   }
 
   multiset &operator=(self_type &&other) noexcept {
+    m_comm.log(log_level::info,
+               "Calling ygm::container::multiset move assignment operator");
     std::swap(m_local_set, other.m_local_set);
     return *this;
   }

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -189,23 +189,6 @@ class set
     pthis.check(m_comm);
   }
 
-  set(const self_type &other)
-      : m_comm(other.comm()),
-        pthis(this),
-        partitioner(other.comm, other.partitioner) {
-    m_comm.log(log_level::info, "Creating ygm::container::set");
-    pthis.check(m_comm);
-  }
-
-  set(self_type &&other) noexcept
-      : m_comm(other.comm()),
-        pthis(this),
-        partitioner(other.partitioner),
-        m_local_set(std::move(other.m_local_set)) {
-    m_comm.log(log_level::info, "Creating ygm::container::set");
-    pthis.check(m_comm);
-  }
-
   set(ygm::comm &comm, std::initializer_list<Value> l)
       : m_comm(comm), pthis(this), partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
@@ -254,6 +237,24 @@ class set
   }
 
   set() = delete;
+
+  set(const self_type &other)
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_local_set(other.m_local_set) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
+    pthis.check(m_comm);
+  }
+
+  set(self_type &&other) noexcept
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.partitioner),
+        m_local_set(std::move(other.m_local_set)) {
+    m_comm.log(log_level::info, "Creating ygm::container::set");
+    pthis.check(m_comm);
+  }
 
   set &operator=(const self_type &other) { return *this = set(other); }
 

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -46,23 +46,6 @@ class multiset
     pthis.check(m_comm);
   }
 
-  multiset(const self_type &other)
-      : m_comm(other.comm()),
-        pthis(this),
-        partitioner(other.comm, other.partitioner) {
-    m_comm.log(log_level::info, "Creating ygm::container::multiset");
-    pthis.check(m_comm);
-  }
-
-  multiset(self_type &&other) noexcept
-      : m_comm(other.comm()),
-        pthis(this),
-        partitioner(other.partitioner),
-        m_local_set(std::move(other.m_local_set)) {
-    m_comm.log(log_level::info, "Creating ygm::container::multiset");
-    pthis.check(m_comm);
-  }
-
   multiset(ygm::comm &comm, std::initializer_list<Value> l)
       : m_comm(comm), pthis(this), partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::multiset");
@@ -113,6 +96,24 @@ class multiset
   }
 
   multiset() = delete;
+
+  multiset(const self_type &other)
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.comm()),
+        m_local_set(other.m_local_set) {
+    m_comm.log(log_level::info, "Copying ygm::container::multiset");
+    pthis.check(m_comm);
+  }
+
+  multiset(self_type &&other) noexcept
+      : m_comm(other.comm()),
+        pthis(this),
+        partitioner(other.partitioner),
+        m_local_set(std::move(other.m_local_set)) {
+    m_comm.log(log_level::info, "Moving ygm::container::multiset");
+    pthis.check(m_comm);
+  }
 
   multiset &operator=(const self_type &other) {
     return *this = multiset(other);

--- a/test/test_bag.cpp
+++ b/test/test_bag.cpp
@@ -44,25 +44,25 @@ int main(int argc, char** argv) {
   //
   // Test copy constructor
   {
-    // ygm::container::bag<std::string> bbag(world);
-    // if (world.rank0()) {
-    //   bbag.async_insert("dog");
-    //   bbag.async_insert("apple");
-    //   bbag.async_insert("red");
-    // }
-    // world.barrier();
-    // YGM_ASSERT_RELEASE(bbag.size() == 3);
-    // ygm::container::bag<std::string> bbag2(bbag);
+    ygm::container::bag<std::string> bbag(world);
+    if (world.rank0()) {
+      bbag.async_insert("dog");
+      bbag.async_insert("apple");
+      bbag.async_insert("red");
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    ygm::container::bag<std::string> bbag2(bbag);
 
-    // YGM_ASSERT_RELEASE(bbag.size() == 3);
-    // YGM_ASSERT_RELEASE(bbag2.size() == 3);
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    YGM_ASSERT_RELEASE(bbag2.size() == 3);
 
-    // if (world.rank0()) {
-    //   bbag2.async_insert("car");
-    // }
-    // world.barrier();
-    // YGM_ASSERT_RELEASE(bbag.size() == 3);
-    // YGM_ASSERT_RELEASE(bbag2.size() == 4);
+    if (world.rank0()) {
+      bbag2.async_insert("car");
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    YGM_ASSERT_RELEASE(bbag2.size() == 4);
   }
 
   //

--- a/test/test_bag.cpp
+++ b/test/test_bag.cpp
@@ -66,6 +66,31 @@ int main(int argc, char** argv) {
   }
 
   //
+  // Test copy assignment operator
+  {
+    ygm::container::bag<std::string> bbag(world);
+    if (world.rank0()) {
+      bbag.async_insert("dog");
+      bbag.async_insert("apple");
+      bbag.async_insert("red");
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    ygm::container::bag<std::string> bbag2(world);
+    bbag2 = bbag;
+
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    YGM_ASSERT_RELEASE(bbag2.size() == 3);
+
+    if (world.rank0()) {
+      bbag2.async_insert("car");
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(bbag.size() == 3);
+    YGM_ASSERT_RELEASE(bbag2.size() == 4);
+  }
+
+  //
   // Test move constructor
   {
     ygm::container::bag<std::string> bbag(world);

--- a/test/test_counting_set.cpp
+++ b/test/test_counting_set.cpp
@@ -168,5 +168,163 @@ int main(int argc, char **argv) {
     YGM_ASSERT_RELEASE(cset2.size() == 3);
   }
 
+  //
+  // Test copy constructor
+  {
+    ygm::container::counting_set<std::string> cset(world);
+    if (world.rank() == 0) {
+      cset.async_insert("dog");
+      cset.async_insert("apple");
+      cset.async_insert("red");
+    }
+
+    ygm::container::counting_set<std::string> cset2(cset);
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset.size() == 3);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset2.size() == 3);
+
+    if (world.rank0()) {
+      cset2.async_insert("dog");
+      cset2.async_insert("apple");
+      cset2.async_insert("red");
+    }
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset.size() == 3);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 2);
+    YGM_ASSERT_RELEASE(cset2.size() == 6);
+  }
+
+  //
+  // Test copy assignment operator
+  {
+    ygm::container::counting_set<std::string> cset(world);
+    if (world.rank() == 0) {
+      cset.async_insert("dog");
+      cset.async_insert("apple");
+      cset.async_insert("red");
+    }
+
+    ygm::container::counting_set<std::string> cset2(world);
+    cset2 = cset;
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset.size() == 3);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset2.size() == 3);
+
+    if (world.rank0()) {
+      cset2.async_insert("dog");
+      cset2.async_insert("apple");
+      cset2.async_insert("red");
+    }
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset.size() == 3);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 2);
+    YGM_ASSERT_RELEASE(cset2.size() == 6);
+  }
+
+  //
+  // Test move constructor
+  {
+    ygm::container::counting_set<std::string> cset(world);
+    if (world.rank() == 0) {
+      cset.async_insert("dog");
+      cset.async_insert("apple");
+      cset.async_insert("red");
+    }
+
+    ygm::container::counting_set<std::string> cset2(std::move(cset));
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 0);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 0);
+    YGM_ASSERT_RELEASE(cset.count("red") == 0);
+    YGM_ASSERT_RELEASE(cset.size() == 0);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset2.size() == 3);
+
+    if (world.rank0()) {
+      cset2.async_insert("dog");
+      cset2.async_insert("apple");
+      cset2.async_insert("red");
+    }
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 0);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 0);
+    YGM_ASSERT_RELEASE(cset.count("red") == 0);
+    YGM_ASSERT_RELEASE(cset.size() == 0);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 2);
+    YGM_ASSERT_RELEASE(cset2.size() == 6);
+  }
+
+  //
+  // Test move assignment operator
+  {
+    ygm::container::counting_set<std::string> cset(world);
+    if (world.rank() == 0) {
+      cset.async_insert("dog");
+      cset.async_insert("apple");
+      cset.async_insert("red");
+    }
+
+    ygm::container::counting_set<std::string> cset2(world);
+    cset2 = std::move(cset);
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 0);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 0);
+    YGM_ASSERT_RELEASE(cset.count("red") == 0);
+    YGM_ASSERT_RELEASE(cset.size() == 0);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 1);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 1);
+    YGM_ASSERT_RELEASE(cset2.size() == 3);
+
+    if (world.rank0()) {
+      cset2.async_insert("dog");
+      cset2.async_insert("apple");
+      cset2.async_insert("red");
+    }
+
+    YGM_ASSERT_RELEASE(cset.count("dog") == 0);
+    YGM_ASSERT_RELEASE(cset.count("apple") == 0);
+    YGM_ASSERT_RELEASE(cset.count("red") == 0);
+    YGM_ASSERT_RELEASE(cset.size() == 0);
+
+    YGM_ASSERT_RELEASE(cset2.count("dog") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("apple") == 2);
+    YGM_ASSERT_RELEASE(cset2.count("red") == 2);
+    YGM_ASSERT_RELEASE(cset2.size() == 6);
+  }
+
   return 0;
 }

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -517,5 +517,107 @@ int main(int argc, char **argv) {
     }
   }
 
+  // Test copy constructor
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::map<std::string, std::string> smap2(smap);
+
+    YGM_ASSERT_RELEASE(smap.size() == 3);
+    YGM_ASSERT_RELEASE(smap2.size() == 3);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 3);
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+  }
+
+  // Test copy assignment operator
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::map<std::string, std::string> smap2(world);
+    smap2 = smap;
+
+    YGM_ASSERT_RELEASE(smap.size() == 3);
+    YGM_ASSERT_RELEASE(smap2.size() == 3);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 3);
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+  }
+
+  // Test move constructor
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::map<std::string, std::string> smap2(std::move(smap));
+
+    YGM_ASSERT_RELEASE(smap.size() ==
+                       0);  // I don't think this is guaranteed for a move. smap
+                            // will be in some undefined state
+    YGM_ASSERT_RELEASE(smap2.size() == 3);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 0);
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+  }
+
+  // Test move assignment operator
+  {
+    ygm::container::map<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::map<std::string, std::string> smap2(world);
+    smap2 = std::move(smap);
+
+    YGM_ASSERT_RELEASE(smap.size() ==
+                       0);  // I don't think this is guaranteed for a move. smap
+                            // will be in some undefined state
+    YGM_ASSERT_RELEASE(smap2.size() == 3);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 0);
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+  }
+
   return 0;
 }

--- a/test/test_multimap.cpp
+++ b/test/test_multimap.cpp
@@ -371,5 +371,111 @@ int main(int argc, char **argv) {
                                           num_removal_rounds * remove_size);
   }
 
+  // Test copy constructor
+  {
+    ygm::container::multimap<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("dog", "bird");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::multimap<std::string, std::string> smap2(smap);
+
+    YGM_ASSERT_RELEASE(smap.size() == 4);
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 4);
+    YGM_ASSERT_RELEASE(smap2.size() == 5);
+  }
+
+  // Test copy assignment operator
+  {
+    ygm::container::multimap<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("dog", "bird");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::multimap<std::string, std::string> smap2(world);
+    smap2 = smap;
+
+    YGM_ASSERT_RELEASE(smap.size() == 4);
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 4);
+    YGM_ASSERT_RELEASE(smap2.size() == 5);
+  }
+
+  // Test move constructor
+  {
+    ygm::container::multimap<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("dog", "bird");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::multimap<std::string, std::string> smap2(std::move(smap));
+
+    YGM_ASSERT_RELEASE(smap.size() ==
+                       0);  // I don't think this is guaranteed for a move. smap
+                            // will be in some undefined state
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 0);
+    YGM_ASSERT_RELEASE(smap2.size() == 5);
+  }
+
+  // Test move assignment operator
+  {
+    ygm::container::multimap<std::string, std::string> smap(world);
+    if (world.rank0()) {
+      smap.async_insert("dog", "cat");
+      smap.async_insert("dog", "bird");
+      smap.async_insert("apple", "orange");
+      smap.async_insert("red", "green");
+    }
+    world.barrier();
+
+    ygm::container::multimap<std::string, std::string> smap2(world);
+    smap2 = std::move(smap);
+
+    YGM_ASSERT_RELEASE(smap.size() ==
+                       0);  // I don't think this is guaranteed for a move. smap
+                            // will be in some undefined state
+    YGM_ASSERT_RELEASE(smap2.size() == 4);
+
+    if (world.rank0()) {
+      smap2.async_insert("up", "down");
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(smap.size() == 0);
+    YGM_ASSERT_RELEASE(smap2.size() == 5);
+  }
+
   return 0;
 }

--- a/test/test_multiset.cpp
+++ b/test/test_multiset.cpp
@@ -242,5 +242,127 @@ int main(int argc, char** argv) {
     }
   }
 
+  //
+  // Test copy constructor
+  {
+    ygm::container::multiset<int> mset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset.async_insert(1);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(mset.size() == size);
+
+    ygm::container::multiset<int> mset2(mset);
+    YGM_ASSERT_RELEASE(mset.size() == size);
+    YGM_ASSERT_RELEASE(mset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset2.async_insert(2 * i);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(mset.size() == size);
+    YGM_ASSERT_RELEASE(mset2.size() == 2 * size);
+  }
+
+  //
+  // Test copy assignment operator
+  {
+    ygm::container::multiset<int> mset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset.async_insert(1);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(mset.size() == size);
+
+    ygm::container::multiset<int> mset2(world);
+    mset2 = mset;
+    YGM_ASSERT_RELEASE(mset.size() == size);
+    YGM_ASSERT_RELEASE(mset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset2.async_insert(2 * i);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(mset.size() == size);
+    YGM_ASSERT_RELEASE(mset2.size() == 2 * size);
+  }
+
+  //
+  // Test move constructor
+  {
+    ygm::container::multiset<int> mset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset.async_insert(1);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(mset.size() == size);
+
+    ygm::container::multiset<int> mset2(std::move(mset));
+    YGM_ASSERT_RELEASE(mset.size() == 0);
+    YGM_ASSERT_RELEASE(mset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset2.async_insert(2 * i);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(mset.size() == 0);
+    YGM_ASSERT_RELEASE(mset2.size() == 2 * size);
+  }
+
+  //
+  // Test move constructor
+  {
+    ygm::container::multiset<int> mset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset.async_insert(1);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(mset.size() == size);
+
+    ygm::container::multiset<int> mset2(world);
+    mset2 = std::move(mset);
+    YGM_ASSERT_RELEASE(mset.size() == 0);
+    YGM_ASSERT_RELEASE(mset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        mset2.async_insert(2 * i);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(mset.size() == 0);
+    YGM_ASSERT_RELEASE(mset2.size() == 2 * size);
+  }
+
   return 0;
 }

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -338,5 +338,126 @@ int main(int argc, char** argv) {
     }
   }
 
+  //
+  // Test copy constructor
+  {
+    ygm::container::set<int> iset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset.async_insert(i);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(iset.size() == size);
+
+    ygm::container::set<int> iset2(iset);
+    YGM_ASSERT_RELEASE(iset.size() == size);
+    YGM_ASSERT_RELEASE(iset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset2.async_insert(2 * i + size);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(iset.size() == size);
+    YGM_ASSERT_RELEASE(iset2.size() == 2 * size);
+  }
+
+  //
+  // Test copy assignment operator
+  {
+    ygm::container::set<int> iset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset.async_insert(i);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(iset.size() == size);
+
+    ygm::container::set<int> iset2(world);
+    iset2 = iset;
+    YGM_ASSERT_RELEASE(iset.size() == size);
+    YGM_ASSERT_RELEASE(iset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset2.async_insert(2 * i + size);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(iset.size() == size);
+    YGM_ASSERT_RELEASE(iset2.size() == 2 * size);
+  }
+
+  //
+  // Test move constructor
+  {
+    ygm::container::set<int> iset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset.async_insert(i);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(iset.size() == size);
+
+    ygm::container::set<int> iset2(std::move(iset));
+    YGM_ASSERT_RELEASE(iset.size() == 0);
+    YGM_ASSERT_RELEASE(iset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset2.async_insert(2 * i + size);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(iset.size() == 0);
+    YGM_ASSERT_RELEASE(iset2.size() == 2 * size);
+  }
+
+  //
+  // Test move constructor
+  {
+    ygm::container::set<int> iset(world);
+
+    int size = 32;
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset.async_insert(i);
+      }
+    }
+    world.barrier();
+
+    YGM_ASSERT_RELEASE(iset.size() == size);
+
+    ygm::container::set<int> iset2(world);
+    iset2 = std::move(iset);
+    YGM_ASSERT_RELEASE(iset.size() == 0);
+    YGM_ASSERT_RELEASE(iset2.size() == size);
+
+    if (world.rank0()) {
+      for (int i = 0; i < size; ++i) {
+        iset2.async_insert(2 * i + size);
+      }
+    }
+    world.barrier();
+    YGM_ASSERT_RELEASE(iset.size() == 0);
+    YGM_ASSERT_RELEASE(iset2.size() == 2 * size);
+  }
   return 0;
 }


### PR DESCRIPTION
Adds missing copy, move, and assignment constructors (along with tests) for all YGM containers except the `ygm::container::tagged_bag` and `ygm::container::disjoint_set`.

As part of the changes to make this work, the `comm()` function of containers was changed to be a `const` member function that returns a non-`const` reference to the container's communicator. This is the expected behavior when viewing the underlying `comm` object as `mutable` from the viewpoint of the container. In particular, this allows a container's copy constructor (which takes a `const` container to copy) to get a non-`const` reference to the communicator for the new copy to use.

The above change could be avoided by directly making use of the `m_comm` member in containers (as opposed to calling `comm()`), but the behavior was unintuitive as it was.