### PR TITLE
Adds iterators to ygm::container::array

### DIFF
--- a/include/ygm/container/detail/block_partitioner.hpp
+++ b/include/ygm/container/detail/block_partitioner.hpp
@@ -91,7 +91,7 @@ struct block_partitioner {
    * @param global_index Index into global container
    * @return Index into local storage
    */
-  index_type local_index(const index_type &global_index) {
+  index_type local_index(const index_type &global_index) const {
     index_type to_return = global_index - m_local_start_index;
     YGM_ASSERT_RELEASE((to_return >= 0) && (to_return < m_local_size));
     return to_return;
@@ -104,7 +104,7 @@ struct block_partitioner {
    * @param local_index Index into locally-held items
    * @return Global index associated to local item index
    */
-  index_type global_index(const index_type &local_index) {
+  index_type global_index(const index_type &local_index) const {
     index_type to_return = m_local_start_index + local_index;
     YGM_ASSERT_RELEASE(to_return < m_partitioned_size);
     return to_return;
@@ -115,14 +115,14 @@ struct block_partitioner {
    *
    * @return Number of items stored on this rank
    */
-  index_type local_size() { return m_local_size; }
+  index_type local_size() const { return m_local_size; }
 
   /**
    * @brief Global index of first local item
    *
    * @return Beginning of global index space assigned to current rank
    */
-  index_type local_start() { return m_local_start_index; }
+  index_type local_start() const { return m_local_start_index; }
 
  private:
   int        m_comm_size;

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -46,6 +46,22 @@ int main(int argc, char **argv) {
     arr.for_all([](const auto index, const auto value) {
       YGM_ASSERT_RELEASE(index == size_t(value));
     });
+
+    // test range-based for
+    for (const auto &index_item : arr) {
+      YGM_ASSERT_RELEASE(index_item.index == size_t(index_item.value));
+    }
+
+    for (auto iter = arr.cbegin(); iter != arr.cend(); ++iter) {
+      YGM_ASSERT_RELEASE(iter->index == size_t(iter->value));
+    }
+
+    auto const_for_loop = [](const ygm::container::array<int> &c_arr) {
+      for (const auto &index_item : c_arr) {
+        YGM_ASSERT_RELEASE(index_item.index == size_t(index_item.value));
+      }
+    };
+    const_for_loop(arr);
   }
 
   // Test async_binary_op_update_value
@@ -306,9 +322,8 @@ int main(int argc, char **argv) {
     });
 
     // Double all values in copy
-    arr_copy.for_all([]([[maybe_unused]] const auto &index, auto &value) {
-      value *= 2;
-    });
+    arr_copy.for_all(
+        []([[maybe_unused]] const auto &index, auto &value) { value *= 2; });
 
     world.barrier();
 


### PR DESCRIPTION
Adds `base_iterators` CRTP class to `ygm::container::array` to allow for local iteration and range-based for loops.

Requires manual implementation of iterators within `array` to get access to index and values pairs from iterator.