### PR TITLE
can choose between docs and no-docs containers, saving gigs of disk space

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,14 @@
 # FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
-FROM mcr.microsoft.com/devcontainers/cpp:dev-ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/cpp:dev-ubuntu-24.04 AS base
 
-RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt -y install clangd-19 clang-tidy-19 openmpi-bin openmpi-doc libopenmpi-dev python3-sphinx python3-breathe doxygen python3-sphinx-rtd-theme texlive-full
+RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt -y install clangd-19 clang-tidy-19 openmpi-bin openmpi-doc libopenmpi-dev
 RUN update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-19 100
 RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 100
+
+# No docs variant - minimal version without documentation tools
+FROM base AS no_docs
+# Inherits base without any additional packages
+
+# Full variant - adds documentation tools
+FROM base AS full
+RUN apt update && export DEBIAN_FRONTEND=noninteractive && apt -y install python3-sphinx python3-breathe doxygen python3-sphinx-rtd-theme texlive-full

--- a/.devcontainer/full/devcontainer.json
+++ b/.devcontainer/full/devcontainer.json
@@ -1,9 +1,10 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-	"name": "YGM",
+	"name": "YGM (Full with Docs)",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "../Dockerfile",
+		"target": "full"
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -11,15 +12,14 @@
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-	"extensions": [
-		"llvm-vs-code-extensions.vscode-clangd",
-		// add other extensions as needed
-	]
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"llvm-vs-code-extensions.vscode-clangd"
+			]
+		}
+	},
 	"mounts": [
-		"source=${localEnv:HOME}${localEnv:USERPROFILE},target=/host-home,type=bind,consistency=cached",
+		"source=${localEnv:HOME}${localEnv:USERPROFILE},target=/host-home,type=bind,consistency=cached"
 	]
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"	
 }

--- a/.devcontainer/no_docs/devcontainer.json
+++ b/.devcontainer/no_docs/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "YGM (No Docs)",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"target": "no_docs"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"llvm-vs-code-extensions.vscode-clangd"
+			]
+		}
+	},
+	"mounts": [
+		"source=${localEnv:HOME}${localEnv:USERPROFILE},target=/host-home,type=bind,consistency=cached"
+	]
+}


### PR DESCRIPTION
VSCode supports multiple dev container configurations. The current configuration is very heavy because it requires tex-full and all the associated dependencies. It takes 10+ minutes to build on my machine.

I created a second alternate container configuration that removes the tex-full and sphinx dependencies - this is intended for development only, not document generation. It builds in less than a minute.

When starting up with a new container, VSCode will prompt the user to install the "full" container or the "no_docs" container.