### PR TITLE
Adds ability to send buffers that are larger than the irecv size

### DIFF
--- a/include/ygm/comm.hpp
+++ b/include/ygm/comm.hpp
@@ -371,6 +371,7 @@ class comm {
   void queue_message_bytes(const ygm::detail::byte_vector &packed,
                            const int                       dest);
 
+  int  prepare_receive_data(mpi_irecv_request &req_buffer, MPI_Status &status);
   void handle_next_receive(std::shared_ptr<ygm::detail::byte_vector> &buffer,
                            const size_t buffer_size, const uint32_t from_rank);
 
@@ -387,6 +388,7 @@ class comm {
   std::shared_ptr<detail::mpi_init_finalize> pimpl_if;
 
   MPI_Comm m_comm_async;
+  MPI_Comm m_comm_async_large_buffer;
   MPI_Comm m_comm_barrier;
   MPI_Comm m_comm_other;
 

--- a/include/ygm/detail/byte_vector.hpp
+++ b/include/ygm/detail/byte_vector.hpp
@@ -95,11 +95,12 @@ class byte_vector {
   const_reference operator[](int i) const { return m_data[i]; }
   reference       operator[](int i) { return m_data[i]; }
 
-  pointer data() const { return m_data; }
-  bool    empty() const { return m_size == 0; }
-  void    clear() { m_size = 0; }
-  size_t  size() const { return m_size; }
-  size_t  capacity() const { return m_capacity; }
+  pointer       data() const { return m_data; }
+  bool          empty() const { return m_size == 0; }
+  void          clear() { m_size = 0; }
+  size_t        size() const { return m_size; }
+  const size_t& size_ref() const { return m_size; }
+  size_t        capacity() const { return m_capacity; }
 
   Byte_Iterator begin() { return Byte_Iterator(this, 0); }
   Byte_Iterator end() { return Byte_Iterator(this, m_size); }

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -18,6 +18,8 @@ struct comm::header_t {
   int32_t  dest;
 };
 
+enum YGMTag : int { buffer_content, large_buffer_size };
+
 /**
  * @brief YGM communicator constructor
  *
@@ -74,6 +76,7 @@ inline void comm::comm_setup(MPI_Comm c) {
   m_logger.log(log_level::info, "Setting up ygm::comm");
 
   YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_async));
+  YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_async_large_buffer));
   YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_barrier));
   YGM_ASSERT_MPI(MPI_Comm_dup(c, &m_comm_other));
 
@@ -206,6 +209,7 @@ inline comm::~comm() {
   }
   YGM_ASSERT_RELEASE(MPI_Barrier(m_comm_async) == MPI_SUCCESS);
   YGM_ASSERT_RELEASE(MPI_Comm_free(&m_comm_async) == MPI_SUCCESS);
+  YGM_ASSERT_RELEASE(MPI_Comm_free(&m_comm_async_large_buffer) == MPI_SUCCESS);
   YGM_ASSERT_RELEASE(MPI_Comm_free(&m_comm_barrier) == MPI_SUCCESS);
   YGM_ASSERT_RELEASE(MPI_Comm_free(&m_comm_other) == MPI_SUCCESS);
 
@@ -249,12 +253,12 @@ inline void comm::async(int dest, AsyncFunction &&fn, const SendArgs &...args) {
   if (m_vec_send_buffers[next_dest].empty()) {
     if (local) {
       m_send_local_dest_queue.push_back(next_dest);
-      m_vec_send_buffers[next_dest].reserve(config.local_buffer_size /
-                                            m_layout.local_size());
+      m_vec_send_buffers[next_dest].reserve(std::max<size_t>(
+          config.local_buffer_size / m_layout.local_size(), 1));
     } else {
       m_send_remote_dest_queue.push_back(next_dest);
-      m_vec_send_buffers[next_dest].reserve(config.remote_buffer_size /
-                                            m_layout.node_size());
+      m_vec_send_buffers[next_dest].reserve(std::max<size_t>(
+          config.remote_buffer_size / m_layout.node_size(), 1));
     }
   }
 
@@ -817,9 +821,8 @@ inline std::pair<uint64_t, uint64_t> comm::barrier_reduce_counts() {
       } else {
         mpi_irecv_request req_buffer = m_recv_queue.front();
         m_recv_queue.pop_front();
-        int buffer_size{0};
-        YGM_ASSERT_MPI(MPI_Get_count(&twin_status[i], MPI_BYTE, &buffer_size));
-        m_stats.irecv(twin_status[i].MPI_SOURCE, buffer_size);
+
+        int buffer_size = prepare_receive_data(req_buffer, twin_status[i]);
 
         handle_next_receive(req_buffer.buffer, buffer_size,
                             twin_status[i].MPI_SOURCE);
@@ -839,6 +842,7 @@ inline void comm::flush_send_buffer(int dest) {
   static size_t counter = 0;
   if (m_vec_send_buffers[dest].size() > 0) {
     check_completed_sends();
+
     mpi_isend_request request;
 
     if (m_trace_mpi) {
@@ -854,20 +858,46 @@ inline void comm::flush_send_buffer(int dest) {
       m_free_send_buffers.pop_back();
     }
     request.buffer->swap(m_vec_send_buffers[dest]);
-    if (config.freq_issend > 0 && counter++ % config.freq_issend == 0) {
+
+    MPI_Comm comm_send = m_comm_async;
+
+    // Need to send message bundle size before message when size becomes too
+    // large
+    if (request.buffer->size() > config.irecv_size) {
+      log(log_level::debug, "MPI_Isend message size " +
+                                std::to_string(request.buffer->size()) +
+                                " to rank " + std::to_string(dest));
+
+      // Creating a temporary MPI_Request that is not going to be checked for
+      // completion. We are guaranteeing the buffer containing only the size of
+      // the message bundle is not invalid when MPI sends the message by using a
+      // reference to the internal size of the byte_vector for the message
+      // bundle that will be sent below. NOTE: This behavior relies on ordering
+      // of MPI sends to guarantee the send of the message bundle completes
+      // after the send containing just the size.
+      MPI_Request tmp_req;
+      YGM_ASSERT_MPI(
+          MPI_Isend(&(request.buffer->size_ref()), 1, MPI_UNSIGNED_LONG_LONG,
+                    dest, YGMTag::large_buffer_size, m_comm_async, &tmp_req));
+      YGM_ASSERT_MPI(MPI_Request_free(&tmp_req));
+
+      comm_send = m_comm_async_large_buffer;
+    }
+
+    if (config.freq_issend > 0 && ++counter % config.freq_issend == 0) {
       log(log_level::debug, "MPI_Issend " +
                                 std::to_string(request.buffer->size()) +
                                 " bytes to rank " + std::to_string(dest));
       YGM_ASSERT_MPI(MPI_Issend(request.buffer->data(), request.buffer->size(),
-                                MPI_BYTE, dest, 0, m_comm_async,
-                                &(request.request)));
+                                MPI_BYTE, dest, YGMTag::buffer_content,
+                                comm_send, &(request.request)));
     } else {
       log(log_level::debug, "MPI_Isend " +
                                 std::to_string(request.buffer->size()) +
                                 " bytes to rank " + std::to_string(dest));
       YGM_ASSERT_MPI(MPI_Isend(request.buffer->data(), request.buffer->size(),
-                               MPI_BYTE, dest, 0, m_comm_async,
-                               &(request.request)));
+                               MPI_BYTE, dest, YGMTag::buffer_content,
+                               comm_send, &(request.request)));
     }
     m_stats.isend(dest, request.buffer->size());
 
@@ -1354,6 +1384,35 @@ inline void comm::queue_message_bytes(const ygm::detail::byte_vector &packed,
 }
 
 /**
+ * @brief Prepare receive buffer for processing after a receive has completed
+ *
+ * @tparam
+ * @param req_buffer mpi_irecv_request object for current receive
+ * @param status MPI_Status associated to current receive
+ * @return Size of received data buffer
+ */
+inline int comm::prepare_receive_data(mpi_irecv_request &req_buffer,
+                                      MPI_Status        &status) {
+  int buffer_size{0};
+
+  if (status.MPI_TAG == YGMTag::buffer_content) {
+    YGM_ASSERT_MPI(MPI_Get_count(&status, MPI_BYTE, &buffer_size));
+    m_stats.irecv(status.MPI_SOURCE, buffer_size);
+  } else if (status.MPI_TAG == YGMTag::large_buffer_size) {
+    memcpy(&buffer_size, req_buffer.buffer.get()->data(), sizeof(int));
+    req_buffer.buffer.get()->resize(buffer_size);
+    YGM_ASSERT_MPI(MPI_Recv(req_buffer.buffer.get()->data(), buffer_size,
+                            MPI_BYTE, status.MPI_SOURCE, YGMTag::buffer_content,
+                            m_comm_async_large_buffer, &status));
+  } else {
+    cerr() << "Unknown tag received" << status.MPI_TAG << std::endl;
+    exit(1);
+  }
+
+  return buffer_size;
+}
+
+/**
  * @brief Deserializes and processes messages in a buffer of received messages
  *
  * @param buffer Shared pointer to buffer of received messages
@@ -1424,6 +1483,7 @@ inline void comm::handle_next_receive(
       m_stats.rpc_execute();
     }
   }
+  buffer->resize(config.irecv_size);
   post_new_irecv(buffer);
   flush_to_capacity();
 }
@@ -1467,9 +1527,8 @@ inline bool comm::process_receive_queue() {
         received_to_return           = true;
         mpi_irecv_request req_buffer = m_recv_queue.front();
         m_recv_queue.pop_front();
-        int buffer_size{0};
-        YGM_ASSERT_MPI(MPI_Get_count(&twin_status[i], MPI_BYTE, &buffer_size));
-        m_stats.irecv(twin_status[i].MPI_SOURCE, buffer_size);
+
+        int buffer_size = prepare_receive_data(req_buffer, twin_status[i]);
 
         handle_next_receive(req_buffer.buffer, buffer_size,
                             twin_status[i].MPI_SOURCE);
@@ -1503,9 +1562,8 @@ inline bool comm::local_process_incoming() {
       received_to_return           = true;
       mpi_irecv_request req_buffer = m_recv_queue.front();
       m_recv_queue.pop_front();
-      int buffer_size{0};
-      YGM_ASSERT_MPI(MPI_Get_count(&status, MPI_BYTE, &buffer_size));
-      m_stats.irecv(status.MPI_SOURCE, buffer_size);
+
+      int buffer_size = prepare_receive_data(req_buffer, status);
 
       handle_next_receive(req_buffer.buffer, buffer_size, status.MPI_SOURCE);
     } else {

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -1397,7 +1397,6 @@ inline int comm::prepare_receive_data(mpi_irecv_request &req_buffer,
 
   if (status.MPI_TAG == YGMTag::buffer_content) {
     YGM_ASSERT_MPI(MPI_Get_count(&status, MPI_BYTE, &buffer_size));
-    m_stats.irecv(status.MPI_SOURCE, buffer_size);
   } else if (status.MPI_TAG == YGMTag::large_buffer_size) {
     memcpy(&buffer_size, req_buffer.buffer.get()->data(), sizeof(int));
     req_buffer.buffer.get()->resize(buffer_size);
@@ -1408,6 +1407,8 @@ inline int comm::prepare_receive_data(mpi_irecv_request &req_buffer,
     cerr() << "Unknown tag received" << status.MPI_TAG << std::endl;
     exit(1);
   }
+
+  m_stats.irecv(status.MPI_SOURCE, buffer_size);
 
   return buffer_size;
 }

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -74,18 +74,21 @@ class comm_environment {
     }
     switch (routing) {
       case routing_type::NONE:
-        local_buffer_size =
-            round_to_nearest_kb((float)total_buffer_size / nodes);
-        remote_buffer_size = total_buffer_size - local_buffer_size;
+        local_buffer_size = std::max<size_t>(
+            round_to_nearest_kb((float)total_buffer_size / nodes), 1);
+        remote_buffer_size =
+            std::max<size_t>(total_buffer_size - local_buffer_size, 1);
         break;
       case routing_type::NR:
-        local_buffer_size  = round_to_nearest_kb((float)total_buffer_size / 2);
+        local_buffer_size = std::max<size_t>(
+            round_to_nearest_kb((float)total_buffer_size / 2), 1);
         remote_buffer_size = local_buffer_size;
         break;
       case routing_type::NLNR:
-        local_buffer_size =
-            round_to_nearest_kb(2 * (float)total_buffer_size / 3);
-        remote_buffer_size = round_to_nearest_kb((float)total_buffer_size / 3);
+        local_buffer_size = std::max<size_t>(
+            round_to_nearest_kb(2 * (float)total_buffer_size / 3), 1);
+        remote_buffer_size = std::max<size_t>(
+            round_to_nearest_kb((float)total_buffer_size / 3), 1);
         break;
     }
     if (const char* cc = std::getenv("YGM_COMM_LOCAL_BUFFER_SIZE_KB")) {

--- a/include/ygm/detail/comm_environment.hpp
+++ b/include/ygm/detail/comm_environment.hpp
@@ -212,7 +212,7 @@ class comm_environment {
   size_t local_buffer_size;
   size_t remote_buffer_size;
 
-  size_t irecv_size = 1024 * 1024 * 1024;
+  size_t irecv_size = 1024 * 1024;
   size_t num_irecvs = 8;
 
   size_t num_isends_wait           = 4;

--- a/test/test_large_messages.cpp
+++ b/test/test_large_messages.cpp
@@ -11,6 +11,7 @@
 int main(int argc, char** argv) {
   // Create comm for very small messages
   ::setenv("YGM_COMM_BUFFER_SIZE_KB", "1", 1);
+  ::setenv("YGM_COMM_IRECV_SIZE_KB", "1", 1);
   ygm::comm world(&argc, &argv);
 
   // Test Rank 0 large message to all ranks


### PR DESCRIPTION
Adds a channel for sending buffers that are larger than the default receive buffer size. Makes use of tags to distinguish messages with content from messages with a large buffer's size and an extra communicator for sending the content of large buffers.