### PR TITLE
Virtual NR Routing

### DIFF
--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -36,7 +36,7 @@ struct comm::header_t {
 inline comm::comm(int *argc, char ***argv)
     : pimpl_if(std::make_shared<detail::mpi_init_finalize>(argc, argv)),
       m_layout(MPI_COMM_WORLD),
-      m_router(m_layout, config.routing) {
+      m_router(m_layout, config, config.routing) {
   // pimpl_if = std::make_shared<detail::mpi_init_finalize>(argc, argv);
   comm_setup(MPI_COMM_WORLD);
 }
@@ -48,7 +48,7 @@ inline comm::comm(int *argc, char ***argv)
  * @return Constructed ygm::comm object
  */
 inline comm::comm(MPI_Comm mcomm)
-    : m_layout(mcomm), m_router(m_layout, config.routing) {
+    : m_layout(mcomm), m_router(m_layout, config, config.routing) {
   pimpl_if.reset();
   int flag(0);
   YGM_ASSERT_MPI(MPI_Initialized(&flag));

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -17,7 +17,7 @@ namespace ygm {
 
 namespace detail {
 
-enum class routing_type { NONE, NR, NLNR };
+enum class routing_type { NONE, NR, NLNR, VIRTUAL_NR };
 
 inline size_t round_to_nearest_kb(float number) {
   return std::ceil(static_cast<float>(number) / 1024) * 1024;
@@ -53,9 +53,15 @@ class comm_environment {
         routing = routing_type::NR;
       } else if (std::string(cc) == "NLNR") {
         routing = routing_type::NLNR;
+      } else if (std::string(cc) == "VIRTUAL_NR") {
+        routing = routing_type::VIRTUAL_NR;
       } else {
         throw std::runtime_error("comm_environment -- unknown routing type");
       }
+    }
+
+    if (const char* cc = std::getenv("YGM_COMM_VIRTUAL_NODE_SIZE")) {
+      virtual_node_size = convert<uint32_t>(cc);
     }
 
     // Calculate local and remote buffer sizes based on heuristics for the
@@ -86,6 +92,10 @@ class comm_environment {
         local_buffer_size =
             round_to_nearest_kb(2 * (float)total_buffer_size / 3);
         remote_buffer_size = round_to_nearest_kb((float)total_buffer_size / 3);
+        break;
+      case routing_type::VIRTUAL_NR:
+        local_buffer_size  = round_to_nearest_kb((float)total_buffer_size / 2);
+        remote_buffer_size = local_buffer_size;
         break;
     }
     if (const char* cc = std::getenv("YGM_COMM_LOCAL_BUFFER_SIZE_KB")) {
@@ -174,6 +184,9 @@ class comm_environment {
       case routing_type::NLNR:
         os << "NLNR\n";
         break;
+      case routing_type::VIRTUAL_NR:
+        os << "VIRTUAL_NR\n";
+        break;
     }
     os << "YGM_COMM_TRACE_YGM          = " << trace_ygm << "\n";
     os << "YGM_COMM_TRACE_MPI          = " << trace_mpi << "\n";
@@ -216,7 +229,8 @@ class comm_environment {
   size_t freq_issend               = 8;
   size_t send_buffer_free_list_len = 32;
 
-  routing_type routing = routing_type::NONE;
+  routing_type routing           = routing_type::NONE;
+  uint32_t     virtual_node_size = 16;
 
   std::string default_log_path  = "./log/ygm_logs_";
   log_level   default_log_level = log_level::off;

--- a/include/ygm/detail/comm_router.hpp
+++ b/include/ygm/detail/comm_router.hpp
@@ -76,6 +76,13 @@ class comm_router {
               m_layout.rank() % m_config.virtual_node_size;
           to_return = dest_virtual_node * m_config.virtual_node_size +
                       current_virtual_offset;
+          if (to_return >=
+              m_layout
+                  .size()) {  // Account for last virtual node not being "full"
+            int last_node_size = m_layout.size() % m_config.virtual_node_size;
+            to_return = dest_virtual_node * m_config.virtual_node_size +
+                        (m_layout.rank() % last_node_size);
+          }
         }
       } break;
       default:

--- a/include/ygm/detail/comm_router.hpp
+++ b/include/ygm/detail/comm_router.hpp
@@ -17,8 +17,9 @@ namespace detail {
  */
 class comm_router {
  public:
-  comm_router(const layout &l, const routing_type route = routing_type::NONE)
-      : m_layout(l), m_default_route(route) {}
+  comm_router(const layout &l, const comm_environment &config,
+              const routing_type route = routing_type::NONE)
+      : m_layout(l), m_default_route(route), m_config(config) {}
 
   /**
    * @brief Calculates the next hop based on the given routing scheme and final
@@ -65,6 +66,18 @@ class comm_router {
           }
         }
         break;
+      case routing_type::VIRTUAL_NR: {
+        int current_virtual_node = m_layout.rank() / m_config.virtual_node_size;
+        int dest_virtual_node    = dest / m_config.virtual_node_size;
+        if (current_virtual_node == dest_virtual_node) {
+          to_return = dest;
+        } else {
+          int current_virtual_offset =
+              m_layout.rank() % m_config.virtual_node_size;
+          to_return = dest_virtual_node * m_config.virtual_node_size +
+                      current_virtual_offset;
+        }
+      } break;
       default:
         std::cerr << "Unknown routing type" << std::endl;
         return -1;
@@ -76,8 +89,9 @@ class comm_router {
   int next_hop(const int dest) const { return next_hop(dest, m_default_route); }
 
  private:
-  const layout &m_layout;
-  routing_type  m_default_route;
+  const layout    &m_layout;
+  routing_type     m_default_route;
+  comm_environment m_config;
 };
 
 }  // namespace detail

--- a/test/test_comm.cpp
+++ b/test/test_comm.cpp
@@ -10,7 +10,8 @@
 int main() {
   YGM_ASSERT_MPI(MPI_Init(nullptr, nullptr));
 
-  std::vector<std::string> routing_schemes{"NONE", "NR", "NLNR"};
+  setenv("YGM_COMM_VIRTUAL_NODE_SIZE", "2", 1);
+  std::vector<std::string> routing_schemes{"NONE", "NR", "NLNR", "VIRTUAL_NR"};
   for (const auto& routing_scheme : routing_schemes) {
     setenv("YGM_COMM_ROUTING", routing_scheme.c_str(), 1);
 

--- a/test/test_comm.cpp
+++ b/test/test_comm.cpp
@@ -10,7 +10,7 @@
 int main() {
   YGM_ASSERT_MPI(MPI_Init(nullptr, nullptr));
 
-  setenv("YGM_COMM_VIRTUAL_NODE_SIZE", "2", 1);
+  setenv("YGM_COMM_VIRTUAL_NODE_SIZE", "3", 1);
   std::vector<std::string> routing_schemes{"NONE", "NR", "NLNR", "VIRTUAL_NR"};
   for (const auto& routing_scheme : routing_schemes) {
     setenv("YGM_COMM_ROUTING", routing_scheme.c_str(), 1);
@@ -31,15 +31,13 @@ int main() {
       YGM_ASSERT_RELEASE(counter == 1);
     }
 
-    /*
     //
     // Test all ranks async to all others
     {
       size_t counter{};
       auto   pcounter = world.make_ygm_ptr(counter);
       for (int dest = 0; dest < world.size(); ++dest) {
-        world.async(
-            dest, [](auto pcounter) { (*pcounter)++; }, pcounter);
+        world.async(dest, [](auto pcounter) { (*pcounter)++; }, pcounter);
       }
       world.barrier();
       YGM_ASSERT_RELEASE(counter == (size_t)world.size());
@@ -67,7 +65,7 @@ int main() {
       }
 
       world.barrier();
-      YGM_ASSERT_RELEASE(counter == num_bcasts * world.size());
+      YGM_ASSERT_RELEASE(counter == size_t(num_bcasts * world.size()));
     }
 
     //
@@ -102,25 +100,31 @@ int main() {
       YGM_ASSERT_RELEASE(min == 0);
 
       auto sum = ygm::sum(size_t(world.rank()), world);
-      YGM_ASSERT_RELEASE(sum ==
-                     (((size_t)world.size() - 1) * (size_t)world.size()) / 2);
+      YGM_ASSERT_RELEASE(
+          sum == (((size_t)world.size() - 1) * (size_t)world.size()) / 2);
 
       size_t id  = world.rank();
-      auto   red = ygm::all_reduce(id, [](size_t a, size_t b) {
-        if (a < b) {
-          return a;
-        } else {
-          return b;
-        }
-      }, world);
+      auto   red = ygm::all_reduce(
+          id,
+          [](size_t a, size_t b) {
+            if (a < b) {
+              return a;
+            } else {
+              return b;
+            }
+          },
+          world);
       YGM_ASSERT_RELEASE(red == 0);
-      auto red2 = ygm::all_reduce(id, [](size_t a, size_t b) {
-        if (a > b) {
-          return a;
-        } else {
-          return b;
-        }
-      }, world);
+      auto red2 = ygm::all_reduce(
+          id,
+          [](size_t a, size_t b) {
+            if (a > b) {
+              return a;
+            } else {
+              return b;
+            }
+          },
+          world);
       YGM_ASSERT_RELEASE(red2 == (size_t)world.size() - 1);
     }
 
@@ -134,7 +138,6 @@ int main() {
       world.barrier();
       YGM_ASSERT_RELEASE(done);
     }
-    */
   }
 
   YGM_ASSERT_MPI(MPI_Finalize());


### PR DESCRIPTION
Adds virtual NR routing scheme that functions similarly to NR but with an environment variable to control the number of ranks assigned to a virtual node for use in routing calculations.

This is enabled and controlled by setting the `YGM_COMM_ROUTING" environment variable to "VIRTUAL_NR", and then setting `YGM_COMM_VIRTUAL_NODE_SIZE` to the desired number of ranks to consider to be on the same node when performing routing calculations.

This routing scheme does not use any information about the mapping of ranks to compute nodes when determining which ranks get assigned to the same virtual node. Ranks are assigned block-cyclically according to their ID.

To get access to the new `YGM_COMM_VIRTUAL_NODE_SIZE` environment variable, the `comm_router` object needs to be given access to the `comm_environment` variable set up by the `comm`.