### PR TITLE
Deprecating comm::all_reduce_* functions

### DIFF
--- a/examples/container/alg_pagerank.cpp
+++ b/examples/container/alg_pagerank.cpp
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     };
     pr.for_all(agg_pr_lambda);
     world.barrier();
-    world.all_reduce_sum(agg_pr);
+    ygm::sum(agg_pr, world);
     std::cout << "Aggregated PR: " << agg_pr << "." << std::endl;
     agg_pr = 0.;
   }

--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -22,9 +22,11 @@
 #include <ygm/detail/mpi.hpp>
 #include <ygm/detail/tracer.hpp>
 #include <ygm/detail/ygm_cereal_archive.hpp>
-#include <ygm/detail/ygm_ptr.hpp>
 
 namespace ygm {
+
+template <typename T>
+class ygm_ptr;
 
 namespace detail {
 class interrupt_mask;
@@ -141,15 +143,19 @@ class comm {
   void register_pre_barrier_callback(const std::function<void()> &fn);
 
   template <typename T>
+  [[deprecated("Use `ygm::sum` defined in ygm/detail/collective.hpp")]]
   T all_reduce_sum(const T &t) const;
 
   template <typename T>
+  [[deprecated("Use `ygm::min` defined in ygm/detail/collective.hpp")]]
   T all_reduce_min(const T &t) const;
 
   template <typename T>
+  [[deprecated("Use `ygm::max` defined in ygm/detail/collective.hpp")]]
   T all_reduce_max(const T &t) const;
 
   template <typename T, typename MergeFunction>
+  [[deprecated("Use `ygm::all_reduce` defined in ygm/detail/collective.hpp")]]
   inline T all_reduce(const T &t, MergeFunction merge) const;
 
   //

--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -8,7 +8,6 @@
 #include <concepts>
 #include <random>
 
-#include <ygm/collective.hpp>
 #include <ygm/comm.hpp>
 #include <ygm/container/container_traits.hpp>
 #include <ygm/container/detail/base_async_insert.hpp>
@@ -164,7 +163,7 @@ class array
       max_index = std::max<mapped_type>(std::get<0>(index_value), max_index);
     });
 
-    max_index = ygm::max(max_index, m_comm);
+    max_index = ::ygm::max(max_index, m_comm);
 
     resize(max_index + 1);
 
@@ -194,7 +193,7 @@ class array
       max_index = std::max<mapped_type>(index, max_index);
     });
 
-    max_index = ygm::max(max_index, m_comm);
+    max_index = ::ygm::max(max_index, m_comm);
 
     resize(max_index + 1);
 
@@ -246,7 +245,7 @@ class array
       max_index = std::max<key_type>(std::get<0>(index_value), max_index);
     });
 
-    max_index = ygm::max(max_index, m_comm);
+    max_index = ::ygm::max(max_index, m_comm);
 
     resize(max_index + 1);
 

--- a/include/ygm/container/counting_set.hpp
+++ b/include/ygm/container/counting_set.hpp
@@ -173,7 +173,7 @@ class counting_set
     mapped_type local_count{0};
     local_for_all(
         [&local_count](const auto &key, auto &value) { local_count += value; });
-    return ygm::sum(local_count, m_map.comm());
+    return ::ygm::sum(local_count, m_map.comm());
   }
 
   // bool is_mine(const key_type &key) const { return m_map.is_mine(key); }

--- a/include/ygm/container/detail/base_count.hpp
+++ b/include/ygm/container/detail/base_count.hpp
@@ -7,7 +7,6 @@
 
 #include <tuple>
 #include <utility>
-#include <ygm/collective.hpp>
 
 namespace ygm::container::detail {
 
@@ -17,7 +16,7 @@ struct base_count {
       const typename std::tuple_element<0, for_all_args>::type& value) const {
     const derived_type* derived_this = static_cast<const derived_type*>(this);
     derived_this->comm().barrier();
-    return ygm::sum(derived_this->local_count(value), derived_this->comm());
+    return ::ygm::sum(derived_this->local_count(value), derived_this->comm());
   }
 };
 

--- a/include/ygm/container/detail/base_iteration.hpp
+++ b/include/ygm/container/detail/base_iteration.hpp
@@ -7,7 +7,6 @@
 
 #include <tuple>
 #include <vector>
