### PR TITLE
Feature/synchronize ygm ptrs

### DIFF
--- a/include/ygm/container/array.hpp
+++ b/include/ygm/container/array.hpp
@@ -150,7 +150,7 @@ class array
    */
   array(ygm::comm& comm, const size_type size)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         m_global_size(size),
         m_default_value{},
         partitioner(comm, size) {
@@ -169,7 +169,7 @@ class array
    */
   array(ygm::comm& comm, const size_type size, const mapped_type& default_value)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         m_global_size(size),
         m_default_value(default_value),
         partitioner(comm, size) {
@@ -191,7 +191,7 @@ class array
    */
   array(ygm::comm& comm, std::initializer_list<mapped_type> l)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         m_global_size(l.size()),
         m_default_value{},
         partitioner(comm, l.size()) {
@@ -222,7 +222,10 @@ class array
    */
   array(ygm::comm&                                               comm,
         std::initializer_list<std::tuple<key_type, mapped_type>> l)
-      : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value{},
+        partitioner(comm, 0) {
     m_comm.cout0("initializer_list assumes all ranks are equal");
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
@@ -260,7 +263,10 @@ class array
     requires detail::HasForAll<T> &&
                  detail::SingleItemTuple<typename T::for_all_args> &&
                  std::same_as<typename T::for_all_args, std::tuple<mapped_type>>
-      : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value{},
+        partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
@@ -299,7 +305,10 @@ class array
                      std::tuple_element_t<
                          1, std::tuple_element_t<0, typename T::for_all_args>>,
                      mapped_type>
-      : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value{},
+        partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
@@ -339,7 +348,10 @@ class array
                  std::convertible_to<
                      std::tuple_element_t<0, typename T::for_all_args>,
                      mapped_type>
-      : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value{},
+        partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
@@ -376,7 +388,10 @@ class array
     requires detail::STLContainer<T> &&
                  (not detail::SingleItemTuple<typename T::value_type>) &&
                  std::convertible_to<typename T::value_type, mapped_type>
-      : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value{},
+        partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
@@ -413,7 +428,10 @@ class array
                  std::convertible_to<
                      std::tuple_element_t<1, typename T::value_type>,
                      mapped_type>
-      : m_comm(comm), pthis(this), m_default_value{}, partitioner(comm, 0) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value{},
+        partitioner(comm, 0) {
     m_comm.log(log_level::info, "Creating ygm::container::array");
     pthis.check(m_comm);
 
@@ -438,7 +456,7 @@ class array
 
   array(const self_type& other)
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_global_size(other.m_global_size),
         m_default_value(other.m_default_value),
         m_local_vec(other.m_local_vec),
@@ -449,7 +467,7 @@ class array
 
   array(self_type&& other) noexcept
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_global_size(other.m_global_size),
         m_default_value(other.m_default_value),
         m_local_vec(std::move(other.m_local_vec)),
@@ -895,7 +913,6 @@ class array
                     "(mapped_type &) signatures");
     }
   }
-
 
   /**
    * @brief Update a locally stored element by performing a binary operation

--- a/include/ygm/container/bag.hpp
+++ b/include/ygm/container/bag.hpp
@@ -47,6 +47,7 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   using size_type      = size_t;
   using for_all_args   = std::tuple<Item>;
   using container_type = ygm::container::bag_tag;
+  using ptr_type       = typename ygm::ygm_ptr<self_type>;
   using iterator       = typename local_container_type::iterator;
   using const_iterator = typename local_container_type::const_iterator;
 
@@ -55,7 +56,10 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
    *
    * @param comm Communicator to use for communication
    */
-  bag(ygm::comm &comm) : m_comm(comm), pthis(this), partitioner(comm) {
+  bag(ygm::comm &comm)
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
   }
@@ -68,7 +72,9 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
    * @details Initializer list is assumed to be replicated on all ranks.
    */
   bag(ygm::comm &comm, std::initializer_list<Item> l)
-      : m_comm(comm), pthis(this), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
@@ -90,7 +96,9 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   bag(ygm::comm &comm, const STLContainer &cont)
     requires detail::STLContainer<STLContainer> &&
                  std::convertible_to<typename STLContainer::value_type, Item>
-      : m_comm(comm), pthis(this), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
 
@@ -113,7 +121,9 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
   bag(ygm::comm &comm, const YGMContainer &yc)
     requires detail::HasForAll<YGMContainer> &&
                  detail::SingleItemTuple<typename YGMContainer::for_all_args>
-      : m_comm(comm), pthis(this), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
     pthis.check(m_comm);
 
@@ -129,7 +139,7 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
 
   bag(const self_type &other)
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_bag(other.m_local_bag),
         partitioner(other.comm()) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
@@ -138,7 +148,7 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
 
   bag(self_type &&other) noexcept
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_bag(std::move(other.m_local_bag)),
         partitioner(other.comm()) {
     m_comm.log(log_level::info, "Creating ygm::container::bag");
@@ -452,9 +462,9 @@ class bag : public detail::base_async_insert_value<bag<Item>, std::tuple<Item>>,
    */
   void local_swap(self_type &other) { m_local_bag.swap(other.m_local_bag); }
 
-  ygm::comm                       &m_comm;
-  typename ygm::ygm_ptr<self_type> pthis;
-  local_container_type             m_local_bag;
+  ygm::comm           &m_comm;
+  ptr_type             pthis;
+  local_container_type m_local_bag;
 
  public:
   detail::round_robin_partitioner partitioner;

--- a/include/ygm/container/counting_set.hpp
+++ b/include/ygm/container/counting_set.hpp
@@ -42,6 +42,7 @@ class counting_set
   using size_type      = size_t;
   using for_all_args   = std::tuple<Key, size_t>;
   using container_type = ygm::container::counting_set_tag;
+  using ptr_type       = typename ygm::ygm_ptr<self_type>;
   using iterator       = typename internal_container_type::iterator;
   using const_iterator = typename internal_container_type::const_iterator;
 
@@ -53,7 +54,10 @@ class counting_set
    * @param comm Communicator to use for communication
    */
   counting_set(ygm::comm &comm)
-      : m_comm(comm), pthis(this), m_map(comm), partitioner(m_map.partitioner) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_map(comm),
+        partitioner(m_map.partitioner) {
     m_comm.log(log_level::info, "Creating ygm::container::counting_set");
     pthis.check(m_comm);
     m_count_cache.resize(count_cache_size, {key_type(), -1});
@@ -69,7 +73,10 @@ class counting_set
    * @details Initializer list is assumed to be replicated on all ranks.
    */
   counting_set(ygm::comm &comm, std::initializer_list<Key> l)
-      : m_comm(comm), pthis(this), m_map(comm), partitioner(m_map.partitioner) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_map(comm),
+        partitioner(m_map.partitioner) {
     m_comm.log(log_level::info, "Creating ygm::container::counting_set");
     pthis.check(m_comm);
     m_count_cache.resize(count_cache_size, {key_type(), -1});
@@ -89,10 +96,13 @@ class counting_set
    * @param cont STL container containing values to count
    */
   template <typename STLContainer>
-  counting_set(ygm::comm &comm, const STLContainer &cont) requires
-      detail::STLContainer<STLContainer> &&
-      std::convertible_to<typename STLContainer::value_type, Key>
-      : m_comm(comm), pthis(this), m_map(comm), partitioner(m_map.partitioner) {
+  counting_set(ygm::comm &comm, const STLContainer &cont)
+    requires detail::STLContainer<STLContainer> &&
+                 std::convertible_to<typename STLContainer::value_type, Key>
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_map(comm),
+        partitioner(m_map.partitioner) {
     m_comm.log(log_level::info, "Creating ygm::container::counting_set");
     pthis.check(m_comm);
     m_count_cache.resize(count_cache_size, {key_type(), -1});
@@ -110,10 +120,13 @@ class counting_set
    * @param yc YGM container containing values to count
    */
   template <typename YGMContainer>
-  counting_set(ygm::comm &comm, const YGMContainer &yc) requires
-      detail::HasForAll<YGMContainer> &&
-      detail::SingleItemTuple<typename YGMContainer::for_all_args>
-      : m_comm(comm), pthis(this), m_map(comm), partitioner(m_map.partitioner) {
+  counting_set(ygm::comm &comm, const YGMContainer &yc)
+    requires detail::HasForAll<YGMContainer> &&
+                 detail::SingleItemTuple<typename YGMContainer::for_all_args>
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_map(comm),
+        partitioner(m_map.partitioner) {
     m_comm.log(log_level::info, "Creating ygm::container::counting_set");
     pthis.check(m_comm);
     m_count_cache.resize(count_cache_size, {key_type(), -1});
@@ -129,7 +142,7 @@ class counting_set
 
   counting_set(const self_type &other)
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_count_cache(other.m_count_cache),
         m_cache_empty(other.m_cache_empty),
         m_map(other.m_map),
@@ -145,7 +158,7 @@ class counting_set
 
   counting_set(self_type &&other)
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_count_cache(std::move(other.m_count_cache)),
         m_cache_empty(other.m_cache_empty),
         m_map(std::move(other.m_map)),
@@ -474,7 +487,7 @@ class counting_set
   }
 
   ygm::comm                           &m_comm;
-  typename ygm::ygm_ptr<self_type>     pthis;
+  ptr_type                             pthis;
   std::vector<std::pair<Key, int32_t>> m_count_cache;
   bool                                 m_cache_empty = true;
   internal_container_type              m_map;

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -20,7 +20,7 @@ class disjoint_set_impl {
   struct data_t;
 
   using self_type         = disjoint_set_impl<Item, Partitioner>;
-  using self_ygm_ptr_type = typename ygm::ygm_ptr<self_type>;
+  using ptr_type          = typename ygm::ygm_ptr<self_type>;
   using value_type        = Item;
   using size_type         = size_t;
   using ygm_for_all_types = std::tuple<Item, Item>;
@@ -127,7 +127,7 @@ class disjoint_set_impl {
   };
 
   disjoint_set_impl(ygm::comm &comm, const size_t cache_size)
-      : m_comm(comm), pthis(this), m_cache(cache_size) {
+      : m_comm(comm), pthis(this, ygm::max(ptr_type::next_index(), comm), m_cache(cache_size) {
     m_comm.log(log_level::info, "Creating ygm::container::disjoint_set");
     pthis.check(m_comm);
   }
@@ -137,7 +137,8 @@ class disjoint_set_impl {
     m_comm.barrier();
   }
 
-  typename ygm::ygm_ptr<self_type> get_ygm_ptr() const { return pthis; }
+  typename ygm::ygm_ptr<self_type> get_ygm_ptr() const {
+    return pthis; }
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const value_type &item, Visitor visitor,
@@ -207,7 +208,7 @@ class disjoint_set_impl {
 
     // Walking up parent trees can be expressed as a recursive operation
     struct simul_parent_walk_functor {
-      void operator()(self_ygm_ptr_type                    p_dset,
+      void operator()(ptr_type                             p_dset,
                       std::pair<const value_type, data_t> &my_item_data,
                       const value_type &my_child, value_type other_parent,
                       value_type other_item, rank_type other_rank) {
@@ -348,7 +349,7 @@ class disjoint_set_impl {
 
     // Walking up parent trees can be expressed as a recursive operation
     struct simul_parent_walk_functor {
-      void operator()(self_ygm_ptr_type                    p_dset,
+      void operator()(ptr_type                             p_dset,
                       std::pair<const value_type, data_t> &my_item_data,
                       const value_type &my_child, value_type other_parent,
                       value_type other_item, rank_type other_rank,
@@ -402,7 +403,7 @@ class disjoint_set_impl {
             if constexpr (std::is_invocable<decltype(fn), const value_type &,
                                             const value_type &, const bool,
                                             FunctionArgs &...>() ||
-                          std::is_invocable<decltype(fn), self_ygm_ptr_type,
+                          std::is_invocable<decltype(fn), ptr_type,
                                             const value_type &,
                                             const value_type &, const bool,
                                             FunctionArgs &...>()) {
@@ -446,7 +447,7 @@ class disjoint_set_impl {
               if constexpr (std::is_invocable<decltype(fn), const value_type &,
                                               const value_type &, const bool,
                                               FunctionArgs &...>() ||
-                            std::is_invocable<decltype(fn), self_ygm_ptr_type,
+                            std::is_invocable<decltype(fn), ptr_type,
                                               const value_type &,
                                               const value_type &, const bool,
                                               FunctionArgs &...>()) {
@@ -528,7 +529,7 @@ class disjoint_set_impl {
 
     struct update_rep_functor {
      public:
-      void operator()(self_ygm_ptr_type p_dset, const value_type &parent,
+      void operator()(ptr_type p_dset, const value_type &parent,
                       const value_type &rep) {
         auto &local_rep_query = queries.at(parent);
         local_rep_query.rep   = rep;
@@ -551,7 +552,7 @@ class disjoint_set_impl {
       }
     };
 
-    auto query_rep_lambda = [](self_ygm_ptr_type p_dset, const value_type &item,
+    auto query_rep_lambda = [](ptr_type p_dset, const value_type &item,
                                int inquiring_rank) {
       const auto &item_info = p_dset->m_local_item_map[item];
 
@@ -627,7 +628,7 @@ class disjoint_set_impl {
     ygm_ptr<return_type> p_to_return(&to_return);
 
     struct find_rep_functor {
-      void operator()(self_ygm_ptr_type pdset, ygm_ptr<return_type> p_to_return,
+      void operator()(ptr_type pdset, ygm_ptr<return_type> p_to_return,
                       const value_type &source_item, const int source_rank,
                       const value_type &local_item) {
         const auto parent = pdset->m_local_item_map[local_item].get_parent();
@@ -638,7 +639,7 @@ class disjoint_set_impl {
           int dest = pdset->owner(source_item);
           pdset->comm().async(
               dest,
-              [](self_ygm_ptr_type pdset, const value_type &source_item,
+              [](ptr_type pdset, const value_type &source_item,
                  const value_type &root) {
                 pdset->m_local_item_map[source_item].set_parent(root);
               },
@@ -709,7 +710,8 @@ class disjoint_set_impl {
     return max(local_max, m_comm);
   }
 
-  ygm::comm &comm() { return m_comm; }
+  ygm::comm &comm() {
+    return m_comm; }
 
  private:
   const std::pair<value_type, rank_type> walk_cache(const value_type &item,
@@ -741,7 +743,7 @@ class disjoint_set_impl {
   disjoint_set_impl() = delete;
 
   ygm::comm        &m_comm;
-  self_ygm_ptr_type pthis;
+  ptr_type pthis;
   item_map_type     m_local_item_map;
 
   hash_cache m_cache;

--- a/include/ygm/container/detail/disjoint_set_impl.hpp
+++ b/include/ygm/container/detail/disjoint_set_impl.hpp
@@ -127,7 +127,9 @@ class disjoint_set_impl {
   };
 
   disjoint_set_impl(ygm::comm &comm, const size_t cache_size)
-      : m_comm(comm), pthis(this, ygm::max(ptr_type::next_index(), comm), m_cache(cache_size) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_cache(cache_size) {
     m_comm.log(log_level::info, "Creating ygm::container::disjoint_set");
     pthis.check(m_comm);
   }
@@ -137,8 +139,7 @@ class disjoint_set_impl {
     m_comm.barrier();
   }
 
-  typename ygm::ygm_ptr<self_type> get_ygm_ptr() const {
-    return pthis; }
+  typename ygm::ygm_ptr<self_type> get_ygm_ptr() const { return pthis; }
 
   template <typename Visitor, typename... VisitorArgs>
   void async_visit(const value_type &item, Visitor visitor,
@@ -710,8 +711,7 @@ class disjoint_set_impl {
     return max(local_max, m_comm);
   }
 
-  ygm::comm &comm() {
-    return m_comm; }
+  ygm::comm &comm() { return m_comm; }
 
  private:
   const std::pair<value_type, rank_type> walk_cache(const value_type &item,
@@ -742,9 +742,9 @@ class disjoint_set_impl {
  protected:
   disjoint_set_impl() = delete;
 
-  ygm::comm        &m_comm;
-  ptr_type pthis;
-  item_map_type     m_local_item_map;
+  ygm::comm    &m_comm;
+  ptr_type      pthis;
+  item_map_type m_local_item_map;
 
   hash_cache m_cache;
 

--- a/include/ygm/container/map.hpp
+++ b/include/ygm/container/map.hpp
@@ -69,7 +69,10 @@ class map
    * @param comm Communicator to use for communication
    */
   map(ygm::comm& comm)
-      : m_comm(comm), pthis(this), m_default_value(), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value(),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
   }
@@ -82,7 +85,7 @@ class map
    */
   map(ygm::comm& comm, const mapped_type& default_value)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         m_default_value(default_value),
         partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::map");
@@ -97,7 +100,10 @@ class map
    * @details Initializer list is assumed to be replicated on all ranks.
    */
   map(ygm::comm& comm, std::initializer_list<std::pair<Key, Value>> l)
-      : m_comm(comm), pthis(this), m_default_value(), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value(),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
@@ -119,7 +125,10 @@ class map
     requires detail::STLContainer<STLContainer> &&
                  std::convertible_to<typename STLContainer::value_type,
                                      std::pair<Key, Value>>
-      : m_comm(comm), pthis(this), m_default_value(), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value(),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
 
@@ -142,7 +151,10 @@ class map
   map(ygm::comm& comm, const YGMContainer& yc)
     requires detail::HasForAll<YGMContainer> &&
                  detail::SingleItemTuple<typename YGMContainer::for_all_args>
-      : m_comm(comm), pthis(this), m_default_value(), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_default_value(),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::map");
     pthis.check(m_comm);
 
@@ -160,7 +172,7 @@ class map
 
   map(const self_type& other)
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_map(other.m_local_map),
         m_default_value(other.m_default_value),
         partitioner(other.comm()) {
@@ -170,7 +182,7 @@ class map
 
   map(self_type&& other) noexcept
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_map(std::move(other.m_local_map)),
         m_default_value(other.m_default_value),
         partitioner(other.comm()) {
@@ -609,10 +621,10 @@ class map
   void local_swap(self_type& other) { m_local_map.swap(other.m_local_map); }
 
  private:
-  ygm::comm&                       m_comm;
-  typename ygm::ygm_ptr<self_type> pthis;
-  local_container_type             m_local_map;
-  mapped_type                      m_default_value;
+  ygm::comm&           m_comm;
+  ptr_type             pthis;
+  local_container_type m_local_map;
+  mapped_type          m_default_value;
 
  public:
   detail::hash_partitioner<detail::hash<key_type>> partitioner;

--- a/include/ygm/container/set.hpp
+++ b/include/ygm/container/set.hpp
@@ -44,6 +44,7 @@ class set
   using size_type      = size_t;
   using for_all_args   = std::tuple<Value>;
   using container_type = ygm::container::set_tag;
+  using ptr_type       = typename ygm::ygm_ptr<self_type>;
   using iterator       = typename local_container_type::iterator;
   using const_iterator = typename local_container_type::const_iterator;
 
@@ -58,7 +59,7 @@ class set
    */
   set(ygm::comm &comm)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         partitioner(comm, detail::hash<value_type>()) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
@@ -72,7 +73,9 @@ class set
    * @details Initializer list is assumed to be replicated on all ranks.
    */
   set(ygm::comm &comm, std::initializer_list<Value> l)
-      : m_comm(comm), pthis(this), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
     if (m_comm.rank0()) {
@@ -94,7 +97,9 @@ class set
   set(ygm::comm &comm, const STLContainer &cont)
     requires detail::STLContainer<STLContainer> &&
                  std::convertible_to<typename STLContainer::value_type, Value>
-      : m_comm(comm), pthis(this), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
 
@@ -115,7 +120,9 @@ class set
   set(ygm::comm &comm, const YGMContainer &yc)
     requires detail::HasForAll<YGMContainer> &&
                  detail::SingleItemTuple<typename YGMContainer::for_all_args>
-      : m_comm(comm), pthis(this), partitioner(comm) {
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        partitioner(comm) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
     pthis.check(m_comm);
 
@@ -133,7 +140,7 @@ class set
 
   set(const self_type &other)
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_set(other.m_local_set),
         partitioner(other.comm()) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
@@ -142,7 +149,7 @@ class set
 
   set(self_type &&other) noexcept
       : m_comm(other.comm()),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_set(std::move(other.m_local_set)),
         partitioner(other.partitioner) {
     m_comm.log(log_level::info, "Creating ygm::container::set");
@@ -330,9 +337,9 @@ class set
   void local_swap(self_type &other) { m_local_set.swap(other.m_local_set); }
 
  private:
-  ygm::comm                       &m_comm;
-  typename ygm::ygm_ptr<self_type> pthis;
-  local_container_type             m_local_set;
+  ygm::comm           &m_comm;
+  ptr_type             pthis;
+  local_container_type m_local_set;
 
  public:
   detail::hash_partitioner<detail::hash<value_type>> partitioner;

--- a/include/ygm/container/tagged_bag.hpp
+++ b/include/ygm/container/tagged_bag.hpp
@@ -21,6 +21,7 @@ class tagged_bag {
   using tag_type   = size_t;
   using value_type = Item;
   using self_type  = tagged_bag<Item, Alloc>;
+  using ptr_type   = typename ygm::ygm_ptr<self_type>;
 
   tagged_bag(const tagged_bag &)                = delete;
   tagged_bag(tagged_bag &&) noexcept            = delete;
@@ -29,7 +30,7 @@ class tagged_bag {
   tagged_bag(ygm::comm &comm)
       : m_next_tag(tag_type(comm.rank()) << TAG_BITS),
         m_tagged_bag(ygm::container::map<tag_type, value_type>(comm)),
-        pthis(this) {
+        pthis(this, ygm::max(ptr_type::next_index(), comm)) {
     m_tagged_bag.comm().log(log_level::info,
                             "Creating ygm::container::tagged_bag");
   }
@@ -125,6 +126,6 @@ class tagged_bag {
   const tag_type MAX_TAGS = (size_t(1) << TAG_BITS) - 1;
   tag_type       m_next_tag;
   ygm::container::map<tag_type, value_type> m_tagged_bag;
-  typename ygm::ygm_ptr<self_type>          pthis;
+  ptr_type                                  pthis;
 };
 }  // namespace ygm::container

--- a/include/ygm/container/work_queue.hpp
+++ b/include/ygm/container/work_queue.hpp
@@ -75,11 +75,21 @@ class work_queue
 
   work_queue(self_type&& other) noexcept
       : m_comm(other.m_comm),
-        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
+        pthis(this,
+              other.get_ygm_ptr().index()),  // temporarily use other's ygm_ptr
         m_local_queue(std::move(other.m_local_queue)),
         m_work_lambda(std::move(other.m_work_lambda)),
         m_callback_registered(false) {
     m_comm.log(log_level::info, "Moving ygm::container::work_queue");
+
+    // Find correct ygm_ptr to use for new work_queue
+    // NOTE: Needs to be done without calling ygm collectives because of
+    // built-in barriers that would process all work items originally stored in
+    // other
+    size_t idx = ptr_type::next_index();
+    MPI_Allreduce(MPI_IN_PLACE, &idx, 1, MPI_LONG_LONG, MPI_MAX,
+                  m_comm.get_mpi_comm());
+    pthis = ptr_type(this, idx);
 
     pthis.check(m_comm);
     other.m_callback_registered = false;
@@ -88,6 +98,7 @@ class work_queue
       register_processing_callback();
     }
   }
+  // work_queue(self_type&& other) = default;
 
   work_queue& operator=(self_type&& other) noexcept {
     if (this == &other) return *this;

--- a/include/ygm/container/work_queue.hpp
+++ b/include/ygm/container/work_queue.hpp
@@ -5,52 +5,53 @@
 
 #pragma once
 
+#include <functional>
 #include <ygm/comm.hpp>
 #include <ygm/container/container_traits.hpp>
 #include <ygm/container/detail/base_misc.hpp>
 #include <ygm/container/detail/work_queue_policy.hpp>
 #include <ygm/detail/meta/functional.hpp>
-#include <functional>
 
 namespace ygm::container {
 
 /**
  * @brief work queue container for YGM
- * 
+ *
  * @tparam Item Type of work items stored in queue
- * @tparam QueuePolicy Policy determining queue ordering (@see detail/work_queue_policy.hpp)
+ * @tparam QueuePolicy Policy determining queue ordering (@see
+ * detail/work_queue_policy.hpp)
  * @tparam WorkLambda Lambda type for processing work items
- * 
+ *
  * @details Provides a work queue that processes items in FIFO, LIFO
- * order or priority order. Work is processed at barriers via registered callbacks.
+ * order or priority order. Work is processed at barriers via registered
+ * callbacks.
  */
 
 template <typename Item, typename QueuePolicy, typename WorkLambda>
 class work_queue
     : public detail::base_misc<work_queue<Item, QueuePolicy, WorkLambda>,
-                                           std::tuple<Item>> {
-  
+                               std::tuple<Item>> {
   friend struct detail::base_misc<work_queue<Item, QueuePolicy, WorkLambda>,
-                                         std::tuple<Item>>;
+                                  std::tuple<Item>>;
 
  public:
-  using self_type =         work_queue<Item, QueuePolicy, WorkLambda>;
-  using ptr_type =                  typename ygm::ygm_ptr<self_type>;
-  using value_type =                                            Item;
-  using size_type =                                           size_t;
-  using queue_type =                typename QueuePolicy::queue_type;
+  using self_type  = work_queue<Item, QueuePolicy, WorkLambda>;
+  using ptr_type   = typename ygm::ygm_ptr<self_type>;
+  using value_type = Item;
+  using size_type  = size_t;
+  using queue_type = typename QueuePolicy::queue_type;
 
   work_queue() = delete;
 
   /**
    * @brief work_queue constructor
-   * 
+   *
    * @param comm Communicator to use for callback registration
    * @param work_fn Lambda to execute on each work item during processing
    */
   work_queue(ygm::comm& comm, WorkLambda&& work_fn)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         m_work_lambda(std::forward<WorkLambda>(work_fn)),
         m_callback_registered(false) {
     m_comm.log(log_level::info, "Creating ygm::container::work_queue");
@@ -60,9 +61,9 @@ class work_queue
 
   /**
    * @brief work_queue destructor
-   * 
+   *
    * @details Asserts queue is empty before destruction to prevent items left
-   * accidentally unprocessed. Call local_clear() explicitly to discard 
+   * accidentally unprocessed. Call local_clear() explicitly to discard
    * unfinished work before destruction.
    */
   ~work_queue() {
@@ -74,7 +75,7 @@ class work_queue
 
   work_queue(self_type&& other) noexcept
       : m_comm(other.m_comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), other.comm())),
         m_local_queue(std::move(other.m_local_queue)),
         m_work_lambda(std::move(other.m_work_lambda)),
         m_callback_registered(false) {
@@ -83,7 +84,7 @@ class work_queue
     pthis.check(m_comm);
     other.m_callback_registered = false;
 
-    if(local_has_work()) {
+    if (local_has_work()) {
       register_processing_callback();
     }
   }
@@ -94,11 +95,11 @@ class work_queue
     m_comm.log(log_level::info,
                "Calling ygm::container::work_queue move assignment operator");
 
-    m_local_queue = std::move(other.m_local_queue);
-    m_callback_registered = false;
+    m_local_queue               = std::move(other.m_local_queue);
+    m_callback_registered       = false;
     other.m_callback_registered = false;
 
-    if(local_has_work()) {
+    if (local_has_work()) {
       register_processing_callback();
     }
 
@@ -107,15 +108,14 @@ class work_queue
 
   /**
    * @brief Unsupported functions
-   * 
-   * @details Common YGM container functions that break under the 
+   *
+   * @details Common YGM container functions that break under the
    * execution model of the work_queue.
    */
-  void size() = delete;
-  void swap() = delete;
-  work_queue(const self_type&) = delete;
+  void size()                             = delete;
+  void swap()                             = delete;
+  work_queue(const self_type&)            = delete;
   work_queue& operator=(const self_type&) = delete;
-
 
   /**
    * @brief Empties remaining items in global storage of work_queue.
@@ -128,14 +128,14 @@ class work_queue
 
   /**
    * @brief Insert a work item into the local queue
-   * 
+   *
    * @param item Work item to insert
    * @details Registers processing callback on first insertion. Does not
    * initiate execution.
    */
   void local_insert(const Item& item) {
     QueuePolicy::push(m_local_queue, item);
-    
+
     // Only register callback once per batch
     if (!m_callback_registered) {
       register_processing_callback();
@@ -144,7 +144,7 @@ class work_queue
 
   /**
    * @brief Process all pending work items in the local queue
-   * 
+   *
    * @details Processes items according to queue policy.
    * Does not call comm.barrier().
    */
@@ -153,59 +153,52 @@ class work_queue
       Item item = QueuePolicy::top(m_local_queue);
       QueuePolicy::pop(m_local_queue);
       ygm::meta::apply_optional(std::forward<WorkLambda>(m_work_lambda),
-                                  std::make_tuple(pthis),
-                                  std::forward_as_tuple(item));
+                                std::make_tuple(pthis),
+                                std::forward_as_tuple(item));
     }
   }
 
   /**
    * @brief Check if there's pending work in the local queue
-   * 
+   *
    * @return true if local queue has work, false otherwise
    */
-  bool local_has_work() const {
-    return !QueuePolicy::empty(m_local_queue);
-  }
+  bool local_has_work() const { return !QueuePolicy::empty(m_local_queue); }
 
   /**
    * @brief Get the size of the local queue
-   * 
+   *
    * @return Number of items in local queue
    */
-  size_type local_size() const {
-    return QueuePolicy::size(m_local_queue);
-  }
+  size_type local_size() const { return QueuePolicy::size(m_local_queue); }
 
   /**
    * @brief Clear the local queue without processing items
-   * 
+   *
    * @details Use this if you want to discard pending work before destruction.
    * Does not call barrier().
    */
-  void local_clear() {
-    m_local_queue = queue_type{};
-  }
-
+  void local_clear() { m_local_queue = queue_type{}; }
 
  private:
   /**
    * @brief Register callback to process work at next barrier
    */
-  void register_processing_callback() {    
+  void register_processing_callback() {
     auto process_all_lambda = [this]() {
       this->local_process_all();
-      this->m_callback_registered = false; // Reset for next batch
+      this->m_callback_registered = false;  // Reset for next batch
     };
-    
+
     m_comm.register_pre_barrier_callback(process_all_lambda);
     m_callback_registered = true;
   }
 
-  ygm::comm&                       m_comm;
-  ptr_type                          pthis;
-  queue_type                m_local_queue;
-  WorkLambda                m_work_lambda;
-  bool              m_callback_registered;
+  ygm::comm& m_comm;
+  ptr_type   pthis;
+  queue_type m_local_queue;
+  WorkLambda m_work_lambda;
+  bool       m_callback_registered;
 };
 
 // Convenient type aliases
@@ -216,7 +209,8 @@ template <typename Item, typename WorkLambda>
 using lifo_work_queue = work_queue<Item, detail::lifo_policy<Item>, WorkLambda>;
 
 template <typename Item, typename Comp, typename WorkLambda>
-using priority_work_queue = work_queue<Item, detail::priority_policy<Item, Comp>, WorkLambda>;
+using priority_work_queue =
+    work_queue<Item, detail::priority_policy<Item, Comp>, WorkLambda>;
 
 // Factory functions for convenient user instantiation
 template <typename Item, typename WorkLambda>
@@ -234,4 +228,4 @@ auto make_priority_work_queue(ygm::comm& comm, WorkLambda work_fn) {
   return priority_work_queue<Item, Comp, WorkLambda>(comm, std::move(work_fn));
 }
 
-} // namespace ygm::container
+}  // namespace ygm::container

--- a/include/ygm/detail/comm.ipp
+++ b/include/ygm/detail/comm.ipp
@@ -77,7 +77,6 @@ inline comm::comm(MPI_Comm mcomm)
  * send buffers, and posts initial receives.
  */
 inline void comm::comm_setup(MPI_Comm c) {
-
   if (rank0()) {
     boost::uuids::random_generator gen;
     m_uuid = boost::uuids::to_string(gen());
@@ -115,13 +114,14 @@ inline void comm::comm_setup(MPI_Comm c) {
   }
 
   if (config.stats_shm) {
-    #ifdef __APPLE__
-      std::string uuid_identifier = m_uuid.substr(0, 8) + "_" + std::to_string(rank());
-    #endif
+#ifdef __APPLE__
+    std::string uuid_identifier =
+        m_uuid.substr(0, 8) + "_" + std::to_string(rank());
+#endif
 
-    #ifdef __linux__
-      std::string uuid_identifier = m_uuid + "_" + std::to_string(rank());
-    #endif
+#ifdef __linux__
+    std::string uuid_identifier = m_uuid + "_" + std::to_string(rank());
+#endif
 
     // Add to set of tracked UUID_rank pairs while blocking signals.
     sigset_t newset, oldset;
@@ -130,9 +130,9 @@ inline void comm::comm_setup(MPI_Comm c) {
     ygm::detail::live_comm_uuids.insert(uuid_identifier);
     sigprocmask(SIG_SETMASK, &oldset, NULL);
 
-    m_stats.open_comm_stats_shm(rank(), size(), m_layout.local_size(), uuid_identifier);
+    m_stats.open_comm_stats_shm(rank(), size(), m_layout.local_size(),
+                                uuid_identifier);
   }
-
 }
 
 /**
@@ -521,7 +521,8 @@ inline void comm::cf_barrier() const {
 
 template <typename T>
 inline ygm_ptr<T> comm::make_ygm_ptr(T &t) {
-  ygm_ptr<T> to_return(&t);
+  size_t     idx = ygm::max(ygm_ptr<T>::next_index(), *this);
+  ygm_ptr<T> to_return(&t, idx);
   to_return.check(*this);
   return to_return;
 }

--- a/include/ygm/detail/ygm_ptr.hpp
+++ b/include/ygm/detail/ygm_ptr.hpp
@@ -51,6 +51,11 @@ class ygm_ptr {
 
   ygm_ptr(const ygm::ygm_ptr<T> &t) { idx = t.idx; }
 
+  ygm_ptr &operator=(const ygm::ygm_ptr<T> &t) {
+    idx = t.idx;
+    return *this;
+  }
+
   T *get_raw_pointer() { return operator->(); }
 
   uint32_t index() const { return idx; }

--- a/include/ygm/detail/ygm_ptr.hpp
+++ b/include/ygm/detail/ygm_ptr.hpp
@@ -21,6 +21,24 @@ class ygm_ptr {
   T &operator*() const { return *sptrs[idx]; }
 
   /**
+   * @brief Construct a new ygm ptr object with a given pointer index
+   *
+   * @warning The user is responsible for ensuring all processes have completed
+   * constructing a ygm_ptr before using in an async manner.   For example, use
+   * ygm_ptr::check(comm&);
+   *
+   * @param t
+   * @param index Index to use in sptrs vector for item
+   */
+  ygm_ptr(T *t, size_t index) {
+    if (sptrs.size() <= index) {
+      sptrs.resize(index + 1);
+    }
+    sptrs[index] = t;
+    idx          = index;
+  }
+
+  /**
    * @brief Construct a new ygm ptr object
    *
    * @warning The user is responsible for ensuring all processes have completed
@@ -29,10 +47,7 @@ class ygm_ptr {
    *
    * @param t
    */
-  ygm_ptr(T *t) {
-    idx = sptrs.size();
-    sptrs.push_back(t);
-  }
+  ygm_ptr(T *t) : ygm_ptr(t, sptrs.size() - 1) {}
 
   ygm_ptr(const ygm::ygm_ptr<T> &t) { idx = t.idx; }
 
@@ -46,6 +61,8 @@ class ygm_ptr {
   void serialize(Archive &archive) {
     archive(idx);
   }
+
+  static size_t next_index() { return sptrs.size(); }
 
  private:
   uint32_t                idx;

--- a/include/ygm/detail/ygm_ptr.hpp
+++ b/include/ygm/detail/ygm_ptr.hpp
@@ -47,7 +47,7 @@ class ygm_ptr {
    *
    * @param t
    */
-  ygm_ptr(T *t) : ygm_ptr(t, sptrs.size() - 1) {}
+  ygm_ptr(T *t) : ygm_ptr(t, sptrs.size()) {}
 
   ygm_ptr(const ygm::ygm_ptr<T> &t) { idx = t.idx; }
 

--- a/include/ygm/io/daily_output.hpp
+++ b/include/ygm/io/daily_output.hpp
@@ -23,6 +23,7 @@ template <typename Partitioner =
 class daily_output {
  public:
   using self_type = daily_output<Partitioner>;
+  using ptr_type  = typename ygm::ygm_ptr<self_type>;
 
   /**
    * @brief Construct a daily_output object
@@ -36,7 +37,7 @@ class daily_output {
   daily_output(ygm::comm &comm, const std::string &filename_prefix,
                size_t buffer_length = 1024 * 1024, bool append = false)
       : m_multi_output(comm, filename_prefix, buffer_length, append),
-        pthis(this) {}
+        pthis(this, ygm::max(ptr_type::next_index(), comm)) {}
 
   /**
    * @brief Write a line of output
@@ -83,7 +84,7 @@ class daily_output {
   }
 
  private:
-  multi_output<Partitioner>        m_multi_output;
-  typename ygm::ygm_ptr<self_type> pthis;
+  multi_output<Partitioner> m_multi_output;
+  ptr_type                  pthis;
 };
 }  // namespace ygm::io

--- a/include/ygm/io/multi_output.hpp
+++ b/include/ygm/io/multi_output.hpp
@@ -31,6 +31,7 @@ template <typename Partitioner =
 class multi_output {
  public:
   using self_type = multi_output<Partitioner>;
+  using ptr_type  = typename ygm::ygm_ptr<self_type>;
 
   /**
    * @brief Construct a multi_output object
@@ -46,7 +47,7 @@ class multi_output {
   multi_output(ygm::comm &comm, std::string filename_prefix,
                size_t buffer_length = 1024 * 1024, bool append = false)
       : m_comm(comm),
-        pthis(this),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
         m_prefix_path(filename_prefix),
         m_buffer_length(buffer_length),
         m_append_flag(append) {
@@ -257,7 +258,7 @@ class multi_output {
   }
 
   ygm::comm                               &m_comm;
-  typename ygm::ygm_ptr<self_type>         pthis;
+  ptr_type                                 pthis;
   fs::path                                 m_prefix_path;
   size_t                                   m_buffer_length;
   bool                                     m_append_flag;

--- a/include/ygm/io/parquet_parser.hpp
+++ b/include/ygm/io/parquet_parser.hpp
@@ -250,6 +250,7 @@ get_file_paths(
 class parquet_parser {
  private:
   using self_type = parquet_parser;
+  using ptr_type  = typename ygm::ygm_ptr<self_type>;
 
  public:
   // List of C++ types supported by this parser
@@ -269,7 +270,7 @@ class parquet_parser {
 
   parquet_parser(ygm::comm &_comm, const std::vector<std::string> &stringpaths,
                  const bool recursive = false)
-      : m_comm(_comm), pthis(this) {
+      : m_comm(_comm), pthis(this, ygm::max(ptr_type::next_index(), _comm)) {
     pthis.check(m_comm);
     init(stringpaths, recursive);
   }
@@ -700,7 +701,7 @@ class parquet_parser {
   }
 
   ygm::comm                      &m_comm;
-  ygm::ygm_ptr<self_type>         pthis;
+  ptr_type                        pthis;
   std::vector<stdfs::path>        m_nlocal_paths;
   std::vector<stdfs::path>        m_global_paths;
   std::vector<column_schema_type> m_col_schema;

--- a/include/ygm/random/alias_table.hpp
+++ b/include/ygm/random/alias_table.hpp
@@ -6,87 +6,104 @@
 
 #pragma once
 
-#include <ygm/comm.hpp>
-#include <ygm/detail/collective.hpp> 
-#include <ygm/container/detail/base_concepts.hpp> 
 #include <cmath>
+#include <ygm/comm.hpp>
+#include <ygm/container/detail/base_concepts.hpp>
+#include <ygm/detail/collective.hpp>
 
 namespace ygm::random {
 
-template<typename Item, typename T>
-concept pair_like_and_convertible_to_weighted_item = 
-    (requires { typename T::first_type; typename T::second_type; } &&
-      std::is_convertible_v<T, std::pair<Item, double>>) ||
+template <typename Item, typename T>
+concept pair_like_and_convertible_to_weighted_item =
+    (requires {
+      typename T::first_type;
+      typename T::second_type;
+    } && std::is_convertible_v<T, std::pair<Item, double>>) ||
     (std::tuple_size_v<T> == 2 &&
-      std::is_convertible_v<std::tuple_element_t<0,T>, Item> &&
-      std::is_convertible_v<std::tuple_element_t<1,T>, double>);
+     std::is_convertible_v<std::tuple_element_t<0, T>, Item> &&
+     std::is_convertible_v<std::tuple_element_t<1, T>, double>);
 
 template <typename Item>
 class alias_table {
-
- public: 
+ public:
   using self_type = alias_table<Item>;
+  using ptr_type  = typename ygm::ygm_ptr<self_type>;
 
   struct item {
-      Item id;
-      double weight;
+    Item   id;
+    double weight;
 
-      template <typename Archive>
-      void serialize(Archive& ar) {
-          ar(id, weight);
-      }
+    template <typename Archive>
+    void serialize(Archive& ar) {
+      ar(id, weight);
+    }
   };
 
-  struct table_item { 
-      // p / m_avg_weight = prob item a is selected. 1 - p / m_avg_weight is prob b is selected.
-      double p; 
-      Item a;
-      Item b;
+  struct table_item {
+    // p / m_avg_weight = prob item a is selected. 1 - p / m_avg_weight is prob
+    // b is selected.
+    double p;
+    Item   a;
+    Item   b;
   };
 
   template <typename YGMContainer>
-  requires ygm::container::detail::HasForAll<YGMContainer> &&
-           ygm::container::detail::SingleItemTuple<typename YGMContainer::for_all_args> &&
-           pair_like_and_convertible_to_weighted_item<Item,
-            std::tuple_element_t<0,typename YGMContainer::for_all_args>>
-  alias_table(ygm::comm &comm, YGMContainer &c,
-    std::optional<std::uint32_t> seed = std::nullopt) 
-    : m_comm(comm), pthis(this), m_rank_dist(0, comm.size()-1), 
-      m_bucket_weight_dist(0.0, 1.0), m_rng(comm) {
+    requires ygm::container::detail::HasForAll<YGMContainer> &&
+                 ygm::container::detail::SingleItemTuple<
+                     typename YGMContainer::for_all_args> &&
+                 pair_like_and_convertible_to_weighted_item<
+                     Item, std::tuple_element_t<
+                               0, typename YGMContainer::for_all_args>>
+  alias_table(ygm::comm& comm, YGMContainer& c,
+              std::optional<std::uint32_t> seed = std::nullopt)
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_rank_dist(0, comm.size() - 1),
+        m_bucket_weight_dist(0.0, 1.0),
+        m_rng(comm) {
     if (seed) {
       m_rng = default_random_engine<>(comm, *seed);
     }
-    c.for_all([&](const auto& id_weight_pair){
-      m_local_items.emplace_back(std::get<0>(id_weight_pair), std::get<1>(id_weight_pair));
+    c.for_all([&](const auto& id_weight_pair) {
+      m_local_items.emplace_back(std::get<0>(id_weight_pair),
+                                 std::get<1>(id_weight_pair));
     });
     build_alias_table();
   }
 
   template <typename YGMContainer>
-  requires ygm::container::detail::HasForAll<YGMContainer> &&
-           ygm::container::detail::DoubleItemTuple<typename YGMContainer::for_all_args> &&
-           pair_like_and_convertible_to_weighted_item<Item, typename YGMContainer::for_all_args>
-  alias_table(ygm::comm &comm, YGMContainer &c, 
-    std::optional<std::uint32_t> seed = std::nullopt) 
-    : m_comm(comm), pthis(this), m_rank_dist(0, comm.size()-1), 
-      m_bucket_weight_dist(0.0, 1.0), m_rng(comm) {
+    requires ygm::container::detail::HasForAll<YGMContainer> &&
+                 ygm::container::detail::DoubleItemTuple<
+                     typename YGMContainer::for_all_args> &&
+                 pair_like_and_convertible_to_weighted_item<
+                     Item, typename YGMContainer::for_all_args>
+  alias_table(ygm::comm& comm, YGMContainer& c,
+              std::optional<std::uint32_t> seed = std::nullopt)
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_rank_dist(0, comm.size() - 1),
+        m_bucket_weight_dist(0.0, 1.0),
+        m_rng(comm) {
     if (seed) {
       m_rng = default_random_engine<>(comm, *seed);
     }
-    c.for_all([&](const auto &id, const auto &weight){
-      m_local_items.emplace_back(id,weight);
+    c.for_all([&](const auto& id, const auto& weight) {
+      m_local_items.emplace_back(id, weight);
     });
     build_alias_table();
   }
 
   template <typename STLContainer>
-  requires ygm::container::detail::STLContainer<STLContainer> &&
-           pair_like_and_convertible_to_weighted_item<
-            Item, typename STLContainer::value_type>
-  alias_table(ygm::comm &comm, STLContainer &c, 
-    std::optional<std::uint32_t> seed = std::nullopt) 
-    : m_comm(comm), pthis(this), m_rank_dist(0, comm.size()-1),
-      m_bucket_weight_dist(0.0, 1.0), m_rng(comm) {  
+    requires ygm::container::detail::STLContainer<STLContainer> &&
+                 pair_like_and_convertible_to_weighted_item<
+                     Item, typename STLContainer::value_type>
+  alias_table(ygm::comm& comm, STLContainer& c,
+              std::optional<std::uint32_t> seed = std::nullopt)
+      : m_comm(comm),
+        pthis(this, ygm::max(ptr_type::next_index(), comm)),
+        m_rank_dist(0, comm.size() - 1),
+        m_bucket_weight_dist(0.0, 1.0),
+        m_rng(comm) {
     if (seed) {
       m_rng = default_random_engine<>(comm, *seed);
     }
@@ -97,7 +114,6 @@ class alias_table {
   }
 
  private:
-
   void build_alias_table() {
     m_comm.barrier();
     balance_weight();
@@ -106,31 +122,34 @@ class alias_table {
     m_local_items.clear();
   }
 
-  void balance_weight() { 
+  void balance_weight() {
     double local_weight = 0.0;
     for (uint32_t i = 0; i < m_local_items.size(); i++) {
       local_weight += m_local_items[i].weight;
     }
-    double global_weight = ygm::sum(local_weight, m_comm);
+    double global_weight   = ygm::sum(local_weight, m_comm);
     double prfx_sum_weight = ygm::prefix_sum(local_weight, m_comm);
 
     // target_weight = Amount of weight each rank should have after balancing
     double target_weight = global_weight / m_comm.size();
-    int dest_rank = prfx_sum_weight / target_weight; 
-    // Spillage weight i.e. weight being contributed by other processors to dest's rank local distribution
-    double curr_weight = std::fmod(prfx_sum_weight, target_weight); 
+    int    dest_rank     = prfx_sum_weight / target_weight;
+    // Spillage weight i.e. weight being contributed by other processors to
+    // dest's rank local distribution
+    double curr_weight = std::fmod(prfx_sum_weight, target_weight);
 
     std::vector<item> new_local_items;
-    using ygm_items_ptr = ygm::ygm_ptr<std::vector<item>>;
-    ygm_items_ptr ptr_new_items = m_comm.make_ygm_ptr(new_local_items); 
+    using ygm_items_ptr         = ygm::ygm_ptr<std::vector<item>>;
+    ygm_items_ptr ptr_new_items = m_comm.make_ygm_ptr(new_local_items);
     m_comm.barrier();
 
     std::vector<item> items_to_send;
-    // WARNING: size of m_local_items can grow during loop. Do not use iterators or pointers in the loop.
-    for (uint64_t i = 0; i < m_local_items.size(); i++) { 
-      item local_item = m_local_items[i]; 
-      if (curr_weight + local_item.weight >= target_weight) { 
-        double remaining_weight = curr_weight + local_item.weight - target_weight;
+    // WARNING: size of m_local_items can grow during loop. Do not use iterators
+    // or pointers in the loop.
+    for (uint64_t i = 0; i < m_local_items.size(); i++) {
+      item local_item = m_local_items[i];
+      if (curr_weight + local_item.weight >= target_weight) {
+        double remaining_weight =
+            curr_weight + local_item.weight - target_weight;
         double weight_to_send = local_item.weight - remaining_weight;
         curr_weight += weight_to_send;
         item item_to_send = {local_item.id, weight_to_send};
@@ -138,16 +157,21 @@ class alias_table {
 
         if (dest_rank < m_comm.size()) {
           // Moves weights to dest_rank's new_local_items
-          m_comm.async(dest_rank, [](std::vector<item> items, ygm_items_ptr new_items_ptr) {
-            new_items_ptr->insert(new_items_ptr->end(), items.begin(), items.end()); 
-          }, items_to_send, ptr_new_items);
+          m_comm.async(
+              dest_rank,
+              [](std::vector<item> items, ygm_items_ptr new_items_ptr) {
+                new_items_ptr->insert(new_items_ptr->end(), items.begin(),
+                                      items.end());
+              },
+              items_to_send, ptr_new_items);
         }
 
-        // Handle case where item weight is large enough to span multiple rank's alias tables
-        if (remaining_weight >= target_weight) { 
+        // Handle case where item weight is large enough to span multiple rank's
+        // alias tables
+        if (remaining_weight >= target_weight) {
           m_local_items.push_back({local_item.id, remaining_weight});
           curr_weight = 0;
-        }  else {
+        } else {
           curr_weight = remaining_weight;
         }
         items_to_send.clear();
@@ -160,12 +184,17 @@ class alias_table {
         curr_weight += local_item.weight;
       }
     }
-    
-    // Need to handle items left in items to send. Must also account for floating point errors.
+
+    // Need to handle items left in items to send. Must also account for
+    // floating point errors.
     if (items_to_send.size() > 0 && dest_rank < m_comm.size()) {
-      m_comm.async(dest_rank, [](std::vector<item> items, ygm_items_ptr new_items_ptr) {
-        new_items_ptr->insert(new_items_ptr->end(), items.begin(), items.end()); 
-      }, items_to_send, ptr_new_items);
+      m_comm.async(
+          dest_rank,
+          [](std::vector<item> items, ygm_items_ptr new_items_ptr) {
+            new_items_ptr->insert(new_items_ptr->end(), items.begin(),
+                                  items.end());
+          },
+          items_to_send, ptr_new_items);
     }
 
     m_comm.barrier();
@@ -173,20 +202,20 @@ class alias_table {
 
     YGM_ASSERT_RELEASE(m_local_items.size() > 0);
     YGM_ASSERT_RELEASE(is_balanced(target_weight));
-  } 
+  }
 
   bool is_balanced(double target) {
     double local_weight = 0.0;
     for (const auto& itm : m_local_items) {
       local_weight += itm.weight;
-    } 
+    }
     double dif = std::abs(target - local_weight);
-    YGM_ASSERT_RELEASE(dif < 1e-6);  
+    YGM_ASSERT_RELEASE(dif < 1e-6);
 
     m_comm.barrier();
-    auto equal = [this](double a, double b){
+    auto equal = [this](double a, double b) {
       return (std::abs(a - b) < 1e-6);
-    }; 
+    };
     bool balanced = ygm::is_same(local_weight, m_comm, equal);
     return balanced;
   }
@@ -195,61 +224,64 @@ class alias_table {
     double local_weight = 0.0;
     for (const auto& itm : m_local_items) {
       local_weight += itm.weight;
-    } 
-    double avg_weight = local_weight / m_local_items.size(); 
+    }
+    double avg_weight = local_weight / m_local_items.size();
 
-    // Implementation of Vose's algorithm, utilized Keith Schwarz numerically stable version
-    // https://www.keithschwarz.com/darts-dice-coins/
+    // Implementation of Vose's algorithm, utilized Keith Schwarz numerically
+    // stable version https://www.keithschwarz.com/darts-dice-coins/
     std::vector<item> heavy_items;
     std::vector<item> light_items;
     for (auto& itm : m_local_items) {
       if (itm.weight < avg_weight) {
-          light_items.push_back(itm);
+        light_items.push_back(itm);
       } else {
-          heavy_items.push_back(itm);
+        heavy_items.push_back(itm);
       }
     }
 
     while (!light_items.empty() && !heavy_items.empty()) {
-      item& l = light_items.back();
-      item& h = heavy_items.back(); 
+      item&      l       = light_items.back();
+      item&      h       = heavy_items.back();
       table_item tbl_itm = {l.weight, l.id, h.id};
       m_local_alias_table.push_back(tbl_itm);
       h.weight = (h.weight + l.weight) - avg_weight;
-      light_items.pop_back(); 
+      light_items.pop_back();
       if (h.weight < avg_weight) {
         light_items.push_back(h);
         heavy_items.pop_back();
-      }   
+      }
     }
 
-    // Either heavy items or light_items is empty, need to flush the non empty 
+    // Either heavy items or light_items is empty, need to flush the non empty
     // vector and add them to the alias table with a p value of avg_weight
     while (!heavy_items.empty()) {
-      item& h = heavy_items.back();
+      item&      h       = heavy_items.back();
       table_item tbl_itm = {avg_weight, h.id, Item()};
       m_local_alias_table.push_back(tbl_itm);
       heavy_items.pop_back();
     }
     while (!light_items.empty()) {
-      item& l = light_items.back();
+      item&      l       = light_items.back();
       table_item tbl_itm = {avg_weight, l.id, Item()};
       m_local_alias_table.push_back(tbl_itm);
       light_items.pop_back();
     }
     m_comm.barrier();
-    m_num_items_uniform_dist = std::uniform_int_distribution<uint64_t>(0,m_local_alias_table.size()-1);
-    m_bucket_weight_dist = std::uniform_real_distribution<double>(0,avg_weight);
+    m_num_items_uniform_dist = std::uniform_int_distribution<uint64_t>(
+        0, m_local_alias_table.size() - 1);
+    m_bucket_weight_dist =
+        std::uniform_real_distribution<double>(0, avg_weight);
     m_avg_weight = avg_weight;
   }
-  
+
  public:
-
   template <typename Visitor, typename... VisitorArgs>
-  void async_sample(Visitor&& visitor, const VisitorArgs &...args) {
-
-    auto sample_wrapper = [visitor](auto ptr_a_tbl, const VisitorArgs &...args) {
-      table_item tbl_itm = ptr_a_tbl->m_local_alias_table[ptr_a_tbl->m_num_items_uniform_dist(ptr_a_tbl->m_rng)];
+  void async_sample(Visitor&& visitor, const VisitorArgs&... args) {
+    auto sample_wrapper = [visitor](auto ptr_a_tbl,
+                                    const VisitorArgs&... args) {
+      table_item tbl_itm =
+          ptr_a_tbl->m_local_alias_table[ptr_a_tbl->m_num_items_uniform_dist(
+              ptr_a_tbl->m_rng)];
       Item s = tbl_itm.a;
       if (tbl_itm.p < ptr_a_tbl->m_avg_weight) {
         double f = ptr_a_tbl->m_bucket_weight_dist(ptr_a_tbl->m_rng);
@@ -257,24 +289,26 @@ class alias_table {
           s = tbl_itm.b;
         }
       }
-      ygm::meta::apply_optional(visitor, std::make_tuple(ptr_a_tbl), std::forward_as_tuple(s, args...));
+      ygm::meta::apply_optional(visitor, std::make_tuple(ptr_a_tbl),
+                                std::forward_as_tuple(s, args...));
     };
 
     uint32_t dest_rank = m_rank_dist(m_rng);
-    m_comm.async(dest_rank, sample_wrapper, pthis, std::forward<const VisitorArgs>(args)...);
-  }        
+    m_comm.async(dest_rank, sample_wrapper, pthis,
+                 std::forward<const VisitorArgs>(args)...);
+  }
 
  private:
-  ygm::comm&                                          m_comm;
-  ygm::ygm_ptr<self_type>                             pthis;
-  std::vector<item>                                   m_local_items;
-  std::vector<table_item>                             m_local_alias_table;
-  std::uniform_int_distribution<uint32_t>             m_rank_dist;
-  std::uniform_int_distribution<uint64_t>             m_num_items_uniform_dist;
-  std::uniform_real_distribution<double>              m_zero_one_dist;
-  std::uniform_real_distribution<double>              m_bucket_weight_dist; 
-  double                                              m_avg_weight;
-  ygm::random::default_random_engine<>                m_rng;
+  ygm::comm&                              m_comm;
+  ptr_type                                pthis;
+  std::vector<item>                       m_local_items;
+  std::vector<table_item>                 m_local_alias_table;
+  std::uniform_int_distribution<uint32_t> m_rank_dist;
+  std::uniform_int_distribution<uint64_t> m_num_items_uniform_dist;
+  std::uniform_real_distribution<double>  m_zero_one_dist;
+  std::uniform_real_distribution<double>  m_bucket_weight_dist;
+  double                                  m_avg_weight;
+  ygm::random::default_random_engine<>    m_rng;
 };
 
 }  // namespace ygm::random

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,7 @@ add_ygm_test(test_stats)
 add_ygm_test(test_work_queue)
 add_ygm_test(test_container_vectors)
 add_ygm_test(test_shm_handling)
+add_ygm_test(test_subcommunicators)
 
 
 if (Arrow_FOUND AND Parquet_FOUND)

--- a/test/test_subcommunicators.cpp
+++ b/test/test_subcommunicators.cpp
@@ -1,0 +1,54 @@
+// Copyright 2019-2026 Lawrence Livermore National Security, LLC and other YGM
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#undef NDEBUG
+#include <ygm/comm.hpp>
+#include <ygm/container/bag.hpp>
+
+int main() {
+  YGM_ASSERT_MPI(MPI_Init(nullptr, nullptr));
+
+  ygm::comm world(MPI_COMM_WORLD);
+
+  //
+  // Test initializing YGM communicator from subcommunicator
+  {
+    MPI_Comm self_mpi_comm;
+    MPI_Comm_split(MPI_COMM_WORLD, world.rank(), 0, &self_mpi_comm);
+
+    ygm::comm self_comm(self_mpi_comm);
+
+    YGM_ASSERT_RELEASE(self_comm.size() == 1);
+    YGM_ASSERT_RELEASE(self_comm.rank() == 0);
+
+    bool flag     = false;
+    auto flag_ptr = self_comm.make_ygm_ptr(flag);
+
+    self_comm.async(0, [](auto flag_ptr) { *flag_ptr = true; }, flag_ptr);
+
+    self_comm.barrier();
+    YGM_ASSERT_RELEASE(flag == true);
+  }
+
+  //
+  // Test container creation on subcommunicators
+  {
+    {
+      MPI_Comm self_mpi_comm;
+      MPI_Comm_split(MPI_COMM_WORLD, world.rank(), 0, &self_mpi_comm);
+
+      ygm::comm self_comm(self_mpi_comm);
+
+      for (int i = 0; i < world.rank(); ++i) {
+        ygm::container::bag<int> b(self_comm);
+      }
+    }
+
+    // Return to world
+    ygm::container::bag<int> b(world);
+  }
+
+  return 0;
+}

--- a/test/test_subcommunicators.cpp
+++ b/test/test_subcommunicators.cpp
@@ -50,5 +50,7 @@ int main() {
     ygm::container::bag<int> b(world);
   }
 
+  MPI_Finalize();
+
   return 0;
 }

--- a/test/test_subcommunicators.cpp
+++ b/test/test_subcommunicators.cpp
@@ -10,44 +10,46 @@
 int main() {
   YGM_ASSERT_MPI(MPI_Init(nullptr, nullptr));
 
-  ygm::comm world(MPI_COMM_WORLD);
-
-  //
-  // Test initializing YGM communicator from subcommunicator
   {
-    MPI_Comm self_mpi_comm;
-    MPI_Comm_split(MPI_COMM_WORLD, world.rank(), 0, &self_mpi_comm);
+    ygm::comm world(MPI_COMM_WORLD);
 
-    ygm::comm self_comm(self_mpi_comm);
-
-    YGM_ASSERT_RELEASE(self_comm.size() == 1);
-    YGM_ASSERT_RELEASE(self_comm.rank() == 0);
-
-    bool flag     = false;
-    auto flag_ptr = self_comm.make_ygm_ptr(flag);
-
-    self_comm.async(0, [](auto flag_ptr) { *flag_ptr = true; }, flag_ptr);
-
-    self_comm.barrier();
-    YGM_ASSERT_RELEASE(flag == true);
-  }
-
-  //
-  // Test container creation on subcommunicators
-  {
+    //
+    // Test initializing YGM communicator from subcommunicator
     {
       MPI_Comm self_mpi_comm;
       MPI_Comm_split(MPI_COMM_WORLD, world.rank(), 0, &self_mpi_comm);
 
       ygm::comm self_comm(self_mpi_comm);
 
-      for (int i = 0; i < world.rank(); ++i) {
-        ygm::container::bag<int> b(self_comm);
-      }
+      YGM_ASSERT_RELEASE(self_comm.size() == 1);
+      YGM_ASSERT_RELEASE(self_comm.rank() == 0);
+
+      bool flag     = false;
+      auto flag_ptr = self_comm.make_ygm_ptr(flag);
+
+      self_comm.async(0, [](auto flag_ptr) { *flag_ptr = true; }, flag_ptr);
+
+      self_comm.barrier();
+      YGM_ASSERT_RELEASE(flag == true);
     }
 
-    // Return to world
-    ygm::container::bag<int> b(world);
+    //
+    // Test container creation on subcommunicators
+    {
+      {
+        MPI_Comm self_mpi_comm;
+        MPI_Comm_split(MPI_COMM_WORLD, world.rank(), 0, &self_mpi_comm);
+
+        ygm::comm self_comm(self_mpi_comm);
+
+        for (int i = 0; i < world.rank(); ++i) {
+          ygm::container::bag<int> b(self_comm);
+        }
+      }
+
+      // Return to world
+      ygm::container::bag<int> b(world);
+    }
   }
 
   MPI_Finalize();

--- a/test/test_work_queue.cpp
+++ b/test/test_work_queue.cpp
@@ -6,36 +6,39 @@
 #undef NDEBUG
 
 #include <ygm/comm.hpp>
-#include <ygm/container/work_queue.hpp>
 #include <ygm/container/array.hpp>
+#include <ygm/container/work_queue.hpp>
 
-#include <vector>
 #include <algorithm>
 #include <numeric>
 #include <random>
+#include <vector>
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ygm::comm world(&argc, &argv);
 
   // priority queue tests
   {
+    /*
     // test local priority work queue ordering and size checks
     {
       size_t test_size = 64;
 
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
-      
+
       auto rng = std::default_random_engine{};
       std::ranges::shuffle(work_items, rng);
 
-      auto work_lambda = [&test_size] (auto p_work_queue, auto& queued_item) {
+      auto work_lambda = [&test_size](auto p_work_queue, auto& queued_item) {
         test_size--;
         YGM_ASSERT_RELEASE(test_size == queued_item);
         YGM_ASSERT_RELEASE(test_size == p_work_queue->local_size());
       };
 
-      auto wq = ygm::container::make_priority_work_queue<size_t, std::less<size_t>> (world, work_lambda);
+      auto wq =
+          ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(
+              world, work_lambda);
 
       for (size_t item : work_items) {
         wq.local_insert(item);
@@ -59,18 +62,22 @@ int main(int argc, char **argv) {
 
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
-      
-      auto rng = std::default_random_engine {};
+
+      auto rng = std::default_random_engine{};
       std::ranges::shuffle(work_items, rng);
 
-      auto work_lambda = [&test_size] (auto p_work_queue, auto& queued_item) {
+      auto work_lambda = [&test_size](auto p_work_queue, auto& queued_item) {
         test_size--;
         YGM_ASSERT_RELEASE(test_size == queued_item);
         YGM_ASSERT_RELEASE(test_size == p_work_queue->local_size());
       };
 
-      auto wq1 = ygm::container::make_priority_work_queue<size_t, std::less<size_t>> (world, work_lambda);
-      auto wq2 = ygm::container::make_priority_work_queue<size_t, std::less<size_t>> (world, work_lambda);
+      auto wq1 =
+          ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(
+              world, work_lambda);
+      auto wq2 =
+          ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(
+              world, work_lambda);
 
       for (size_t item : work_items) {
         wq1.local_insert(item);
@@ -92,6 +99,7 @@ int main(int argc, char **argv) {
 
       world.barrier();
     }
+  */
 
     // test move constructor
     {
@@ -99,22 +107,24 @@ int main(int argc, char **argv) {
 
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
-      
-      auto rng = std::default_random_engine {};
+
+      auto rng = std::default_random_engine{};
       std::ranges::shuffle(work_items, rng);
 
-      auto work_lambda = [&test_size] (auto p_work_queue, auto& queued_item) {
+      auto work_lambda = [&test_size](auto p_work_queue, auto& queued_item) {
         test_size--;
         YGM_ASSERT_RELEASE(test_size == queued_item);
         YGM_ASSERT_RELEASE(test_size == p_work_queue->local_size());
       };
 
-      auto wq1 = ygm::container::make_priority_work_queue<size_t, std::less<size_t>> (world, work_lambda);
-      
+      auto wq1 =
+          ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(
+              world, work_lambda);
+
       for (size_t item : work_items) {
         wq1.local_insert(item);
       }
-      
+
       auto wq2(std::move(wq1));
 
       YGM_ASSERT_RELEASE(wq1.local_has_work() == false);
@@ -139,11 +149,13 @@ int main(int argc, char **argv) {
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
 
-      auto work_lambda = [&test_size] (auto& queued_item) {
+      auto work_lambda = [&test_size](auto& queued_item) {
         test_size += queued_item;
       };
 
-      auto wq = ygm::container::make_priority_work_queue<size_t, std::less<size_t>> (world, work_lambda);
+      auto wq =
+          ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(
+              world, work_lambda);
 
       for (size_t item : work_items) {
         wq.local_insert(item);
@@ -162,27 +174,29 @@ int main(int argc, char **argv) {
 
     // test recursive calls with priority ordering
     {
-      size_t cutoff = 64;
-      bool found_cutoff = false;
+      size_t cutoff       = 64;
+      bool   found_cutoff = false;
 
       size_t xref = 0;
 
-      auto work_lambda = [&cutoff, &found_cutoff, &xref] (auto p_work_queue, auto& queued_item) {
+      auto work_lambda = [&cutoff, &found_cutoff, &xref](auto  p_work_queue,
+                                                         auto& queued_item) {
         YGM_ASSERT_RELEASE(xref == queued_item);
         xref++;
-        
+
         if (queued_item < cutoff) {
           YGM_ASSERT_RELEASE(found_cutoff == false);
 
           p_work_queue->local_insert(queued_item + cutoff + 1);
           p_work_queue->local_insert(queued_item + 1);
-        } 
-        else {
+        } else {
           found_cutoff = true;
         }
       };
 
-      auto wq = ygm::container::make_priority_work_queue<size_t, std::greater<size_t>> (world, work_lambda);
+      auto wq = ygm::container::make_priority_work_queue<size_t,
+                                                         std::greater<size_t>>(
+          world, work_lambda);
 
       wq.local_insert(0);
 
@@ -191,7 +205,7 @@ int main(int argc, char **argv) {
 
     // test container traversal
     {
-      int                               size = 64;
+      int                        size = 64;
       ygm::container::array<int> arr(world, size);
 
       if (world.rank0()) {
@@ -202,19 +216,21 @@ int main(int argc, char **argv) {
 
       world.barrier();
 
-      auto recv_enqueue_lambda = [size] (const auto&, int &val, auto p_wq) {
-        if (val < size -1) {
+      auto recv_enqueue_lambda = [size](const auto&, int& val, auto p_wq) {
+        if (val < size - 1) {
           p_wq->local_insert(val + 1);
         };
 
         val = 0;
       };
 
-      auto work_lambda = [&arr, &recv_enqueue_lambda] (auto p_wq, int item) {
+      auto work_lambda = [&arr, &recv_enqueue_lambda](auto p_wq, int item) {
         arr.async_visit(item, recv_enqueue_lambda, p_wq);
       };
 
-      auto wq = ygm::container::make_priority_work_queue<int, std::greater<int>> (world, work_lambda);
+      auto wq =
+          ygm::container::make_priority_work_queue<int, std::greater<int>>(
+              world, work_lambda);
 
       if (world.rank0()) {
         wq.local_insert(0);
@@ -222,9 +238,7 @@ int main(int argc, char **argv) {
 
       world.barrier();
 
-      arr.for_all([] (const auto value) {
-        YGM_ASSERT_RELEASE(value == 0);
-      });
+      arr.for_all([](const auto value) { YGM_ASSERT_RELEASE(value == 0); });
 
       world.barrier();
     }
@@ -233,26 +247,25 @@ int main(int argc, char **argv) {
     {
       size_t total_processed = 0;
 
-      auto work_lambda = [&total_processed] (size_t) {
-        total_processed++;
-      };
+      auto work_lambda = [&total_processed](size_t) { total_processed++; };
 
-      auto wq = ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(world, work_lambda);
-      
+      auto wq =
+          ygm::container::make_priority_work_queue<size_t, std::less<size_t>>(
+              world, work_lambda);
+
       // First batch
       for (size_t i = 0; i < 10; i++) wq.local_insert(i);
       world.barrier();
       YGM_ASSERT_RELEASE(total_processed == 10);
-      
+
       // Second batch
       for (size_t i = 0; i < 20; i++) wq.local_insert(i);
       world.barrier();
       YGM_ASSERT_RELEASE(total_processed == 30);
-      
+
       world.barrier();
     }
   }
-
 
   // FIFO queue tests
   {
@@ -264,13 +277,14 @@ int main(int argc, char **argv) {
       std::iota(work_items.begin(), work_items.end(), 0);
       std::reverse(work_items.begin(), work_items.end());
 
-      auto work_lambda = [&test_size] (auto p_work_queue, auto& queued_item) {
+      auto work_lambda = [&test_size](auto p_work_queue, auto& queued_item) {
         test_size--;
         YGM_ASSERT_RELEASE(test_size == queued_item);
         YGM_ASSERT_RELEASE(test_size == p_work_queue->local_size());
       };
 
-      auto wq = ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
+      auto wq =
+          ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
 
       for (size_t item : work_items) {
         wq.local_insert(item);
@@ -278,7 +292,6 @@ int main(int argc, char **argv) {
 
       YGM_ASSERT_RELEASE(wq.local_has_work() == true);
       YGM_ASSERT_RELEASE(wq.local_size() == test_size);
-
 
       world.barrier();
 
@@ -296,11 +309,12 @@ int main(int argc, char **argv) {
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
 
-      auto work_lambda = [&test_size] (auto& queued_item) {
+      auto work_lambda = [&test_size](auto& queued_item) {
         test_size += queued_item;
       };
 
-      auto wq = ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
+      auto wq =
+          ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
 
       for (size_t item : work_items) {
         wq.local_insert(item);
@@ -320,27 +334,28 @@ int main(int argc, char **argv) {
     // test fifo ordering with recursion
     {
       size_t cutoff = 64;
-      size_t mod = 8;
-      size_t xref = 0;
+      size_t mod    = 8;
+      size_t xref   = 0;
 
-      auto work_lambda = [&cutoff, &mod, &xref] (auto p_work_queue, auto& queued_item) {
-        
+      auto work_lambda = [&cutoff, &mod, &xref](auto  p_work_queue,
+                                                auto& queued_item) {
         YGM_ASSERT_RELEASE(queued_item == xref);
-        
+
         if (queued_item == cutoff) {
           return;
         }
-        
+
         if (queued_item % mod == 0) {
           for (size_t i = 1; i <= mod; i++) {
             p_work_queue->local_insert(queued_item + i);
-          } 
+          }
         }
 
         xref++;
       };
 
-      auto wq = ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
+      auto wq =
+          ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
 
       wq.local_insert(0);
 
@@ -351,7 +366,7 @@ int main(int argc, char **argv) {
 
     // test container traversal
     {
-      int                               size = 64;
+      int                        size = 64;
       ygm::container::array<int> arr(world, size);
 
       if (world.rank0()) {
@@ -362,8 +377,7 @@ int main(int argc, char **argv) {
 
       world.barrier();
 
-
-      auto recv_enqueue_lambda = [size] (const auto&, int &val, auto p_wq) {
+      auto recv_enqueue_lambda = [size](const auto&, int& val, auto p_wq) {
         if (val < size - 1) {
           p_wq->local_insert(val + 1);
         };
@@ -371,7 +385,7 @@ int main(int argc, char **argv) {
         val = 0;
       };
 
-      auto work_lambda = [&arr, &recv_enqueue_lambda] (auto p_wq, int item) {
+      auto work_lambda = [&arr, &recv_enqueue_lambda](auto p_wq, int item) {
         arr.async_visit(item, recv_enqueue_lambda, p_wq);
       };
 
@@ -383,9 +397,7 @@ int main(int argc, char **argv) {
 
       world.barrier();
 
-      arr.for_all([] (const auto value) {
-        YGM_ASSERT_RELEASE(value == 0);
-      });
+      arr.for_all([](const auto value) { YGM_ASSERT_RELEASE(value == 0); });
 
       world.barrier();
     }
@@ -393,25 +405,23 @@ int main(int argc, char **argv) {
     // test multiple work batches
     {
       size_t total_processed = 0;
-      auto work_lambda = [&total_processed] (size_t) {
-        total_processed++;
-      };
-      auto wq = ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
-      
+      auto   work_lambda = [&total_processed](size_t) { total_processed++; };
+      auto   wq =
+          ygm::container::make_fifo_work_queue<size_t>(world, work_lambda);
+
       // First batch
       for (size_t i = 0; i < 10; i++) wq.local_insert(i);
       world.barrier();
       YGM_ASSERT_RELEASE(total_processed == 10);
-      
+
       // Second batch
       for (size_t i = 0; i < 20; i++) wq.local_insert(i);
       world.barrier();
       YGM_ASSERT_RELEASE(total_processed == 30);
-      
+
       world.barrier();
     }
   }
-
 
   // LIFO queue tests
   {
@@ -422,13 +432,14 @@ int main(int argc, char **argv) {
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
 
-      auto work_lambda = [&test_size] (auto p_work_queue, auto& queued_item) {
+      auto work_lambda = [&test_size](auto p_work_queue, auto& queued_item) {
         test_size--;
         YGM_ASSERT_RELEASE(test_size == queued_item);
         YGM_ASSERT_RELEASE(test_size == p_work_queue->local_size());
       };
 
-      auto wq = ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
+      auto wq =
+          ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
 
       for (size_t item : work_items) {
         wq.local_insert(item);
@@ -436,7 +447,6 @@ int main(int argc, char **argv) {
 
       YGM_ASSERT_RELEASE(wq.local_has_work() == true);
       YGM_ASSERT_RELEASE(wq.local_size() == test_size);
-
 
       world.barrier();
 
@@ -454,11 +464,12 @@ int main(int argc, char **argv) {
       std::vector<size_t> work_items(test_size);
       std::iota(work_items.begin(), work_items.end(), 0);
 
-      auto work_lambda = [&test_size] (auto& queued_item) {
+      auto work_lambda = [&test_size](auto& queued_item) {
         test_size += queued_item;
       };
 
-      auto wq = ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
+      auto wq =
+          ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
 
       for (size_t item : work_items) {
         wq.local_insert(item);
@@ -478,27 +489,28 @@ int main(int argc, char **argv) {
     // test lifo ordering with recursion
     {
       size_t cutoff = 64;
-      size_t mod = 8;
-      size_t xref = 0;
+      size_t mod    = 8;
+      size_t xref   = 0;
 
-      auto work_lambda = [&cutoff, &mod, &xref] (auto p_work_queue, auto& queued_item) {
-        
+      auto work_lambda = [&cutoff, &mod, &xref](auto  p_work_queue,
+                                                auto& queued_item) {
         YGM_ASSERT_RELEASE(queued_item == xref);
-        
+
         if (queued_item == cutoff) {
           return;
         }
-        
+
         if (queued_item % mod == 0) {
           for (size_t i = mod; i > 0; i--) {
             p_work_queue->local_insert(queued_item + i);
-          } 
+          }
         }
 
         xref++;
       };
 
-      auto wq = ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
+      auto wq =
+          ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
 
       wq.local_insert(0);
 
@@ -509,7 +521,7 @@ int main(int argc, char **argv) {
 
     // test container traversal
     {
-      int                               size = 64;
+      int                        size = 64;
       ygm::container::array<int> arr(world, size);
 
       if (world.rank0()) {
@@ -520,20 +532,19 @@ int main(int argc, char **argv) {
 
       world.barrier();
 
-
-      auto recv_enqueue_lambda = [size] (const auto&, int &val, auto p_wq) {
-        if (val < size -1) {
+      auto recv_enqueue_lambda = [size](const auto&, int& val, auto p_wq) {
+        if (val < size - 1) {
           p_wq->local_insert(val + 1);
         };
 
         val = 0;
       };
 
-      auto work_lambda = [&arr, &recv_enqueue_lambda] (auto p_wq, int item) {
+      auto work_lambda = [&arr, &recv_enqueue_lambda](auto p_wq, int item) {
         arr.async_visit(item, recv_enqueue_lambda, p_wq);
       };
 
-      auto wq = ygm::container::make_lifo_work_queue<int> (world, work_lambda);
+      auto wq = ygm::container::make_lifo_work_queue<int>(world, work_lambda);
 
       if (world.rank0()) {
         wq.local_insert(0);
@@ -541,9 +552,7 @@ int main(int argc, char **argv) {
 
       world.barrier();
 
-      arr.for_all([] (const auto value) {
-        YGM_ASSERT_RELEASE(value == 0);
-      });
+      arr.for_all([](const auto value) { YGM_ASSERT_RELEASE(value == 0); });
 
       world.barrier();
     }
@@ -551,21 +560,20 @@ int main(int argc, char **argv) {
     // test multiple work batches
     {
       size_t total_processed = 0;
-      auto work_lambda = [&total_processed] (size_t) {
-        total_processed++;
-      };
-      auto wq = ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
-      
+      auto   work_lambda = [&total_processed](size_t) { total_processed++; };
+      auto   wq =
+          ygm::container::make_lifo_work_queue<size_t>(world, work_lambda);
+
       // First batch
       for (size_t i = 0; i < 10; i++) wq.local_insert(i);
       world.barrier();
       YGM_ASSERT_RELEASE(total_processed == 10);
-      
+
       // Second batch
       for (size_t i = 0; i < 20; i++) wq.local_insert(i);
       world.barrier();
       YGM_ASSERT_RELEASE(total_processed == 30);
-      
+
       world.barrier();
     }
   }


### PR DESCRIPTION
Fixes a bug where using subcommunicators can cause `ygm_ptr`s to get out of sync.