### PR TITLE
Hotfix/spdlog include

### DIFF
--- a/include/ygm/detail/logger.hpp
+++ b/include/ygm/detail/logger.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
 #include <filesystem>

--- a/include/ygm/detail/logger.hpp
+++ b/include/ygm/detail/logger.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "spdlog.h"
 #include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/spdlog.h"
 
 #include <filesystem>
 


### PR DESCRIPTION
Fixing an issue with `spdlog` includes when linking an application against YGM and spdlog, pointed out in [Issue 382](https://github.com/LLNL/ygm/issues/382).