-#include <ygm/collective.hpp>
 #include <ygm/container/detail/base_concepts.hpp>
 
 namespace ygm::container::detail {
@@ -98,9 +97,10 @@ struct base_iteration_value {
 
     //
     // All reduce global top_k
-    auto to_return = mycomm.all_reduce(
-        local_topk, [comp, k](const std::vector<value_type>& va,
-                              const std::vector<value_type>& vb) {
+    auto to_return = ::ygm::all_reduce(
+        local_topk,
+        [comp, k](const std::vector<value_type>& va,
+                  const std::vector<value_type>& vb) {
           std::vector<value_type> out(va.begin(), va.end());
           out.insert(out.end(), vb.begin(), vb.end());
           std::sort(out.begin(), out.end(), comp);
@@ -108,7 +108,8 @@ struct base_iteration_value {
             out.pop_back();
           }
           return out;
-        });
+        },
+        mycomm);
     return to_return;
   }
 
@@ -267,8 +268,9 @@ struct base_iteration_key_value {
 
     //
     // All reduce global top_k
-    auto to_return = mycomm.all_reduce(
-        local_topk, [comp, k](const vec_type& va, const vec_type& vb) {
+    auto to_return = ::ygm::all_reduce(
+        local_topk,
+        [comp, k](const vec_type& va, const vec_type& vb) {
           vec_type out(va.begin(), va.end());
           out.insert(out.end(), vb.begin(), vb.end());
           std::sort(out.begin(), out.end(), comp);
@@ -276,7 +278,8 @@ struct base_iteration_key_value {
             out.pop_back();
           }
           return out;
-        });
+        },
+        mycomm);
     return to_return;
   }
 

--- a/include/ygm/container/detail/base_misc.hpp
+++ b/include/ygm/container/detail/base_misc.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <ygm/collective.hpp>
-
 namespace ygm::container::detail {
 
 template <typename derived_type, typename for_all_args>
@@ -14,7 +12,7 @@ struct base_misc {
   size_t size() const {
     const derived_type* derived_this = static_cast<const derived_type*>(this);
     derived_this->comm().barrier();
-    return ygm::sum(derived_this->local_size(), derived_this->comm());
+    return ::ygm::sum(derived_this->local_size(), derived_this->comm());
   }
 
   void clear() {

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <unordered_map>
 #include <vector>
-#include <ygm/collective.hpp>
 #include <ygm/comm.hpp>
 #include <ygm/container/container_traits.hpp>
 #include <ygm/container/detail/hash_partitioner.hpp>
@@ -685,7 +684,7 @@ class disjoint_set_impl {
 
   size_t size() {
     m_comm.barrier();
-    return m_comm.all_reduce_sum(m_local_item_map.size());
+    return ::ygm::sum(m_local_item_map.size(), m_comm);
   }
 
   size_type num_sets() {
@@ -696,8 +695,7 @@ class disjoint_set_impl {
         ++num_local_sets;
       }
     }
-    return m_comm.all_reduce_sum(num_local_sets);
-    return 0;
+    return ::ygm::sum(num_local_sets, m_comm);
   }
 
   int owner(const value_type &item) const {

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <boost/unordered/unordered_flat_map.hpp>
-#include <ygm/collective.hpp>
 #include <ygm/container/container_traits.hpp>
 #include <ygm/container/detail/base_async_erase.hpp>
 #include <ygm/container/detail/base_async_insert.hpp>

--- a/include/ygm/detail/collective.hpp
+++ b/include/ygm/detail/collective.hpp
@@ -24,7 +24,7 @@ T prefix_sum(const T &value, const comm &c) {
   c.barrier();
   MPI_Comm mpi_comm = c.get_mpi_comm();
   YGM_ASSERT_MPI(MPI_Exscan(&value, &to_return, 1, detail::mpi_typeof(value),
-                        MPI_SUM, mpi_comm));
+                            MPI_SUM, mpi_comm));
   return to_return;
 }
 
@@ -43,7 +43,7 @@ T sum(const T &value, const comm &c) {
   c.barrier();
   MPI_Comm mpi_comm = c.get_mpi_comm();
   YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1, detail::mpi_typeof(T()),
-                           MPI_SUM, mpi_comm));
+                               MPI_SUM, mpi_comm));
   return to_return;
 }
 
