### PR TITLE
ci: add concurrency groups to cancel obsolete CI runs

### DIFF
--- a/.github/workflows/build-pdf-docs.yaml
+++ b/.github/workflows/build-pdf-docs.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_docs:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/ci-test-macos.yaml
+++ b/.github/workflows/ci-test-macos.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ 'feature/**', 'hotfix/**']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     strategy:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ 'feature/**', 'hotfix/**']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     strategy:

--- a/.github/workflows/test_docs_build.yaml
+++ b/.github/workflows/test_docs_build.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ 'feature/**', 'hotfix/**']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Pull Request:** Add Concurrency Groups to Project CI Workflows 🚀

---

## Overview

This PR injects a top-level `concurrency` block into every CI workflow under `.github/workflows/` so that when a newer commit is pushed to the same branch, any queued or in-progress jobs from the previous commit are automatically cancelled.

Affected files:

* `build-pdf-docs.yaml`
* `ci-test.yaml`
* `ci-test-macos.yaml`
* `test_docs_build.yaml`

Each now includes:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

---

## Example of the Issue

1. **Without concurrency groups:**

   * Developer A pushes **commit `abc123`** → CI run **15** is queued.
   * Before 15 starts, Dev A pushes **commit `def456`** → CI run **16** is queued behind 15.
   * CI run 15 starts and completes, then 16 runs.
   * **Wasted effort:** Runner time spent on 15, even though its results are now obsolete.

2. **With concurrency groups (this PR):**

   * Dev A pushes **commit `abc123`** → CI run **15** queued.
   * Dev A pushes **commit `def456`** → CI run **16** queued **and immediately cancels** 15.
   * Only 16 runs.
   * **Result:** No redundant builds; feedback for the latest code arrives sooner.

---

## Why This Matters

* **Eliminate Redundant Builds:** Frees up runner capacity by auto-cancelling outdated runs.
* **Accelerate Feedback Loops:** Developers receive results for the most recent push without delay.
* **Reduce CI Costs:** Prevents needless consumption of compute minutes.
* **Maintain Clean Build History:** Only relevant runs remain, making failures easier to diagnose.

---

## How to Verify

1. Push a change to any branch (e.g. `feature/foo`).
2. Immediately push another commit to the same branch.
3. In the Actions UI, observe that the first run is canceled the moment the second is queued.

---

Please review and let me know if any adjustments are needed to the grouping key or scope. Once approved, all future workflows in this repo will follow the same pattern for optimal CI throughput and developer productivity.
