### PR TITLE
Add ygm_ptr access for multi_output

### DIFF
--- a/include/ygm/io/daily_output.hpp
+++ b/include/ygm/io/daily_output.hpp
@@ -35,7 +35,8 @@ class daily_output {
    */
   daily_output(ygm::comm &comm, const std::string &filename_prefix,
                size_t buffer_length = 1024 * 1024, bool append = false)
-      : m_multi_output(comm, filename_prefix, buffer_length, append) {}
+      : m_multi_output(comm, filename_prefix, buffer_length, append),
+        pthis(this) {}
 
   /**
    * @brief Write a line of output
@@ -62,7 +63,27 @@ class daily_output {
     m_multi_output.async_write_line(date_path, std::forward<Args>(args)...);
   }
 
+  /**
+   * @brief Access to own ygm_ptr
+   *
+   * @return `ygm_ptr` used by the container when identifying itself in `async`
+   * calls on the `ygm::comm`
+   */
+  typename ygm::ygm_ptr<self_type> get_ygm_ptr() {
+    return static_cast<self_type *>(this)->pthis;
+  }
+
+  /**
+   * @brief Const access to own ygm ptr
+   *
+   * @return `ygm_ptr` to const version of container
+   */
+  const typename ygm::ygm_ptr<self_type> get_ygm_ptr() const {
+    return static_cast<const self_type *>(this)->pthis;
+  }
+
  private:
-  multi_output<Partitioner> m_multi_output;
+  multi_output<Partitioner>        m_multi_output;
+  typename ygm::ygm_ptr<self_type> pthis;
 };
 }  // namespace ygm::io

--- a/include/ygm/io/multi_output.hpp
+++ b/include/ygm/io/multi_output.hpp
@@ -16,7 +16,6 @@
 #include <string>
 
 #include <ygm/container/detail/hash_partitioner.hpp>
-#include <ygm/detail/ygm_ptr.hpp>
 
 namespace ygm::io {
 
@@ -108,7 +107,7 @@ class multi_output {
   ygm::comm &comm() { return m_comm; }
 
   /**
-   * @brief Access to the ygm_ptr
+   * @brief Access to own ygm_ptr
    *
    * @return `ygm_ptr` used by the container when identifying itself in `async`
    * calls on the `ygm::comm`
@@ -118,7 +117,7 @@ class multi_output {
   }
 
   /**
-   * @brief Const access to the ygm ptr used by the container
+   * @brief Const access to own ygm ptr
    *
    * @return `ygm_ptr` to const version of container
    */

--- a/include/ygm/io/multi_output.hpp
+++ b/include/ygm/io/multi_output.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <ygm/container/detail/base_misc.hpp>
 #include <ygm/container/detail/hash_partitioner.hpp>
 
 namespace ygm::io {

--- a/include/ygm/io/multi_output.hpp
+++ b/include/ygm/io/multi_output.hpp
@@ -14,8 +14,9 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <ygm/container/detail/base_misc.hpp>
+
 #include <ygm/container/detail/hash_partitioner.hpp>
+#include <ygm/detail/ygm_ptr.hpp>
 
 namespace ygm::io {
 
@@ -105,6 +106,25 @@ class multi_output {
   }
 
   ygm::comm &comm() { return m_comm; }
+
+  /**
+   * @brief Access to the ygm_ptr
+   *
+   * @return `ygm_ptr` used by the container when identifying itself in `async`
+   * calls on the `ygm::comm`
+   */
+  typename ygm::ygm_ptr<self_type> get_ygm_ptr() {
+    return static_cast<self_type *>(this)->pthis;
+  }
+
+  /**
+   * @brief Const access to the ygm ptr used by the container
+   *
+   * @return `ygm_ptr` to const version of container
+   */
+  const typename ygm::ygm_ptr<self_type> get_ygm_ptr() const {
+    return static_cast<const self_type *>(this)->pthis;
+  }
 
  private:
   class buffered_ofstream {


### PR DESCRIPTION
Add get_ygm_ptr member functions to ygm::io::multi_output. 

Since ygm/container/detail/base_misc.hpp has some additional functions that don't seem relevant for multi_output, I added get_ygm_ptr directly to multi_output instead of including base_misc.