@@ -62,7 +62,7 @@ T min(const T &value, const comm &c) {
   c.barrier();
   MPI_Comm mpi_comm = c.get_mpi_comm();
   YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1, detail::mpi_typeof(T()),
-                           MPI_MIN, mpi_comm));
+                               MPI_MIN, mpi_comm));
   return to_return;
 }
 
@@ -81,7 +81,7 @@ T max(const T &value, const comm &c) {
   c.barrier();
   MPI_Comm mpi_comm = c.get_mpi_comm();
   YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1, detail::mpi_typeof(T()),
-                           MPI_MAX, mpi_comm));
+                               MPI_MAX, mpi_comm));
   return to_return;
 }
 
@@ -98,8 +98,8 @@ inline bool logical_and(bool value, const comm &c) {
   bool to_return;
   c.barrier();
   MPI_Comm mpi_comm = c.get_mpi_comm();
-  YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1, detail::mpi_typeof(bool()),
-                           MPI_LAND, mpi_comm));
+  YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1,
+                               detail::mpi_typeof(bool()), MPI_LAND, mpi_comm));
   return to_return;
 }
 
@@ -116,8 +116,8 @@ inline bool logical_or(bool value, const comm &c) {
   bool to_return;
   c.barrier();
   MPI_Comm mpi_comm = c.get_mpi_comm();
-  YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1, detail::mpi_typeof(bool()),
-                           MPI_LOR, mpi_comm));
+  YGM_ASSERT_MPI(MPI_Allreduce(&value, &to_return, 1,
+                               detail::mpi_typeof(bool()), MPI_LOR, mpi_comm));
   return to_return;
 }
 
@@ -143,13 +143,14 @@ void bcast(T &to_bcast, int root, const comm &cm) {
     }
     size_t packed_size = packed.size();
     YGM_ASSERT_RELEASE(packed_size < 1024 * 1024 * 1024);
