### PR TITLE
Hotfix/disable system boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif ()
 # Boost
 #
 if (NOT boost_POPULATED)
-    find_package(Boost 1.81 COMPONENTS json unordered container)
+    find_package(Boost 1.87 COMPONENTS json unordered container static_string)
     if (Boost_FOUND)
         message(STATUS ${PROJECT_NAME} " found boost include dirs: "
                        ${Boost_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,20 +103,13 @@ endif ()
 # Boost
 #
 if (NOT boost_POPULATED)
-    find_package(Boost 1.81 COMPONENTS json unordered container static_string)
-    if (Boost_FOUND)
-        message(STATUS ${PROJECT_NAME} " found boost include dirs: "
-                       ${Boost_INCLUDE_DIRS}
-        )
-    else ()
-        message(STATUS "Fetching Boost from source")
-        FetchContent_Declare(
-            Boost
-            URL ${BOOST_FETCH_URL}
-        )
-        set(BOOST_INCLUDE_LIBRARIES json unordered container static_string)
-        FetchContent_MakeAvailable(Boost)
-    endif ()
+    message(STATUS "Fetching Boost from source")
+    FetchContent_Declare(
+        Boost
+        URL ${BOOST_FETCH_URL}
+    )
+    set(BOOST_INCLUDE_LIBRARIES json unordered container static_string)
+    FetchContent_MakeAvailable(Boost)
 endif ()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif ()
 # Boost
 #
 if (NOT boost_POPULATED)
-    find_package(Boost 1.81)
+    find_package(Boost 1.81 COMPONENTS json unordered container)
     if (Boost_FOUND)
         message(STATUS ${PROJECT_NAME} " found boost include dirs: "
                        ${Boost_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif ()
 # Boost
 #
 if (NOT boost_POPULATED)
-    find_package(Boost 1.87 COMPONENTS json unordered container static_string)
+    find_package(Boost 1.81 COMPONENTS json unordered container static_string)
     if (Boost_FOUND)
         message(STATUS ${PROJECT_NAME} " found boost include dirs: "
                        ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
Removing the ability to use Boost installed on the system. When CMake finds a version of Boost that meets the version requirement on Boost but does not include all necessary components, we get conflicts with Boost targets from the version we need to download with the system version that was partially found.

There is likely a way to deal with this, but I'm putting in the crude solution for now.