### PR TITLE
MacOS GCC Tests

### DIFF
--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15]
-        compiler: [g++-14, clang-18]
+        compiler: [clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15]
-        compiler: [g++-13, clang-18]
+        compiler: [g++-14, clang-18]
         mpi-type: [openmpi]
         build-type: [Release, Debug]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removing final macos CI tests using GCC. CMake is currently unable to find MPI after installing OpenMPI. This does not seem to affect Clang CI jobs at this time.

Seems to be the same issue as was in [PR 332](https://github.com/LLNL/ygm/pull/332) that caused removal of gcc-14 tests on macos. The timing of the previous change was suspiciously close to [Homebrew's change from gcc-14 to gcc-15](https://github.com/Homebrew/homebrew-core/commit/a590c35f46813f3bfda08c8b3740d82cedb020ce). 