-    YGM_ASSERT_MPI(MPI_Bcast(&packed_size, 1, ygm::detail::mpi_typeof(packed_size),
-                         root, cm.get_mpi_comm()));
+    YGM_ASSERT_MPI(MPI_Bcast(&packed_size, 1,
+                             ygm::detail::mpi_typeof(packed_size), root,
+                             cm.get_mpi_comm()));
     if (cm.rank() != root) {
       packed.resize(packed_size);
     }
     YGM_ASSERT_MPI(MPI_Bcast(packed.data(), packed_size, MPI_BYTE, root,
-                         cm.get_mpi_comm()));
+                             cm.get_mpi_comm()));
 
     if (cm.rank() != root) {
       cereal::YGMInputArchive iarchive(packed.data(), packed.size());

--- a/include/ygm/detail/collective.hpp
+++ b/include/ygm/detail/collective.hpp
@@ -5,7 +5,10 @@
 
 #pragma once
 
-#include <ygm/comm.hpp>
+// Note: collective.hpp should not be included directly by users. This may cause
+// the collectives to be unable to find a definition of `ygm::comm` or the
+// `ygm::comm` to be unable to find a definition for collective operations it is
+// using.
 
 namespace ygm {
 

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -4,9 +4,11 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <ygm/detail/collective.hpp>
 #include <ygm/detail/lambda_compliance.hpp>
 #include <ygm/detail/meta/functional.hpp>
 #include <ygm/detail/ygm_cereal_archive.hpp>
+#include <ygm/detail/ygm_ptr.hpp>
 #include <ygm/version.hpp>
 
 namespace ygm {
@@ -108,15 +110,15 @@ inline void comm::stats_print(const std::string &name, std::ostream &os) {
        << "NAME                     = " << name << "\n"
        << "TIME                     = " << stats.get_elapsed_time() << "\n"
        << "GLOBAL_ASYNC_COUNT       = "
-       << all_reduce_sum(stats.get_async_count()) << "\n"
+       << ::ygm::sum(stats.get_async_count(), *this) << "\n"
        << "GLOBAL_ISEND_COUNT       = "
-       << all_reduce_sum(stats.get_isend_count()) << "\n"
+       << ::ygm::sum(stats.get_isend_count(), *this) << "\n"
        << "GLOBAL_ISEND_BYTES       = "
-       << all_reduce_sum(stats.get_isend_bytes()) << "\n"
+       << ::ygm::sum(stats.get_isend_bytes(), *this) << "\n"
        << "MAX_WAITSOME_ISEND_IRECV = "
-       << all_reduce_max(stats.get_waitsome_isend_irecv_time()) << "\n"
+       << ::ygm::max(stats.get_waitsome_isend_irecv_time(), *this) << "\n"
        << "MAX_WAITSOME_IALLREDUCE  = "
-       << all_reduce_max(stats.get_waitsome_iallreduce_time()) << "\n"
+       << ::ygm::max(stats.get_waitsome_iallreduce_time(), *this) << "\n"
        << "COUNT_IALLREDUCE         = " << stats.get_iallreduce_count() << "\n"
        << "======================================";
 
@@ -294,10 +296,11 @@ inline void comm::barrier() {
 
 /**
  * @brief barrier logic for both a full barrier and an async_barrier
- * 
+ *
  * @param local_full is the local rank at a full global barrier
  * @return true the barrier was a full global barrier
- * @return false was not a full global barrier, at least one rank is at async_barrier
+ * @return false was not a full global barrier, at least one rank is at
+ * async_barrier
  */
 inline bool comm::priv_barrier(bool local_full) {
   flush_all_local_and_process_incoming();

--- a/include/ygm/detail/ygm_ptr.hpp
+++ b/include/ygm/detail/ygm_ptr.hpp
@@ -7,15 +7,14 @@
 
 #include <vector>
 #include <ygm/detail/assert.hpp>
+#include <ygm/detail/collective.hpp>
 
 namespace ygm {
-
-class comm;
 
 template <typename T>
 class ygm_ptr {
  public:
-  ygm_ptr(){};
+  ygm_ptr() {};
 
   T       *operator->() { return sptrs[idx]; }
   T *const operator->() const { return sptrs[idx]; }
@@ -42,10 +41,7 @@ class ygm_ptr {
 
   uint32_t index() const { return idx; }
 
-  template <typename Comm>
-  void check(Comm &c) const {
-    YGM_ASSERT_RELEASE(idx == c.all_reduce_min(idx));
-  }
+  void check(comm &c) const { YGM_ASSERT_RELEASE(idx == ::ygm::min(idx, c)); }
 
   template <class Archive>
   void serialize(Archive &archive) {

--- a/include/ygm/io/parquet_parser.hpp
+++ b/include/ygm/io/parquet_parser.hpp
@@ -372,7 +372,7 @@ class parquet_parser {
         total_rows += get_num_rows(m_global_paths[i]);
       }
     }
-    m_num_rows = m_comm.all_reduce_sum(total_rows);
+    m_num_rows = ::ygm::sum(total_rows, m_comm);
   }
 
   /// Open a Parquet file and return a ParquetFileReader object.
@@ -405,7 +405,7 @@ class parquet_parser {
     const size_t gcnt = m_comm.rank0() ? m_global_paths.size() : 0;
     const size_t lcnt =
         m_comm.layout().local_id() == 0 ? m_nlocal_paths.size() : 0;
-    m_num_files = m_comm.all_reduce_sum(lcnt) + m_comm.all_reduce_sum(gcnt);
+    m_num_files = ::ygm::sum(lcnt, m_comm) + ::ygm::sum(gcnt, m_comm);
   }
 
   /// Check if the file is legit.
@@ -426,7 +426,7 @@ class parquet_parser {
 
     // Make sure the file is openable
     const bool rethrow_exception = false;
-    const bool openable       = open_file(p, rethrow_exception) != nullptr;
+    const bool openable          = open_file(p, rethrow_exception) != nullptr;
     return openable;
   }
 

--- a/test/test_bag.cpp
+++ b/test/test_bag.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     YGM_ASSERT_RELEASE(bbag.count("red") == 1);
     YGM_ASSERT_RELEASE(bbag.size() == 3);
 
-    for(auto& value : bbag) {
+    for (auto& value : bbag) {
       world.cout(value);
     }
   }
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
     }
     int count{0};
     bbag.for_all([&count](std::string& mstr) { ++count; });
-    int global_count = world.all_reduce_sum(count);
+    int global_count = ygm::sum(count, world);
     world.barrier();
     YGM_ASSERT_RELEASE(global_count == 3);
   }
@@ -258,7 +258,7 @@ int main(int argc, char** argv) {
     int count{0};
     pbag.for_all(
         [&count](std::pair<std::string, int>& mstr) { count += mstr.second; });
-    int global_count = world.all_reduce_sum(count);
+    int global_count = ygm::sum(count, world);
     world.barrier();
     YGM_ASSERT_RELEASE(global_count == 6);
   }
@@ -275,7 +275,7 @@ int main(int argc, char** argv) {
   //   int count{0};
   //   pbag.for_all(
   //       [&count](std::string& first, int& second) { count += second; });
-  //   int global_count = world.all_reduce_sum(count);
+  //   int global_count = ygm::sum(count, world);
   //   world.barrier();
   //   YGM_ASSERT_RELEASE(global_count == 6);
   // }

--- a/test/test_collective.cpp
+++ b/test/test_collective.cpp
@@ -5,7 +5,6 @@
 
 #undef NDEBUG
 
-#include <ygm/collective.hpp>
 #include <ygm/comm.hpp>
 
 int main(int argc, char** argv) {

--- a/test/test_comm.cpp
+++ b/test/test_comm.cpp
@@ -94,32 +94,32 @@ int main(int argc, char** argv) {
     //
     // Test reductions
     {
-      auto max = world.all_reduce_max(size_t(world.rank()));
+      auto max = ygm::max(size_t(world.rank()), world);
       YGM_ASSERT_RELEASE(max == (size_t)world.size() - 1);
 
-      auto min = world.all_reduce_min(size_t(world.rank()));
+      auto min = ygm::min(size_t(world.rank()), world);
       YGM_ASSERT_RELEASE(min == 0);
 
-      auto sum = world.all_reduce_sum(size_t(world.rank()));
+      auto sum = ygm::sum(size_t(world.rank()), world);
       YGM_ASSERT_RELEASE(sum ==
                      (((size_t)world.size() - 1) * (size_t)world.size()) / 2);
 
       size_t id  = world.rank();
-      auto   red = world.all_reduce(id, [](size_t a, size_t b) {
+      auto   red = ygm::all_reduce(id, [](size_t a, size_t b) {
         if (a < b) {
           return a;
         } else {
           return b;
         }
-      });
+      }, world);
       YGM_ASSERT_RELEASE(red == 0);
-      auto red2 = world.all_reduce(id, [](size_t a, size_t b) {
+      auto red2 = ygm::all_reduce(id, [](size_t a, size_t b) {
         if (a > b) {
           return a;
         } else {
           return b;
         }
-      });
+      }, world);
       YGM_ASSERT_RELEASE(red2 == (size_t)world.size() - 1);
     }
 

--- a/test/test_csv_parser.cpp
+++ b/test/test_csv_parser.cpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv) {
   });
 
   world.barrier();
-  YGM_ASSERT_RELEASE(world.all_reduce_sum(local_count) == 100);
+  YGM_ASSERT_RELEASE(ygm::sum(local_count, world) == 100);
 
   return 0;
 }

--- a/test/test_daily_output.cpp
+++ b/test/test_daily_output.cpp
@@ -55,8 +55,9 @@ int main(int argc, char **argv) {
       xor_write = std::hash<std::string>()(message);
       d.async_write_line(timestamp, message);
 
-      xor_write = world.all_reduce(
-          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_write = ygm::all_reduce(
+          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Read lines back
@@ -68,8 +69,9 @@ int main(int argc, char **argv) {
         xor_read ^= std::hash<std::string>()(line);
       });
 
-      xor_read = world.all_reduce(
-          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_read = ygm::all_reduce(
+          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Clean up files
@@ -110,8 +112,9 @@ int main(int argc, char **argv) {
       xor_write ^= std::hash<std::string>()(message);
       d.async_write_line(timestamp, message);
 
-      xor_write = world.all_reduce(
-          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_write = ygm::all_reduce(
+          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Read lines back
@@ -123,8 +126,9 @@ int main(int argc, char **argv) {
         xor_read ^= std::hash<std::string>()(line);
       });
 
-      xor_read = world.all_reduce(
-          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_read = ygm::all_reduce(
+          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Clean up files

--- a/test/test_layout.cpp
+++ b/test/test_layout.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
   // node sizes agree
   {
     int node_size(world.layout().node_size());
-    int min_node_size = world.all_reduce_min(node_size);
+    int min_node_size = ygm::min(node_size, world);
     world.barrier();
     YGM_ASSERT_RELEASE(min_node_size == node_size);
   }
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
   // local sizes agree
   {
     int local_size(world.layout().local_size());
-    int min_local_size = world.all_reduce_min(local_size);
+    int min_local_size = ygm::min(local_size, world);
     world.barrier();
     YGM_ASSERT_RELEASE(min_local_size == local_size);
   }

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
 
   //   world.barrier();
 
-  //   YGM_ASSERT_RELEASE(world.all_reduce_sum(dog_visit_counter) ==
+  //   YGM_ASSERT_RELEASE(sum(dog_visit_counter, world) ==
   //   world.size());
 
   //   static int apple_visit_counter{0};
@@ -200,7 +200,7 @@ int main(int argc, char **argv) {
 
   //   world.barrier();
 
-  //   YGM_ASSERT_RELEASE(world.all_reduce_sum(apple_visit_counter) ==
+  //   YGM_ASSERT_RELEASE(sum(apple_visit_counter, world) ==
   //                  world.size() - 1);
 
   //   if (world.rank0()) {
@@ -297,8 +297,8 @@ int main(int argc, char **argv) {
       YGM_ASSERT_RELEASE(key >= remove_size);
     });
 
-    //testing range based loop
-    for(auto& kv : imap) {
+    // testing range based loop
+    for (auto &kv : imap) {
       YGM_ASSERT_RELEASE(kv.first >= remove_size);
     }
 

--- a/test/test_multi_output.cpp
+++ b/test/test_multi_output.cpp
@@ -57,8 +57,9 @@ int main(int argc, char **argv) {
       xor_write = std::hash<std::string>()(message);
       mo.async_write_line(subpath, message);
 
-      xor_write = world.all_reduce(
-          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_write = ygm::all_reduce(
+          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Read lines back
@@ -70,8 +71,9 @@ int main(int argc, char **argv) {
         xor_read ^= std::hash<std::string>()(line);
       });
 
-      xor_read = world.all_reduce(
-          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_read = ygm::all_reduce(
+          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Clean up files
@@ -112,8 +114,9 @@ int main(int argc, char **argv) {
       xor_write ^= std::hash<std::string>()(message);
       mo.async_write_line(subpath, message);
 
-      xor_write = world.all_reduce(
-          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_write = ygm::all_reduce(
+          xor_write, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Read lines back
@@ -125,8 +128,9 @@ int main(int argc, char **argv) {
         xor_read ^= std::hash<std::string>()(line);
       });
 
-      xor_read = world.all_reduce(
-          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; });
+      xor_read = ygm::all_reduce(
+          xor_read, [](const uint64_t a, const uint64_t b) { return a ^ b; },
+          world);
     }
 
     // Clean up files

--- a/test/test_ndjson_parser.cpp
+++ b/test/test_ndjson_parser.cpp
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
   jsonp.for_all([&world, &local_count](const auto& json) { ++local_count; });
 
   world.barrier();
-  YGM_ASSERT_RELEASE(world.all_reduce_sum(local_count) == 3);
+  YGM_ASSERT_RELEASE(ygm::sum(local_count, world) == 3);
 
   return 0;
 }

--- a/test/test_parquet_reader.cpp
+++ b/test/test_parquet_reader.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
           YGM_ASSERT_RELEASE(bool_col == expected.bool_col);
           ++count_rows;
         });
-    YGM_ASSERT_RELEASE(world.all_reduce_sum(count_rows) == 10);
+    YGM_ASSERT_RELEASE(ygm::sum(count_rows, world) == 10);
 
     // For all with column names
     count_rows = 0;
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
 
           ++count_rows;
         });
-    YGM_ASSERT_RELEASE(world.all_reduce_sum(count_rows) == 10);
+    YGM_ASSERT_RELEASE(ygm::sum(count_rows, world) == 10);
 
     // Test peek()
     {

--- a/test/test_random.cpp
+++ b/test/test_random.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
     rn_set.for_all([](int key, int val) { YGM_ASSERT_RELEASE(val == 1); });
     sample_set.for_all([](int key, int val) { YGM_ASSERT_RELEASE(val == 1); });
 
-    int global_counter = world.all_reduce_sum(local_counter);
+    int global_counter = ygm::sum(local_counter, world);
 
     YGM_ASSERT_RELEASE(global_counter == world.size());
   }

--- a/test/test_recursion_large_messages.cpp
+++ b/test/test_recursion_large_messages.cpp
@@ -6,7 +6,6 @@
 #undef NDEBUG
 #include <random>
 #include <vector>
-#include <ygm/collective.hpp>
 #include <ygm/comm.hpp>
 
 static std::default_random_engine gen;
@@ -49,7 +48,8 @@ int main(int argc, char **argv) {
     }
 
     world.barrier();
-    YGM_ASSERT_RELEASE(ygm::sum(counter, world) == ((size_t(1) << max_hops) - 1));
+    YGM_ASSERT_RELEASE(ygm::sum(counter, world) ==
+                       ((size_t(1) << max_hops) - 1));
   }
 
   return 0;

--- a/test/test_recursion_progress.cpp
+++ b/test/test_recursion_progress.cpp
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 #undef NDEBUG
-#include <ygm/collective.hpp>
 #include <ygm/comm.hpp>
 
 static size_t counter = 0;

--- a/test/test_reduce_by_key.cpp
+++ b/test/test_reduce_by_key.cpp
@@ -6,8 +6,8 @@
 #undef NDEBUG
 
 #include <ygm/comm.hpp>
-#include <ygm/container/reduce_by_key.hpp>
 #include <ygm/container/bag.hpp>
+#include <ygm/container/reduce_by_key.hpp>
 
 int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
@@ -22,7 +22,8 @@ int main(int argc, char** argv) {
 
     YGM_ASSERT_RELEASE(test.size() == 1);
     test.async_visit(
-        0, [](int key, int value, int size) { YGM_ASSERT_RELEASE(value == size); },
+        0,
+        [](int key, int value, int size) { YGM_ASSERT_RELEASE(value == size); },
         world.size());
   }
 
@@ -49,7 +50,7 @@ int main(int argc, char** argv) {
         YGM_ASSERT_RELEASE(false);
       }
     });
-    YGM_ASSERT_RELEASE(world.all_reduce_sum(found) == 2);
+    YGM_ASSERT_RELEASE(ygm::sum(found, world) == 2);
   }
 
   return 0;

--- a/tools/parquet_tools.cpp
+++ b/tools/parquet_tools.cpp
@@ -194,7 +194,7 @@ void count_rows(const options_t& opt, ygm::comm& world) {
   if (opt.read_lines) {
     world.cout0() << "Actually read lines." << std::endl;
     parquetp.for_all([&num_rows](const auto& row) { ++num_rows; });
-    num_rows = world.all_reduce_sum(num_rows);
+    num_rows = ::ygm::sum(num_rows, world);
   } else {
     num_rows = parquetp.num_rows();
   }
@@ -282,7 +282,7 @@ void dump(const options_t& opt, ygm::comm& world) {
     ::MPI_Abort(world.get_mpi_comm(), EXIT_FAILURE);
   }
   const auto elapsed_time = timer.elapsed();
-  num_rows                = world.all_reduce_sum(num_rows);
+  num_rows                = ::ygm::sum(num_rows, world);
 
   world.cout0() << "Elapsed time: " << elapsed_time << " seconds" << std::endl;
   world.cout0() << "#of rows = " << num_rows << std::endl;


### PR DESCRIPTION
Includes changing all internal uses of collectives in YGM to use the stand-alone functions.

There was a circular dependency from the `comm` using collectives for printing stats. In order to work around this cleanly, user code should not include `collective.hpp`. As such, this file was moved to `include/ygm/detail/collective.hpp`. As it is, including `collective.hpp` in user-code may cause collectives or `ygm::comm` to be unable to find definitions for the other.