### PR TITLE
Parquet: accept existing python env

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(YGM_BUILD_TESTS "Build tests" OFF)
 option(YGM_BUILD_DOCS "Adds targets for generating Doxygen and Sphinx documentation" OFF)
 option(YGM_DOCS_ONLY "Run Cmake for only generating documentation (i.e. for Read the Docs)" OFF)
 option(YGM_INSTALL_PARQUET "Installs Arrow Parquet." OFF)
+set(YGM_PYTHON_VENV_ROOT CACHE PATH "Path to a Python virtual environment root. If set, YGM will use this virtual environment for Python dependencies.")
 option(YGM_DONT_USE_MREMAP "Do not try using mremap for managing memory." OFF)
 
 #

--- a/cmake/FindArrowParquet.cmake
+++ b/cmake/FindArrowParquet.cmake
@@ -99,6 +99,11 @@ function(find_pyarrow_package)
 endfunction()
 
 # Install pyarrow using pip
+# Input:
+# YGM_PYTHON_VENV_ROOT can be set to the root of an existing Python virtual environment.
+# This function will activate the virtual environment and find or install pyarrow.
+# If it is not set, a Python virtual environment is created in the build directory.
+#
 # Output:
 # PIP_PYARROW_ROOT is set to the root of the pyarrow installation.
 function(install_pyarrow_in_venv)

--- a/cmake/FindArrowParquet.cmake
+++ b/cmake/FindArrowParquet.cmake
@@ -102,9 +102,14 @@ endfunction()
 # Output:
 # PIP_PYARROW_ROOT is set to the root of the pyarrow installation.
 function(install_pyarrow_in_venv)
-    setup_python_venv()
-    if (NOT PYTHON_VENV_ROOT)
-        return()
+    if (YGM_PYTHON_VENV_ROOT)
+        set(PYTHON_VENV_ROOT ${YGM_PYTHON_VENV_ROOT})
+    else ()
+        setup_python_venv()
+        # setup_python_venv() sets PYTHON_VENV_ROOT
+        if (NOT PYTHON_VENV_ROOT)
+            return()
+        endif ()
     endif ()
 
     activate_python_venv(${PYTHON_VENV_ROOT})


### PR DESCRIPTION
This PR makes YGM take a path to an existing Python virtual environment directory and use the location for finding/installing pyarrow.
This PR is also useful for specifying a specific Python executable.

```shell

/path/to/python3 -m venv $HOME/venv/my-venv
source $HOME/venv/my-venv/bin/activate
# If pyarrow is not installed, YGM's will do that during the CMake configuration.
pip install pyarrow==20.0.*
deactivate

# Build YGM
cd ygm//build
cmake ../ -DYGM_INSTALL_PARQUET=ON -DYGM_PYTHON_VENV_ROOT=$HOME/venv/my-venv

```